### PR TITLE
fix(init): keep ownership sweep out of live per-cell kuketty tty state

### DIFF
--- a/cmd/kuke/init/init.go
+++ b/cmd/kuke/init/init.go
@@ -363,13 +363,39 @@ func applyKukeonOwnership(
 		return r, fmt.Errorf("apply kukeon ownership to %q: %w", runDir, err)
 	}
 	r.RunDirApplied = true
-	if err := sysuser.ChownTreeAndChmod(
+	if err := sysuser.ChownTreeAndChmodSkip(
 		runPath, 0, ensure.GID, kukeonRunPathDirMode, kukeonRunPathFileMode,
+		skipLiveCellState,
 	); err != nil {
 		return r, fmt.Errorf("apply kukeon ownership to %q: %w", runPath, err)
 	}
 	r.RunPathApplied = true
 	return r, nil
+}
+
+// skipLiveCellState reports whether the recursive `kuke init` ownership sweep
+// must leave a path untouched. Per-container kuketty state is provisioned and
+// owned by the runner at the container's resolved process uid
+// (attachableBuildOpts + attachablePostCreateChown + kuketty), not by init:
+//
+//   - the tty directory (consts.KukeonContainerTTYDir) and everything inside
+//     it — the live attach socket bound 0o660, the capture transcript, the
+//     kuketty log, and kuketty's own runtime metadata it rewrites in place;
+//   - the rendered per-container kuketty metadata file
+//     (ctr.AttachableMetadataFile), chown'd to the container uid so the
+//     in-container wrapper can read it through the bind mount.
+//
+// The blanket sweep treated a live socket as "just a file": it chmodded it
+// 0o660 → 0o640 (stripping group-write, so every kukeon-group operator got
+// EACCES on `kuke attach`) and chown'd it back to root, undoing
+// attachablePostCreateChown. Because `make dev-init` runs `kuke init` on every
+// iteration, the sweep re-broke attach for every pre-existing cell each time
+// (issue #1207). Returning true for the tty directory prunes the whole subtree.
+func skipLiveCellState(_ string, info os.FileInfo) bool {
+	if info.IsDir() {
+		return info.Name() == consts.KukeonContainerTTYDir
+	}
+	return info.Name() == ctr.AttachableMetadataFile
 }
 
 // stageKukepause copies the kukepause binary into <runPath>/bin/kukepause and

