### PR TITLE
fix(uninstall): force a synchronous GC sweep before deleting a drained namespace

### DIFF
--- a/e2e/e2e_kuke_test.go
+++ b/e2e/e2e_kuke_test.go
@@ -389,6 +389,78 @@ func TestKuke_DaemonReset_RoundTrip(t *testing.T) {
 	}
 }
 
+// TestKuke_DaemonResetPurgeSystem_ThenUninstall exercises issue #1182's AC:
+// `kuke init` → `kuke daemon reset --purge-system` → `kuke uninstall -y`
+// succeeds in a single invocation (exit 0) and leaves no `*.kukeon.io`
+// containerd namespaces behind.
+//
+// `daemon reset --purge-system` deletes the kukeond cell and the on-disk
+// kuke-system metadata tree, but the kuke-system containerd namespace (the
+// staged kukeond image layers / snapshots) survives. The bug was that the
+// subsequent uninstall drained that namespace but then raced the next
+// periodic GC on the immediately-following DeleteNamespace, failing the
+// first pass with "namespace must be empty ... still has snapshots on
+// overlayfs"; a re-run succeeded once GC caught up. The drain now forces a
+// synchronous GC sweep before DeleteNamespace, so the single invocation
+// suffices.
+//
+// Not run with t.Parallel(): like its siblings TestKuke_Uninstall_VerifyState
+// and TestKuke_DaemonReset_RoundTrip, it touches host-global state (every
+// kukeon-suffixed containerd namespace, /run/kukeon, /opt/kukeon, the kukeon
+// user/group) and must not race them.
+func TestKuke_DaemonResetPurgeSystem_ThenUninstall(t *testing.T) {
+	runPath := getRandomRunPath(t)
+	kukeondImage := loadKukeondImageIntoContainerd(t)
+
+	systemNS := consts.RealmNamespace(consts.KukeSystemRealmName)
+
+	t.Cleanup(func() {
+		// Best-effort: if the test exits before its own uninstall fires,
+		// re-run so the next test does not inherit kukeon-suffixed namespaces
+		// or the run path. Failures here are diagnostic only.
+		_, _, _ = runBinary(t, nil, kuke, append(
+			buildKukeRunPathArgs(runPath), "uninstall", "--yes",
+		)...)
+	})
+
+	// Step 1: init brings up both realms and the kukeond cell, staging the
+	// kukeond image into the kuke-system containerd namespace.
+	args := append(buildKukeRunPathArgs(runPath), "init", "--kukeond-image", kukeondImage)
+	exitCode, stdout, stderr := runBinary(t, nil, kuke, args...)
+	if exitCode != 0 {
+		t.Fatalf("kuke init failed: code=%d stdout=%s stderr=%s",
+			exitCode, string(stdout), string(stderr))
+	}
+
+	// Step 2: daemon reset --purge-system deletes the kukeond cell and the
+	// on-disk kuke-system metadata, but leaves the containerd namespace (with
+	// the staged image layers) in place — the precondition the bug needs.
+	args = append(buildKukeRunPathArgs(runPath), "daemon", "reset", "--purge-system")
+	exitCode, stdout, stderr = runBinary(t, nil, kuke, args...)
+	if exitCode != 0 {
+		t.Fatalf("kuke daemon reset --purge-system failed: code=%d stdout=%s stderr=%s",
+			exitCode, string(stdout), string(stderr))
+	}
+	if !verifyContainerdNamespace(t, systemNS) {
+		t.Fatalf("pre-uninstall: kuke-system namespace %q must survive daemon reset --purge-system "+
+			"(its image layers are what uninstall has to drain); got it already gone, "+
+			"so the single-invocation assertion below would pass vacuously", systemNS)
+	}
+
+	// Step 3: a SINGLE uninstall must succeed (exit 0) — issue #1182 AC #1.
+	args = append(buildKukeRunPathArgs(runPath), "uninstall", "--yes")
+	exitCode, stdout, stderr = runBinary(t, nil, kuke, args...)
+	if exitCode != 0 {
+		t.Fatalf("kuke uninstall failed on first pass (issue #1182 regression): "+
+			"code=%d stdout=%s stderr=%s", exitCode, string(stdout), string(stderr))
+	}
+
+	// Step 4: no kukeon-suffixed containerd namespaces survive — AC #2.
+	if surviving := listKukeonContainerdNamespaces(t); len(surviving) > 0 {
+		t.Fatalf("post-uninstall: kukeon-owned containerd namespaces survive: %v", surviving)
+	}
+}
+
 // TestKuke_Stop_Help tests kuke stop help.
 func TestKuke_Stop_Help(t *testing.T) {
 	t.Parallel()

--- a/internal/ctr/namespaces.go
+++ b/internal/ctr/namespaces.go
@@ -190,7 +190,9 @@ var KukeonKnownSnapshotters = []string{
 //  3. snapshots — for every snapshotter when `snapshotter == ""` (the
 //     uninstall path's default), or just the named snapshotter when one is
 //     specified explicitly,
-//  4. blobs (content store).
+//  4. blobs (content store),
+//  5. a final forced synchronous GC sweep (a throwaway lease deleted with
+//     leases.SynchronousDelete).
 //
 // Leases run first because leases.SynchronousDelete triggers the containerd
 // GC scheduler's ScheduleAndWait sweep before returning. That sweep is what
@@ -201,6 +203,18 @@ var KukeonKnownSnapshotters = []string{
 // state (containerd v2 metadata/snapshot.go). Draining leases first lets the
 // GC sweep clear them, then the subsequent snapshotter walk handles whatever
 // the user/runtime layer still pinned directly.
+//
+// The trailing forced GC sweep (step 5) reclaims a snapshot the explicit
+// Walk+Remove pass could not remove directly — notably a BuildKit "Active"
+// snapshot left by `kuke build` whose Remove transiently fails, leaving the
+// snapshot multi-pass loop to log "made no progress, giving up". By that
+// point the straggler is fully unreferenced (its leases and image are gone),
+// so it is collectible — but only by a GC pass. The lease-first sweep above
+// ran before the image/snapshot drain, so it could not collect it; without a
+// sweep after the drain, the immediately-following DeleteNamespace races the
+// next periodic GC and fails with "namespace must be empty ... still has
+// snapshots on overlayfs". The straggler is collected a moment later, so a
+// re-run succeeds — the deterministic two-command failure from issue #1182.
 //
 // Each class logs a count summary at INFO and per-resource debug lines at
 // DEBUG, so a future "namespace not empty" failure points at the exact class
@@ -244,6 +258,50 @@ func (c *client) drainNamespaceResources(
 	}
 
 	c.drainBlobs(nsCtx, namespace, srv)
+	c.forceGCSweep(nsCtx, namespace, srv)
+}
+
+// forceGCSweep triggers a final synchronous containerd GC pass by creating a
+// throwaway lease and immediately deleting it with leases.SynchronousDelete,
+// which blocks on the GC scheduler's ScheduleAndWait sweep. The sweep reclaims
+// resources that became unreferenced during the drain above but that the
+// explicit Walk+Remove passes could not remove directly — notably a BuildKit
+// "Active" snapshot whose Remove transiently fails, which the snapshot loop
+// gives up on with "made no progress". Without this sweep the
+// immediately-following DeleteNamespace fails with "namespace must be empty
+// ... still has snapshots on overlayfs" even though the straggler is moments
+// from being collected by the next periodic GC — the issue #1182 first-pass
+// failure. Best-effort: a failure to create or delete the throwaway lease is
+// logged at WARN and does not surface as an error, mirroring the rest of the
+// drain. The lease is always deleted, so it never itself blocks the namespace
+// delete.
+func (c *client) forceGCSweep(nsCtx context.Context, namespace string, srv containerdNamespaceServices) {
+	c.logger.DebugContext(c.ctx, "forcing GC sweep before namespace delete", "namespace", namespace)
+	leaseManager := srv.LeasesService()
+	lease, err := leaseManager.Create(nsCtx, leases.WithRandomID())
+	if err != nil {
+		c.logger.WarnContext(
+			c.ctx,
+			"failed to create throwaway lease for GC sweep",
+			"namespace",
+			namespace,
+			"error",
+			err,
+		)
+		return
+	}
+	if deleteErr := leaseManager.Delete(nsCtx, lease, leases.SynchronousDelete); deleteErr != nil {
+		c.logger.WarnContext(
+			c.ctx,
+			"failed to delete throwaway lease for GC sweep",
+			"namespace",
+			namespace,
+			"lease",
+			lease.ID,
+			"error",
+			deleteErr,
+		)
+	}
 }
 
 // drainLeases releases every lease in the namespace using

--- a/internal/ctr/namespaces_internal_test.go
+++ b/internal/ctr/namespaces_internal_test.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
+	"strings"
 	"testing"
 
 	"github.com/containerd/containerd/v2/core/content"
@@ -118,6 +119,82 @@ func TestCleanupNamespaceResourcesDrainsLeasePinnedSnapshots(t *testing.T) {
 	}
 }
 
+// TestCleanupNamespaceResourcesForcedGCSweepReclaimsStraggler is the
+// regression guard for issue #1182 — `kuke daemon reset --purge-system`
+// followed by `kuke uninstall -y` failed first-pass with "namespace must be
+// empty ... still has snapshots on overlayfs". The drain leaves one BuildKit
+// "Active" straggler snapshot the explicit snapshotter.Remove pass cannot
+// reclaim (it logs "made no progress, giving up"); the straggler is fully
+// unreferenced and collectible only by a GC pass. The fix appends a forced
+// synchronous GC sweep (a throwaway lease deleted with leases.SynchronousDelete)
+// after the drain so the namespace ends genuinely empty in a single pass,
+// rather than relying on the next periodic GC the immediately-following
+// DeleteNamespace would race.
+//
+// The fake models the field semantic: snapshotter.Remove fails on the gcOnly
+// straggler, and a synchronous lease Delete reclaims it once the images are
+// drained. A drainNamespaceResources without the trailing sweep would strand
+// the straggler — which is what this test asserts is no longer the case.
+//
+// Real-containerd integration of this drain+delete path lives in the e2e
+// suite; CI's `make test` target intentionally avoids needing a containerd
+// socket, so a fake is the only viable substrate for a per-package guard.
+func TestCleanupNamespaceResourcesForcedGCSweepReclaimsStraggler(t *testing.T) {
+	srv := newFakeServices()
+	srv.addSnapshot("overlayfs", "sha256:base")
+	srv.addSnapshot("overlayfs", "sha256:layer")
+	srv.addGCOnlySnapshot("overlayfs", "buildkit-active-straggler")
+	srv.addImage("kukeon.internal/kukeond:v0.0.0-dev", "sha256:manifest")
+	srv.addBlob("sha256:blob-a")
+
+	c := &client{
+		ctx:    context.Background(),
+		logger: slog.New(slog.NewTextHandler(io.Discard, nil)),
+	}
+	c.drainNamespaceResources(context.Background(), "kuke-system.kukeon.io", "overlayfs", srv)
+
+	if got := len(srv.snaps["overlayfs"]); got != 0 {
+		remaining := make([]string, 0, got)
+		for k := range srv.snaps["overlayfs"] {
+			remaining = append(remaining, k)
+		}
+		t.Errorf(
+			"snapshots remaining after drain: got %d (%v), want 0 — forced GC sweep did not reclaim the straggler",
+			got,
+			remaining,
+		)
+	}
+	if got := len(srv.leases); got != 0 {
+		t.Errorf("leases remaining after drain: got %d, want 0 — throwaway GC-sweep lease leaked", got)
+	}
+
+	// The forced sweep must run AFTER the snapshot drain: a synchronous lease
+	// delete that fired before the image/snapshot drain (the early drainLeases
+	// pass) could not reclaim the straggler, so the sweep is only load-bearing
+	// as the trailing step. The forced sweep is the only path that *creates* a
+	// lease (drainLeases only lists+deletes existing ones), so a lease.Create
+	// after the last snapshot walk uniquely identifies it.
+	lastSnapWalk := -1
+	for i, op := range srv.callLog {
+		if op == "snapshotter.Walk(overlayfs)" {
+			lastSnapWalk = i
+		}
+	}
+	if lastSnapWalk == -1 {
+		t.Fatalf("call log missing snapshotter.Walk(overlayfs); got %v", srv.callLog)
+	}
+	forcedSweep := -1
+	for i, op := range srv.callLog {
+		if i > lastSnapWalk && strings.HasPrefix(op, "lease.Create(") {
+			forcedSweep = i
+			break
+		}
+	}
+	if forcedSweep == -1 {
+		t.Errorf("call log missing the trailing forced-GC-sweep lease.Create after the snapshot drain; got %v", srv.callLog)
+	}
+}
+
 // fakeServices models the subset of containerd surface drainNamespaceResources
 // uses. The pinning semantic — snapshotter.Remove fails while any lease
 // references the snapshot via a leases.Resource{Type:"snapshots/<name>",ID:<key>}
@@ -138,6 +215,14 @@ type fakeServices struct {
 
 type fakeSnapshot struct {
 	name string
+	// gcOnly models a snapshot the explicit snapshotter.Remove cannot reclaim
+	// (Remove returns FailedPrecondition with no lease pinning it) — the
+	// BuildKit "Active" straggler from issue #1182. It is reclaimed only by a
+	// synchronous GC sweep (a lease Delete with Synchronous set) once the
+	// namespace's images are drained, mirroring the field behavior where the
+	// straggler is collectible only after its transitive image reference is
+	// gone.
+	gcOnly bool
 }
 
 type fakeLease struct {
@@ -158,6 +243,29 @@ func (f *fakeServices) addSnapshot(snapshotter, key string) {
 		f.snaps[snapshotter] = map[string]*fakeSnapshot{}
 	}
 	f.snaps[snapshotter][key] = &fakeSnapshot{name: key}
+}
+
+// addGCOnlySnapshot adds a snapshot that the explicit snapshotter.Remove pass
+// cannot reclaim — only the trailing forced synchronous GC sweep collects it
+// (issue #1182).
+func (f *fakeServices) addGCOnlySnapshot(snapshotter, key string) {
+	if f.snaps[snapshotter] == nil {
+		f.snaps[snapshotter] = map[string]*fakeSnapshot{}
+	}
+	f.snaps[snapshotter][key] = &fakeSnapshot{name: key, gcOnly: true}
+}
+
+// reclaimGCOnlySnapshots removes every gcOnly snapshot across all
+// snapshotters. Invoked by a synchronous lease Delete once the namespace's
+// images are drained — the fake's stand-in for containerd's GC sweep.
+func (f *fakeServices) reclaimGCOnlySnapshots() {
+	for _, bucket := range f.snaps {
+		for key, snap := range bucket {
+			if snap.gcOnly {
+				delete(bucket, key)
+			}
+		}
+	}
 }
 
 func (f *fakeServices) addLease(id, resourceType string, keys ...string) {
@@ -219,9 +327,38 @@ func (m *fakeLeaseManager) List(_ context.Context, _ ...string) ([]leases.Lease,
 	return out, nil
 }
 
-func (m *fakeLeaseManager) Delete(_ context.Context, l leases.Lease, _ ...leases.DeleteOpt) error {
+func (m *fakeLeaseManager) Create(ctx context.Context, opts ...leases.Opt) (leases.Lease, error) {
+	var l leases.Lease
+	for _, opt := range opts {
+		if err := opt(&l); err != nil {
+			return leases.Lease{}, err
+		}
+	}
+	if l.ID == "" {
+		l.ID = fmt.Sprintf("fake-lease-%d", len(m.f.leases)+len(m.f.callLog))
+	}
+	m.f.callLog = append(m.f.callLog, "lease.Create("+l.ID+")")
+	m.f.leases[l.ID] = &fakeLease{id: l.ID}
+	return l, nil
+}
+
+func (m *fakeLeaseManager) Delete(ctx context.Context, l leases.Lease, opts ...leases.DeleteOpt) error {
+	var do leases.DeleteOptions
+	for _, opt := range opts {
+		if err := opt(ctx, &do); err != nil {
+			return err
+		}
+	}
 	m.f.callLog = append(m.f.callLog, "lease.Delete("+l.ID+")")
 	delete(m.f.leases, l.ID)
+	// A synchronous lease delete blocks on containerd's GC sweep. The sweep
+	// reclaims gcOnly stragglers once the namespace's images are drained —
+	// the issue #1182 forced-sweep behavior. While images are still present
+	// (the early drainLeases sweeps), the straggler stays transitively
+	// referenced and is left in place.
+	if do.Synchronous && len(m.f.imageList) == 0 {
+		m.f.reclaimGCOnlySnapshots()
+	}
 	return nil
 }
 
@@ -288,6 +425,12 @@ func (s *fakeSnapshotter) Remove(_ context.Context, key string) error {
 	s.f.callLog = append(s.f.callLog, "snapshotter.Remove("+s.name+","+key+")")
 	if pins := s.f.snapshotPinnedBy(s.name, key); len(pins) > 0 {
 		return fmt.Errorf("snapshot %q pinned by %v: %w", key, pins, errdefs.ErrFailedPrecondition)
+	}
+	if snap, ok := s.f.snaps[s.name][key]; ok && snap.gcOnly {
+		// Models the BuildKit "Active" straggler: the explicit Remove fails
+		// transiently and the snapshot multi-pass loop gives up on it. Only
+		// the trailing forced GC sweep reclaims it (issue #1182).
+		return fmt.Errorf("snapshot %q not removable directly: %w", key, errdefs.ErrFailedPrecondition)
 	}
 	delete(s.f.snaps[s.name], key)
 	return nil


### PR DESCRIPTION
## Summary

`kuke daemon reset --purge-system` followed by `kuke uninstall -y` failed first-pass (exit non-zero) with:

```
namespace "kuke-system.kukeon.io" must be empty, but it still has snapshots on "overlayfs" snapshotter: failed precondition
```

`daemon reset --purge-system` removes the on-disk `kuke-system` metadata but leaves the containerd namespace (the staged kukeond image layers/snapshots) in place. uninstall then drains the namespace and deletes it — but the drain leaves exactly **one** straggler snapshot the explicit `snapshotter.Remove` pass cannot reclaim (a BuildKit "Active" snapshot from `kuke build` whose `Remove` transiently fails; the multi-pass loop logs `snapshot cleanup made no progress, giving up remaining=1`). That straggler is fully unreferenced (its leases and image are already drained), so containerd's *next periodic GC* reclaims it — but `DeleteNamespace` runs immediately and races it. The straggler is collected a moment later, which is why the documented "re-run" recovery worked and why a plain single-layer image never reproduced.

**Fix:** append a final forced synchronous GC sweep to `drainNamespaceResources` — create a throwaway lease and delete it with `leases.SynchronousDelete`, which blocks on the GC scheduler's `ScheduleAndWait`. This reclaims the straggler before `DeleteNamespace`, so the single invocation succeeds. The lease-first drain step couldn't cover this because it runs *before* the image/snapshot drain.

### Root-cause verification (live containerd)

Reproduced and fixed on a live containerd with the real BuildKit-built kukeond image (36 snapshots: 5 Active + 31 Committed). Instrumented probe of the drain:

- **before fix:** after-drain `snaps=1` (straggler) → `DeleteNamespace` fails → re-run succeeds (GC caught up).
- **after fix:** after-drain `snaps=1` → forced GC sweep → `snaps=0` → `DeleteNamespace` err=nil.
- End-to-end with the rebuilt `kuke`: a single `kuke uninstall --yes` against the BuildKit-populated namespace exits **0** and removes the namespace (plus its `_history` companion) in one pass.

A plain single-layer image (`hello-world`) drains cleanly on both old and new code — the bug requires the BuildKit Active-snapshot straggler.

### Notes for the reviewer

- `internal/ctr/namespaces.go`'s `drainImages` deletes images **without** `images.SynchronousDelete()` (unlike `internal/ctr/image.go:309`). The trailing forced sweep subsumes that gap; I left `drainImages` unchanged to keep the fix minimal (no scope creep).
- The forced sweep runs for every namespace drain, including the BuildKit `_history` companion (out of scope here per the issue; already handled by #1205) — it's an idempotent create+delete and a no-op on an already-empty namespace.
- The `docs/cli-use-cases.md` § *Full per-host teardown* recovery procedure remains valid for other genuine residual-namespace causes (e.g. a truly busy mount); it's no longer required for the two-command sequence, but I did not edit it to keep this a focused code fix.

## Test plan

- [x] `make test` (CI unit target: `test-root` + `test-kukebuild`) — passes.
- [x] `go vet ./...` (GOWORK=off) — clean.
- [x] New deterministic unit guard `TestCleanupNamespaceResourcesForcedGCSweepReclaimsStraggler` in `internal/ctr/namespaces_internal_test.go` — models the un-removable straggler and asserts the trailing forced sweep reclaims it (fails without the fix).
- [x] Existing `TestCleanupNamespaceResourcesDrainsLeasePinnedSnapshots` (#401) and `TestPruneLeasesDropsOrphansKeepsProtected` still pass after the shared-fake change.
- [x] Manual live-containerd repro + fix verification (BuildKit kukeond image): exit 1 before fix, exit 0 after; `ctr ns ls` shows no `*.kukeon.io` namespaces after.
- [ ] `make e2e` (new `TestKuke_DaemonResetPurgeSystem_ThenUninstall`, AC #1/#2; existing `TestKuke_Uninstall_VerifyState`, AC #3) — **not run locally: no docker daemon on the dev host** (`make e2e` requires docker for `docker save`). Both compile (`go vet ./e2e/` clean) and run in CI's `make e2e` job. Note: the e2e harness stages the image via `docker save`/`ctr import` (committed snapshots only), so it may not populate the BuildKit Active-snapshot straggler that triggers this bug on old code — the deterministic regression guard is the unit test above; the e2e test encodes the AC end-to-end and asserts single-pass success + no surviving namespaces, which hold on the fixed code.

## Acceptance criteria

- [x] `kuke daemon reset --purge-system` followed by `kuke uninstall -y` succeeds in one invocation, exit 0. (verified on live containerd)
- [x] After uninstall, `ctr ns ls` shows no `*.kukeon.io` namespaces. (verified on live containerd)
- [x] Existing single-invocation uninstall on a fully healthy host still passes (e2e #206 class). (additive fix — trailing sweep is a no-op on an empty/healthy namespace; `make test` green; `TestKuke_Uninstall_VerifyState` unchanged)

Closes #1182