### PR TITLE
fix: settle cell Failed on non-zero workload exit, distinct from clean Stopped

### DIFF
--- a/docs/cli-use-cases.md
+++ b/docs/cli-use-cases.md
@@ -296,6 +296,7 @@ sudo kuke run --clone <cell> --name custom                               # same,
 - `--container` is only valid in attach mode; passing both `--container` and `-d/--detach` exits non-zero.
 - `--rm` is processed by `kukeond`'s reconcile loop. `kuke run` is daemon-only after #566 — `KUKEON_NO_DAEMON=true` and `--run-path` promotion no longer reach an in-process branch for workload verbs, so `--rm` and `--run-path` are not mutually exclusive on `kuke run`. Cleanup latency is bounded by the daemon's reconcile interval (default 30s), not real-time.
 - A clean `^]^]` detach in attach mode does **not** trigger `--rm` cleanup; the cell stays alive for re-attach. Only workload termination, peer hangup, or an unrecoverable controller error fires cleanup.
+- `--rm` cleanup fires only on a **clean** workload exit (the cell settles `Stopped`). A workload that exits non-zero / crashes settles the cell `Failed` (#1206), which is excluded from auto-delete — the failed cell is preserved with its exit code/signal in `reason`/`message` so the failure can be inspected, and is cleaned up with an explicit `kuke delete cell`.
 - `kuke run -f /missing.yaml` exits non-zero with a `failed to open file` error.
 - A reference to an unavailable image surfaces the containerd resolver error verbatim (e.g. `pull access denied, repository does not exist or may require authorization`) and exits non-zero; the half-created cell may need `kuke purge cell` to clean up.
 

--- a/docs/site/concepts/cell.md
+++ b/docs/site/concepts/cell.md
@@ -65,8 +65,8 @@ A cell's **identity is its own document** — the `CellDoc`. The CellDoc owns th
 | --------- | --------------------------------------------------------------- |
 | `Pending` | Cell metadata exists; containers not yet created                |
 | `Ready`   | Root container is running; non-root containers are running      |
-| `Stopped` | All containers have exited                                      |
-| `Failed`  | The root container failed to start or exited unexpectedly       |
+| `Stopped` | All containers have exited cleanly (every exit code zero)       |
+| `Failed`  | Startup failed, or a workload exited non-zero / crashed; `reason` + `message` carry the failing container and its exit code/signal. Preserved (not auto-deleted) so the failure can be inspected — clear with `kuke delete cell` |
 | `Unknown` | The daemon can't determine the state (e.g., containerd offline) |
 
 ## Operations

--- a/internal/controller/runner/refresh.go
+++ b/internal/controller/runner/refresh.go
@@ -393,6 +393,17 @@ func (r *Exec) RefreshCell(cell intmodel.Cell) (intmodel.Cell, int, error) {
 		newStatus.State = r.deriveCellState(cell)
 	}
 
+	// Stamp the runtime-failure breadcrumb on a fresh transition to
+	// CellStateFailed (#1206), same contract as ReconcileCell. carryCellLifecycle
+	// above already copied any prior Reason/Message forward, so an
+	// already-Failed cell (e.g. a startup markCellFailed) keeps its original
+	// reason; only a Stopped/Ready → Failed transition restamps here. cell's
+	// container snapshot was populated above, so the breadcrumb resolves the
+	// failing container even though the final write target is newStatus.
+	if newStatus.State == intmodel.CellStateFailed && originalStatus.State != intmodel.CellStateFailed {
+		newStatus.Reason, newStatus.Message = cellFailureBreadcrumb(cell)
+	}
+
 	// Run ReadyObserved through the same one-way latch ReconcileCell uses.
 	// Without this, `kuke refresh` racing a synchronous Ready write would
 	// wipe the latched ReadyObserved to false (newStatus is constructed
@@ -740,6 +751,16 @@ func (r *Exec) ReconcileCell(cell intmodel.Cell) (intmodel.Cell, ReconcileOutcom
 	cell.Status.ReadyObserved = latchReadyObserved(
 		originalStatus.ReadyObserved, originalStatus.State, newState)
 
+	// Surface the workload exit that drove a fresh runtime CellStateFailed
+	// (#1206) so `kuke get cell -o yaml` carries the failing container + exit
+	// code/signal, mirroring the startup-path breadcrumb markCellFailed
+	// writes. Only stamp on the fresh transition: an already-Failed cell is
+	// short-circuited by the cellStateIsSticky guard above and never reaches
+	// here, so its original Reason/Message is preserved.
+	if newState == intmodel.CellStateFailed && originalStatus.State != intmodel.CellStateFailed {
+		stampCellFailure(&cell)
+	}
+
 	// RestartPolicy gate (#1003): per-container restartPolicy can veto both
 	// the auto-delete and the wind-down kill so a workload authored with
 	// `restartPolicy: never` (or `on-failure` that exited cleanly) is left
@@ -1078,6 +1099,17 @@ func (r *Exec) deriveCellState(cell intmodel.Cell) intmodel.CellState {
 // NotCreated as a terminal state alongside Stopped/Failed, so a non-root
 // workload that exited and was reaped naturally still counts toward "all
 // stopped" here.
+//
+// Once every non-root workload is terminal, the exit triple decides between
+// the two terminal cell states (#1206): a workload that exited non-zero (or
+// landed in ContainerStateFailed) settles the cell in CellStateFailed so a
+// crash is distinguishable from a clean completion, which stays
+// CellStateStopped. ExitCode is preserved across task reaping by
+// populateCellContainerStatuses, so a failed-then-reaped (NotCreated)
+// workload still carries its non-zero code here. CellStateFailed is sticky
+// and excluded from auto-delete / wind-down (cellStateIsSticky,
+// cellStateAutoDeleteTriggers), so the crashed cell is preserved with its
+// exit code intact for the operator instead of being reaped to Stopped.
 func deriveCellStateFromNonRootContainerStatuses(
 	specs []intmodel.ContainerSpec,
 	statuses []intmodel.ContainerStatus,
@@ -1092,6 +1124,7 @@ func deriveCellStateFromNonRootContainerStatuses(
 	seen := 0
 	anyActive := false
 	anyUnknown := false
+	anyFailed := false
 	for i := range statuses {
 		if _, ok := nonRootIDs[statuses[i].ID]; !ok {
 			continue
@@ -1109,7 +1142,11 @@ func deriveCellStateFromNonRootContainerStatuses(
 			intmodel.ContainerStateFailed,
 			intmodel.ContainerStateNotCreated:
 			// terminal — does not contribute to active. A reaped/absent
-			// workload (NotCreated) counts the same as a clean stop here.
+			// workload (NotCreated) counts the same as a clean stop here,
+			// unless its preserved exit triple marks it a failure (#1206).
+			if containerExitedNonZero(statuses[i]) {
+				anyFailed = true
+			}
 		}
 	}
 
@@ -1125,7 +1162,21 @@ func deriveCellStateFromNonRootContainerStatuses(
 	if anyUnknown {
 		return intmodel.CellStateUnknown
 	}
+	if anyFailed {
+		return intmodel.CellStateFailed
+	}
 	return intmodel.CellStateStopped
+}
+
+// containerExitedNonZero reports whether a terminal container's observed exit
+// indicates a workload failure rather than a clean completion (#1206): a
+// non-zero exit code (the common case — populateCellContainerStatuses
+// preserves it across task reaping) or the explicit ContainerStateFailed
+// observation. A clean exit (code 0) — including a never-started container
+// reaped to NotCreated with a zero code — is not a failure. Callers must only
+// consult this for containers already known to be terminal.
+func containerExitedNonZero(status intmodel.ContainerStatus) bool {
+	return status.State == intmodel.ContainerStateFailed || status.ExitCode != 0
 }
 
 // hasNonRootContainerSpec reports whether the cell has at least one
@@ -1143,6 +1194,14 @@ func hasNonRootContainerSpec(specs []intmodel.ContainerSpec) bool {
 // deriveCellStateFromRootContainer resolves the cell's state from the root
 // container's task. Returns Ready when no root container is configured (a
 // cgroup-only cell counts as Ready by cgroup existence).
+//
+// When the root has terminally exited, the exit triple chooses between the
+// two terminal cell states the same way the non-root path does (#1206): a
+// non-zero root exit settles the cell Failed (preserving the crash + exit
+// code), a clean exit stays Stopped. The exit triple is read from the
+// container-status snapshot populateCellContainerStatuses just wrote (both
+// callers populate before deriving), which preserves the exit code across
+// task reaping.
 func (r *Exec) deriveCellStateFromRootContainer(cell intmodel.Cell) intmodel.CellState {
 	rootSpec := findRootContainerSpec(cell)
 	if rootSpec == nil {
@@ -1163,10 +1222,99 @@ func (r *Exec) deriveCellStateFromRootContainer(cell intmodel.Cell) intmodel.Cel
 	case intmodel.ContainerStateStopped,
 		intmodel.ContainerStateFailed,
 		intmodel.ContainerStateNotCreated:
+		if rootContainerExitedNonZero(rootSpec.ID, cell.Status.Containers) {
+			return intmodel.CellStateFailed
+		}
 		return intmodel.CellStateStopped
 	default:
 		return intmodel.CellStateUnknown
 	}
+}
+
+// rootContainerExitedNonZero looks up the root container's exit triple in the
+// freshly populated status snapshot and reports whether it marks a failure
+// (#1206). Returns false when the root's status is missing from the snapshot —
+// a partial populate must not flip the cell to Failed on absent data.
+func rootContainerExitedNonZero(rootID string, statuses []intmodel.ContainerStatus) bool {
+	for i := range statuses {
+		if statuses[i].ID == rootID {
+			return containerExitedNonZero(statuses[i])
+		}
+	}
+	return false
+}
+
+// reasonWorkloadFailed is the stable PascalCase Status.Reason label stamped
+// when a runtime workload exit (not a startup-path error — markCellFailed owns
+// those) drives a cell to CellStateFailed (#1206). Distinct from the
+// StartCellFailed / CreateCellFailed / StartContainerFailed startup reasons so
+// machine consumers can tell a post-Ready crash apart from a failed bring-up.
+const reasonWorkloadFailed = "WorkloadFailed"
+
+// cellFailureBreadcrumb returns the (Reason, Message) pair to stamp on a cell
+// transitioning to CellStateFailed from a runtime workload exit (#1206).
+// Reason is the stable machine label; Message names the failing container and
+// its exit code/signal, falling back to a generic line if the failing
+// container can't be pinpointed in the snapshot.
+func cellFailureBreadcrumb(cell intmodel.Cell) (string, string) {
+	msg := describeCellFailure(cell)
+	if msg == "" {
+		msg = "workload exited with a non-zero status"
+	}
+	return reasonWorkloadFailed, msg
+}
+
+// stampCellFailure writes the runtime-failure breadcrumb onto cell.Status in
+// place. The cell's container-status snapshot must already be populated.
+func stampCellFailure(cell *intmodel.Cell) {
+	cell.Status.Reason, cell.Status.Message = cellFailureBreadcrumb(*cell)
+}
+
+// describeCellFailure builds the operator-facing Status.Message for a cell that
+// derived CellStateFailed from a workload exit (#1206), naming the first
+// failing container and its exit code/signal. Mirrors deriveCellState's
+// dispatch so the reported container matches the one that drove the state:
+// non-root workloads for cells that have them, otherwise the root. Returns ""
+// when no failing container is found (defensive — callers only invoke this
+// after derivation returned Failed).
+func describeCellFailure(cell intmodel.Cell) string {
+	statusByID := make(map[string]intmodel.ContainerStatus, len(cell.Status.Containers))
+	for i := range cell.Status.Containers {
+		statusByID[cell.Status.Containers[i].ID] = cell.Status.Containers[i]
+	}
+
+	if hasNonRootContainerSpec(cell.Spec.Containers) {
+		for i := range cell.Spec.Containers {
+			spec := cell.Spec.Containers[i]
+			if spec.Root {
+				continue
+			}
+			if st, ok := statusByID[spec.ID]; ok &&
+				containerStateIsTerminal(st.State) && containerExitedNonZero(st) {
+				return formatContainerFailure(st)
+			}
+		}
+		return ""
+	}
+
+	rootSpec := findRootContainerSpec(cell)
+	if rootSpec != nil {
+		if st, ok := statusByID[rootSpec.ID]; ok && containerExitedNonZero(st) {
+			return formatContainerFailure(st)
+		}
+	}
+	return ""
+}
+
+// formatContainerFailure renders a single container's exit triple as a human
+// breadcrumb, surfacing the decoded signal when the exit code carries one
+// (128+signum, per ContainerStatus.ExitSignal).
+func formatContainerFailure(st intmodel.ContainerStatus) string {
+	if st.ExitSignal != "" {
+		return fmt.Sprintf("container %q terminated by %s (exit code %d)",
+			st.ID, st.ExitSignal, st.ExitCode)
+	}
+	return fmt.Sprintf("container %q exited with code %d", st.ID, st.ExitCode)
 }
 
 func findRootContainerSpec(cell intmodel.Cell) *intmodel.ContainerSpec {

--- a/internal/controller/runner/refresh_test.go
+++ b/internal/controller/runner/refresh_test.go
@@ -348,16 +348,80 @@ func TestDeriveCellStateFromNonRootContainerStatuses(t *testing.T) {
 			want: intmodel.CellStateStopped,
 		},
 		{
-			name: "all_workloads_failed_also_stopped",
+			name: "workload_in_failed_state_settles_cell_failed",
 			specs: []intmodel.ContainerSpec{
 				{ID: "root", Root: true},
 				{ID: "work", Root: false},
 			},
+			// A non-root workload observed in ContainerStateFailed is a crash,
+			// not a clean stop — the cell settles Failed so callers can tell a
+			// failed run from a completed one (#1206).
 			statuses: []intmodel.ContainerStatus{
 				{ID: "root", State: intmodel.ContainerStateReady},
 				{ID: "work", State: intmodel.ContainerStateFailed},
 			},
-			want: intmodel.CellStateStopped,
+			want: intmodel.CellStateFailed,
+		},
+		{
+			name: "workload_exited_nonzero_settles_cell_failed",
+			specs: []intmodel.ContainerSpec{
+				{ID: "root", Root: true},
+				{ID: "work", Root: false},
+			},
+			// The headline #1206 case: a stopped workload carrying a non-zero
+			// exit code is a crash, distinct from a clean Stopped completion.
+			statuses: []intmodel.ContainerStatus{
+				{ID: "root", State: intmodel.ContainerStateReady},
+				{ID: "work", State: intmodel.ContainerStateStopped, ExitCode: 127},
+			},
+			want: intmodel.CellStateFailed,
+		},
+		{
+			name: "reaped_workload_preserved_nonzero_exit_settles_failed",
+			specs: []intmodel.ContainerSpec{
+				{ID: "root", Root: true},
+				{ID: "work", Root: false},
+			},
+			// A failed workload whose containerd task was reaped reads back
+			// NotCreated, but populateCellContainerStatuses preserves the
+			// non-zero ExitCode — the cell must still settle Failed (#1206).
+			statuses: []intmodel.ContainerStatus{
+				{ID: "root", State: intmodel.ContainerStateReady},
+				{ID: "work", State: intmodel.ContainerStateNotCreated, ExitCode: 1},
+			},
+			want: intmodel.CellStateFailed,
+		},
+		{
+			name: "mixed_clean_and_failed_workloads_settle_failed",
+			specs: []intmodel.ContainerSpec{
+				{ID: "root", Root: true},
+				{ID: "work-a", Root: false},
+				{ID: "work-b", Root: false},
+			},
+			// One clean exit, one crash → Failed wins: any failure among the
+			// terminal workloads marks the cell Failed (#1206).
+			statuses: []intmodel.ContainerStatus{
+				{ID: "root", State: intmodel.ContainerStateReady},
+				{ID: "work-a", State: intmodel.ContainerStateStopped, ExitCode: 0},
+				{ID: "work-b", State: intmodel.ContainerStateStopped, ExitCode: 2},
+			},
+			want: intmodel.CellStateFailed,
+		},
+		{
+			name: "active_workload_outranks_a_failed_sibling",
+			specs: []intmodel.ContainerSpec{
+				{ID: "root", Root: true},
+				{ID: "work-a", Root: false},
+				{ID: "work-b", Root: false},
+			},
+			// A still-running workload keeps the cell Ready even when a sibling
+			// crashed — the cell is not terminal yet, so no Failed verdict.
+			statuses: []intmodel.ContainerStatus{
+				{ID: "root", State: intmodel.ContainerStateReady},
+				{ID: "work-a", State: intmodel.ContainerStateReady},
+				{ID: "work-b", State: intmodel.ContainerStateStopped, ExitCode: 1},
+			},
+			want: intmodel.CellStateReady,
 		},
 		{
 			name: "absent_workload_counts_as_terminal_like_stopped",
@@ -446,6 +510,129 @@ func TestDeriveCellStateFromNonRootContainerStatuses(t *testing.T) {
 					got, tc.want)
 			}
 		})
+	}
+}
+
+// TestContainerExitedNonZero pins the failure predicate that flips a terminal
+// cell from Stopped to Failed (#1206): non-zero exit code or an explicit
+// ContainerStateFailed observation, but never a clean (code 0) exit.
+func TestContainerExitedNonZero(t *testing.T) {
+	cases := []struct {
+		name   string
+		status intmodel.ContainerStatus
+		want   bool
+	}{
+		{"clean_stop_is_not_a_failure",
+			intmodel.ContainerStatus{State: intmodel.ContainerStateStopped, ExitCode: 0}, false},
+		{"reaped_clean_exit_is_not_a_failure",
+			intmodel.ContainerStatus{State: intmodel.ContainerStateNotCreated, ExitCode: 0}, false},
+		{"nonzero_exit_is_a_failure",
+			intmodel.ContainerStatus{State: intmodel.ContainerStateStopped, ExitCode: 1}, true},
+		{"reaped_nonzero_exit_is_a_failure",
+			intmodel.ContainerStatus{State: intmodel.ContainerStateNotCreated, ExitCode: 137}, true},
+		{"failed_state_is_a_failure_even_with_zero_code",
+			intmodel.ContainerStatus{State: intmodel.ContainerStateFailed, ExitCode: 0}, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := containerExitedNonZero(tc.status); got != tc.want {
+				t.Errorf("containerExitedNonZero(%+v) = %v, want %v", tc.status, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestDescribeCellFailure verifies the operator-facing breadcrumb names the
+// failing container and surfaces the exit code/signal, mirroring
+// deriveCellState's root-vs-non-root dispatch (#1206).
+func TestDescribeCellFailure(t *testing.T) {
+	t.Run("non_root_workload_with_signal", func(t *testing.T) {
+		cell := intmodel.Cell{
+			Spec: intmodel.CellSpec{Containers: []intmodel.ContainerSpec{
+				{ID: "root", Root: true},
+				{ID: "agent", Root: false},
+			}},
+			Status: intmodel.CellStatus{Containers: []intmodel.ContainerStatus{
+				{ID: "root", State: intmodel.ContainerStateReady},
+				{ID: "agent", State: intmodel.ContainerStateStopped, ExitCode: 139, ExitSignal: "SIGSEGV"},
+			}},
+		}
+		got := describeCellFailure(cell)
+		want := `container "agent" terminated by SIGSEGV (exit code 139)`
+		if got != want {
+			t.Errorf("describeCellFailure() = %q, want %q", got, want)
+		}
+	})
+
+	t.Run("non_root_workload_plain_exit_code", func(t *testing.T) {
+		cell := intmodel.Cell{
+			Spec: intmodel.CellSpec{Containers: []intmodel.ContainerSpec{
+				{ID: "root", Root: true},
+				{ID: "agent", Root: false},
+			}},
+			Status: intmodel.CellStatus{Containers: []intmodel.ContainerStatus{
+				{ID: "root", State: intmodel.ContainerStateReady},
+				{ID: "agent", State: intmodel.ContainerStateStopped, ExitCode: 127},
+			}},
+		}
+		got := describeCellFailure(cell)
+		want := `container "agent" exited with code 127`
+		if got != want {
+			t.Errorf("describeCellFailure() = %q, want %q", got, want)
+		}
+	})
+
+	t.Run("root_only_cell_reports_root", func(t *testing.T) {
+		cell := intmodel.Cell{
+			Spec: intmodel.CellSpec{Containers: []intmodel.ContainerSpec{
+				{ID: "root", Root: true},
+			}},
+			Status: intmodel.CellStatus{Containers: []intmodel.ContainerStatus{
+				{ID: "root", State: intmodel.ContainerStateStopped, ExitCode: 1},
+			}},
+		}
+		got := describeCellFailure(cell)
+		want := `container "root" exited with code 1`
+		if got != want {
+			t.Errorf("describeCellFailure() = %q, want %q", got, want)
+		}
+	})
+
+	t.Run("falls_back_to_generic_when_no_failure_found", func(t *testing.T) {
+		cell := intmodel.Cell{
+			Spec: intmodel.CellSpec{Containers: []intmodel.ContainerSpec{
+				{ID: "root", Root: true},
+				{ID: "agent", Root: false},
+			}},
+			Status: intmodel.CellStatus{Containers: []intmodel.ContainerStatus{
+				{ID: "root", State: intmodel.ContainerStateReady},
+				{ID: "agent", State: intmodel.ContainerStateStopped, ExitCode: 0},
+			}},
+		}
+		if got := describeCellFailure(cell); got != "" {
+			t.Errorf("describeCellFailure() = %q, want empty", got)
+		}
+		reason, msg := cellFailureBreadcrumb(cell)
+		if reason != reasonWorkloadFailed {
+			t.Errorf("reason = %q, want %q", reason, reasonWorkloadFailed)
+		}
+		if msg != "workload exited with a non-zero status" {
+			t.Errorf("message = %q, want generic fallback", msg)
+		}
+	})
+}
+
+// TestRootContainerExitedNonZero pins the root snapshot lookup: a missing root
+// status must read false so a partial populate can't flip the cell to Failed.
+func TestRootContainerExitedNonZero(t *testing.T) {
+	statuses := []intmodel.ContainerStatus{
+		{ID: "root", State: intmodel.ContainerStateStopped, ExitCode: 5},
+	}
+	if !rootContainerExitedNonZero("root", statuses) {
+		t.Errorf("rootContainerExitedNonZero(root) = false, want true")
+	}
+	if rootContainerExitedNonZero("missing", statuses) {
+		t.Errorf("rootContainerExitedNonZero(missing) = true, want false (absent status)")
 	}
 }
 


### PR DESCRIPTION
## Summary

- A cell whose workload exits non-zero (or whose onInit fails) previously settled in `Stopped`/`Synced` — the same terminal state as a clean exit — so a control plane watching cells could not tell "the agent finished" from "the workload crashed on startup". This makes a non-zero terminal exit settle the cell in the distinct **`Failed`** state instead, surfacing the failing container + exit code/signal in `status.reason`/`status.message`. A clean (exit 0) completion still settles `Stopped`.
- **State mapping (the issue asked us to confirm it):** when every relevant container has terminally exited, the derivation now inspects the preserved exit triple — non-zero exit code (or an explicit `ContainerStateFailed` observation) → `CellStateFailed`; all-zero → `CellStateStopped`. Applied to both derivation paths (`deriveCellStateFromNonRootContainerStatuses` for user-workload cells, `deriveCellStateFromRootContainer` for root-only/kukeond cells). The exit code is already preserved across containerd task reaping by `populateCellContainerStatuses` (#1137), so a failed-then-reaped (`NotCreated`) workload still carries its code.
- **Reusing the existing `Failed` state, not a new `Error` state.** `#407` introduced `CellStateFailed` as "the terminal Error state" for startup-path failures, already **sticky** (`cellStateIsSticky`) and **excluded from auto-delete/wind-down** (`cellStateAutoDeleteTriggers`). Its documented intent — "`kuke run --rm` does not auto-clean a Failed cell ... preserving the cell on failure keeps the diagnostic surface intact" — is exactly what this issue wants, so a runtime workload exit now reaches the state that machinery was built for. A new runtime `reason` label `WorkloadFailed` (distinct from `StartCellFailed`/`CreateCellFailed`/`StartContainerFailed`) lets consumers tell a post-Ready crash from a failed bring-up.

## Behavior-change notes (non-obvious calls — reviewer please weigh in)

- **Failed cells are preserved, not reaped.** Because `Failed` is excluded from auto-delete/wind-down, a crashed cell is now kept (root container left alive for non-root-workload cells, no `--rm` cleanup) instead of being reaped to `Stopped`. This is essential to the issue's goal — if `--rm` deleted the cell, the caller could never read the `Failed` state — and it matches `#407`'s documented "preserve the diagnostic surface" intent. The operator clears it with `kuke delete cell`. `kuke run <cell>` already refuses a `Failed` cell with a delete pointer (`docs/cli-use-cases.md`), so re-run is handled.
- **Interaction with `#1003` restart-policy reap.** Previously `restartPolicy: on-failure`/`always` + non-zero exit permitted wind-down/auto-delete (reaped to `Stopped`/gone). Now the non-zero exit derives `Failed` first, which the trigger gate (Stopped-only) excludes, so the cell settles `Failed` + preserved. Clean exits are unchanged on every policy. I judged surfacing the crash as `Failed` to be the more-correct behavior and the issue's explicit ask, but flagging it since it inverts `on-failure`'s reap-on-failure outcome.
- `killCellLocked` hard-codes `State=Stopped` (kill.go:257), so wind-down must not fire on `Failed` (it doesn't — gated on the Stopped-only trigger); this is why preserving rather than winding-down is the correct integration.

## Docs touched (directly-related, not unrelated cleanup)

- `docs/site/concepts/cell.md` — `Failed`/`Stopped` lifecycle descriptions updated for the broadened `Failed` semantics.
- `docs/cli-use-cases.md` — `--rm` invariant clarified: cleanup fires only on a clean exit; a non-zero exit settles `Failed` (preserved).

## Test plan

- [x] `GOWORK=off go build ./...` (workspace split per `go.work` — `GOWORK=off` is the documented build mode)
- [x] `GOWORK=off go vet ./internal/controller/runner/`
- [x] `make test` equivalent — `GOWORK=off go test $(go list ./... | grep -v /e2e)` — 106 packages ok, exit 0
- [x] New unit tests: `deriveCellStateFromNonRootContainerStatuses` cases (non-zero exit / reaped-with-preserved-code / mixed clean+failed / failed-state / active-sibling-outranks), `containerExitedNonZero`, `rootContainerExitedNonZero`, `describeCellFailure`/`cellFailureBreadcrumb` (signal + plain code + root-only + fallback)
- [x] `make dev-init` smoke (change touches the daemon reconcile path) — exit 0, daemon-parity tail shows `default`/`kuke-system` both `Ready` with byte-identical daemon vs in-process views, attach smoke passed

Closes #1206