--- a/cmd/kuke/init/init_test.go
+++ b/cmd/kuke/init/init_test.go
@@ -22,6 +22,7 @@ import (
 	"errors"
 	"io"
 	"log/slog"
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -32,8 +33,11 @@ import (
 	initpkg "github.com/eminwux/kukeon/cmd/kuke/init"
 	kukshared "github.com/eminwux/kukeon/cmd/kuke/shared"
 	"github.com/eminwux/kukeon/cmd/types"
+	"github.com/eminwux/kukeon/internal/consts"
 	"github.com/eminwux/kukeon/internal/controller"
+	"github.com/eminwux/kukeon/internal/ctr"
 	"github.com/eminwux/kukeon/internal/errdefs"
+	"github.com/eminwux/kukeon/internal/sysuser"
 	v1beta1 "github.com/eminwux/kukeon/pkg/api/model/v1beta1"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
@@ -78,6 +82,9 @@ func printCgroupAction(cmd *cobra.Command, label string, existedPre bool, exists
 
 //go:linkname printContainerAction github.com/eminwux/kukeon/cmd/kuke/init.printContainerAction
 func printContainerAction(cmd *cobra.Command, label string, existedPre bool, existsPost bool, created bool)
+
+//go:linkname skipLiveCellState github.com/eminwux/kukeon/cmd/kuke/init.skipLiveCellState
+func skipLiveCellState(path string, info os.FileInfo) bool
 
 //go:linkname printStartAction github.com/eminwux/kukeon/cmd/kuke/init.printStartAction
 func printStartAction(cmd *cobra.Command, label string, startedPre bool, startedPost bool, started bool)
@@ -1003,4 +1010,83 @@ func newOutputCommand() (*cobra.Command, *bytes.Buffer) {
 	cmd.SetOut(buf)
 	cmd.SetErr(buf)
 	return cmd, buf
+}
+
+// TestSkipLiveCellState_PreservesLiveSocketUnderInitSweep builds a RunPath
+// resembling the real `/opt/kukeon` layout — a per-container kuketty tty
+// directory holding a live attach socket at 0o660, a rendered
+// kuketty-metadata.json, and a swept cell metadata file — then drives the
+// init ownership sweep through skipLiveCellState (the predicate
+// applyKukeonOwnership wires into sysuser.ChownTreeAndChmodSkip). It asserts
+// the live socket and the rendered metadata file keep their modes while the
+// daemon metadata file is swept to the file mode, the regression guard for
+// issue #1207. uid/gid stay the current process so the test runs unprivileged
+// in CI (the production sweep targets root:kukeon).
+func TestSkipLiveCellState_PreservesLiveSocketUnderInitSweep(t *testing.T) {
+	runPath := t.TempDir()
+	// data/<realm>/<space>/<stack>/<cell>/<container>/{tty/,kuketty-metadata.json}
+	containerDir := filepath.Join(
+		runPath, consts.KukeonMetadataSubdir,
+		"default.kukeon.io", "kukeon", "kukeon", "kukeond", "kukeond",
+	)
+	ttyDir := filepath.Join(containerDir, consts.KukeonContainerTTYDir)
+	if err := os.MkdirAll(ttyDir, 0o2750); err != nil {
+		t.Fatalf("mkdir tty dir: %v", err)
+	}
+	socket := filepath.Join(ttyDir, consts.KukeonContainerSocketFile)
+	if err := os.WriteFile(socket, []byte("x"), 0o660); err != nil {
+		t.Fatalf("write socket: %v", err)
+	}
+	// os.WriteFile honors the umask; chmod explicitly so the live socket is a
+	// genuine 0o660 (group-writable) before the sweep, matching how the daemon
+	// binds it.
+	if err := os.Chmod(socket, 0o660); err != nil {
+		t.Fatalf("chmod socket: %v", err)
+	}
+	renderedMeta := filepath.Join(containerDir, ctr.AttachableMetadataFile)
+	if err := os.WriteFile(renderedMeta, []byte("{}"), 0o600); err != nil {
+		t.Fatalf("write rendered metadata: %v", err)
+	}
+	// A daemon metadata file the sweep SHOULD touch (cell metadata.json).
+	cellDir := filepath.Dir(containerDir)
+	cellMeta := filepath.Join(cellDir, consts.KukeonMetadataFile)
+	if err := os.WriteFile(cellMeta, []byte("{}"), 0o600); err != nil {
+		t.Fatalf("write cell metadata: %v", err)
+	}
+
+	const (
+		dirMode  = os.ModeSetgid | os.FileMode(0o750)
+		fileMode = os.FileMode(0o640)
+	)
+	uid, gid := os.Getuid(), os.Getgid()
+	if err := sysuser.ChownTreeAndChmodSkip(
+		runPath, uid, gid, dirMode, fileMode, skipLiveCellState,
+	); err != nil {
+		t.Fatalf("sweep: %v", err)
+	}
+
+	// Live socket: untouched (still group-writable, attach stays reachable).
+	if info, err := os.Stat(socket); err != nil {
+		t.Fatalf("stat socket: %v", err)
+	} else if got := info.Mode().Perm(); got != 0o660 {
+		t.Errorf("live socket mode: got %#o want 0o660 (untouched by sweep)", got)
+	}
+	// Rendered per-container metadata: untouched.
+	if info, err := os.Stat(renderedMeta); err != nil {
+		t.Fatalf("stat rendered metadata: %v", err)
+	} else if got := info.Mode().Perm(); got != 0o600 {
+		t.Errorf("rendered metadata mode: got %#o want 0o600 (untouched by sweep)", got)
+	}
+	// tty directory itself: pruned, keeps its provisioned mode.
+	if info, err := os.Stat(ttyDir); err != nil {
+		t.Fatalf("stat tty dir: %v", err)
+	} else if got := info.Mode().Perm(); got != 0o750 {
+		t.Errorf("tty dir mode: got %#o want 0o750 (untouched by sweep)", got)
+	}
+	// Daemon cell metadata: swept to the file mode.
+	if info, err := os.Stat(cellMeta); err != nil {
+		t.Fatalf("stat cell metadata: %v", err)
+	} else if got := info.Mode().Perm(); got != 0o640 {
+		t.Errorf("cell metadata mode: got %#o want 0o640 (swept)", got)
+	}
 }

--- a/internal/sysuser/sysuser.go
+++ b/internal/sysuser/sysuser.go
@@ -194,9 +194,32 @@ func ChownAndChmod(path string, uid, gid int, mode os.FileMode) error {
 // symlinks, and os.Chmod follows the link, which would mutate the wrong
 // file.
 func ChownTreeAndChmod(root string, uid, gid int, dirMode, fileMode os.FileMode) error {
+	return ChownTreeAndChmodSkip(root, uid, gid, dirMode, fileMode, nil)
+}
+
+// ChownTreeAndChmodSkip is ChownTreeAndChmod with an optional skip predicate.
+// When skip is non-nil and returns true for an entry, that entry is left
+// untouched — its owner and mode are preserved. Returning true for a
+// directory prunes the entire subtree (filepath.SkipDir), so live state that
+// a different code path owns is never re-chowned/chmodded by a tree-wide
+// sweep. `kuke init` uses this to keep its idempotent ownership pass out of
+// per-container kuketty tty directories, whose socket the daemon binds at
+// 0o660 owned by the container's runtime uid (issue #1207).
+func ChownTreeAndChmodSkip(
+	root string,
+	uid, gid int,
+	dirMode, fileMode os.FileMode,
+	skip func(path string, info os.FileInfo) bool,
+) error {
 	return filepath.Walk(root, func(path string, info os.FileInfo, walkErr error) error {
 		if walkErr != nil {
 			return walkErr
+		}
+		if skip != nil && skip(path, info) {
+			if info.IsDir() {
+				return filepath.SkipDir
+			}
+			return nil
 		}
 		if err := os.Lchown(path, uid, gid); err != nil {
 			return fmt.Errorf("chown %q: %w", path, err)

--- a/internal/sysuser/sysuser_test.go
+++ b/internal/sysuser/sysuser_test.go
@@ -261,6 +261,88 @@ func TestChownTreeAndChmod_SGIDBit(t *testing.T) {
 	}
 }
 
+// TestChownTreeAndChmodSkip_PrunesSubtreeAndFile confirms the skip predicate
+// both prunes a whole directory subtree and leaves a single matched file
+// untouched, while still sweeping every non-skipped entry. This is the
+// mechanism `kuke init` relies on to keep its ownership sweep out of live
+// per-container kuketty tty directories (issue #1207).
+func TestChownTreeAndChmodSkip_PrunesSubtreeAndFile(t *testing.T) {
+	root := t.TempDir()
+	// A directory that must be swept and a file inside it.
+	swept := filepath.Join(root, "swept")
+	if err := os.MkdirAll(swept, 0o700); err != nil {
+		t.Fatalf("mkdir swept: %v", err)
+	}
+	sweptFile := filepath.Join(swept, "data.json")
+	if err := os.WriteFile(sweptFile, []byte("{}"), 0o600); err != nil {
+		t.Fatalf("write swept file: %v", err)
+	}
+	// A directory whose basename is skipped, with a file inside it that must
+	// be pruned (never visited) along with the subtree.
+	skippedDir := filepath.Join(root, "tty")
+	if err := os.MkdirAll(skippedDir, 0o700); err != nil {
+		t.Fatalf("mkdir skipped dir: %v", err)
+	}
+	prunedFile := filepath.Join(skippedDir, "socket")
+	if err := os.WriteFile(prunedFile, []byte("x"), 0o660); err != nil {
+		t.Fatalf("write pruned file: %v", err)
+	}
+	// os.WriteFile honors the umask, so chmod to the intended mode explicitly
+	// (chmod is not umask-masked) — the socket must be a genuine 0o660 going
+	// in for the "untouched" assertion to mean anything.
+	if err := os.Chmod(prunedFile, 0o660); err != nil {
+		t.Fatalf("chmod pruned file: %v", err)
+	}
+	// A single file (not a directory) that is skipped by basename.
+	skippedFile := filepath.Join(root, "kuketty-metadata.json")
+	if err := os.WriteFile(skippedFile, []byte("{}"), 0o600); err != nil {
+		t.Fatalf("write skipped file: %v", err)
+	}
+
+	skip := func(_ string, info os.FileInfo) bool {
+		if info.IsDir() {
+			return info.Name() == "tty"
+		}
+		return info.Name() == "kuketty-metadata.json"
+	}
+
+	uid, gid := os.Getuid(), os.Getgid()
+	if err := sysuser.ChownTreeAndChmodSkip(root, uid, gid, 0o750, 0o640, skip); err != nil {
+		t.Fatalf("walk: %v", err)
+	}
+
+	// Swept entries get the sweep modes.
+	if info, err := os.Stat(swept); err != nil {
+		t.Fatalf("stat swept: %v", err)
+	} else if got := info.Mode().Perm(); got != 0o750 {
+		t.Errorf("swept dir mode: got %#o want 0o750", got)
+	}
+	if info, err := os.Stat(sweptFile); err != nil {
+		t.Fatalf("stat swept file: %v", err)
+	} else if got := info.Mode().Perm(); got != 0o640 {
+		t.Errorf("swept file mode: got %#o want 0o640", got)
+	}
+
+	// The pruned subtree keeps its original modes — the walk never descended.
+	if info, err := os.Stat(skippedDir); err != nil {
+		t.Fatalf("stat skipped dir: %v", err)
+	} else if got := info.Mode().Perm(); got != 0o700 {
+		t.Errorf("skipped dir mode: got %#o want 0o700 (untouched)", got)
+	}
+	if info, err := os.Stat(prunedFile); err != nil {
+		t.Fatalf("stat pruned file: %v", err)
+	} else if got := info.Mode().Perm(); got != 0o660 {
+		t.Errorf("pruned socket mode: got %#o want 0o660 (untouched)", got)
+	}
+
+	// The skipped single file keeps its original mode.
+	if info, err := os.Stat(skippedFile); err != nil {
+		t.Fatalf("stat skipped file: %v", err)
+	} else if got := info.Mode().Perm(); got != 0o600 {
+		t.Errorf("skipped file mode: got %#o want 0o600 (untouched)", got)
+	}
+}
+
 // runnerFunc adapts a function value to the CommandRunner interface for tests.
 type runnerFunc func(ctx context.Context, name string, args ...string) error
 


### PR DESCRIPTION
## Summary

- `applyKukeonOwnership` (`cmd/kuke/init/init.go`) ran `sysuser.ChownTreeAndChmod` over the **entire** `/opt/kukeon` tree, treating a live per-container kuketty attach socket as "just a file": it chmodded it `0o660 → 0o640` (stripping group-write → EACCES on `kuke attach`/`kuke run` for every kukeon-group operator) and chown'd it back to `root`, undoing `attachablePostCreateChown`. Because `make dev-init` runs `kuke init` on every iteration, each run re-broke attach for every pre-existing cell (#1207).
- Added `sysuser.ChownTreeAndChmodSkip` — `ChownTreeAndChmod` with an optional skip predicate that prunes a whole subtree (`filepath.SkipDir`) when it returns true for a directory. `ChownTreeAndChmod` now delegates with a nil predicate (behavior unchanged for all other callers — init was the only one).
- `applyKukeonOwnership` passes `skipLiveCellState`, which prunes per-container live state the runner owns at the container uid: the `tty/` directory subtree (live socket, capture, kuketty log, sbsh runtime metadata) and the rendered `kuketty-metadata.json`. The rest of the init-owned skeleton (`bin/`, instance metadata, realm/space/stack/cell metadata dirs) is still swept exactly as before, so first-init group-ownership setup is unchanged.

This is the issue's strongly-preferred **Option 1** (exclude live cell work state from the sweep), implemented against the real on-disk layout.

## AC-vs-codebase divergence (documented per dev CLAUDE.md)

The issue describes the clobbered socket as `…/work/tty/socket` and Option 1 as "never recurse into `data/<realm>/<space>/<stack>/<cell>/work/`". There is **no `work/` path component** in the actual layout (`internal/util/fs/metadata.go`): the live per-container state lives at `data/<realm>/<space>/<stack>/<cell>/<container>/tty/` (`fs.ContainerTTYDir` → `consts.KukeonContainerTTYDir = "tty"`), with the rendered config at `<container>/kuketty-metadata.json` (`ctr.AttachableMetadataFile`). The intent is unambiguous — keep the init sweep out of runner-owned live cell state — so I implemented against the real layout rather than the literal (non-existent) `work/` basename. Both excluded inodes are exactly what `attachablePostCreateChown` chowns to the container uid (`internal/controller/runner/attachable.go:505-551`).

## Scope

This is the **init-side** fix only (#1207). The complementary attach-path self-heal (#1169 — `kuke run`/`attach` never heals a wrong-mode socket) is a separate issue and is **not** included here; together they give the defense-in-depth the issue describes.

## Test plan

- [x] `make test` (full CI suite — `test-root` + `test-kukebuild`) — green.
- [x] `go vet ./internal/sysuser/ ./cmd/kuke/init/` — clean.
- [x] `pre-commit run --files <changed>` — all hooks pass (go fmt, golangci-lint, addlicense, …).
- [x] New unit test `TestChownTreeAndChmodSkip_PrunesSubtreeAndFile` (`internal/sysuser`) — confirms the skip predicate prunes a directory subtree and a single file while sweeping everything else.
- [x] New unit test `TestSkipLiveCellState_PreservesLiveSocketUnderInitSweep` (`cmd/kuke/init`) — builds a realistic RunPath (`data/…/<cell>/<container>/tty/socket` at `0o660` + rendered `kuketty-metadata.json`), drives the real `skipLiveCellState` predicate through the sweep, and asserts the live socket (`0o660`) and rendered metadata stay untouched while the daemon cell metadata is swept to the file mode. This is the regression observable (socket mode + ownership), directly testable via filesystem stat.
- [ ] `make dev-init` end-to-end smoke — **not run**: this host carries the live agent-cell fleet, and the issue documents that `make dev-init` is the exact mutator that re-breaks attach on every pre-existing cell. Running the destructive smoke here would disrupt unrelated production state (the very hazard this PR fixes); deferred to a clean host. The fix's observable (socket mode/ownership survives the sweep) is covered by the unit tests above.

Closes #1207