### PR TITLE
fix(dev-init): warn on nested run without KUKEON_PROFILE=dev

### DIFF
--- a/scripts/dev-init.sh
+++ b/scripts/dev-init.sh
@@ -93,6 +93,31 @@ if [ -e "${NESTED_PROBE}" ]; then
     echo "Routing the nested kukeond through ${NESTED_SOCKET_PATH} (per-nest socket)."
     echo "Parent host's /run/kukeon/tty bind is left untouched; verified on exit."
 
+    # Nested without the dev profile is not a supported configuration
+    # (issue #1191). The socket redirect above is automatic, but the
+    # default profile still reuses the parent host's canonical kukeon.io
+    # namespaces, /kukeon cgroup root, and 10.88.0.0/16 pod subnet — and
+    # that subnet's 10.88.0.1 gateway is *also* the dev-root cell's own
+    # default gateway, so a nested default-profile run shadows the gateway
+    # and blackholes the nested cells' egress (docs/dev-init.md "Nested
+    # egress: the dev profile's pod-CIDR redirect"). The lower-blast-radius
+    # default is to warn loudly and continue (preserving the historical
+    # behavior of this script) rather than force KUKEON_PROFILE=dev; the
+    # operator is told how to opt into the supported per-nest path.
+    if [ "${KUKEON_PROFILE}" != "dev" ]; then
+        cat >&2 <<EOF
+
+WARNING: nested 'make dev-init' without KUKEON_PROFILE=dev is not a supported
+         configuration (see docs/dev-init.md). The default profile reuses the
+         parent host's kukeon.io namespaces, /kukeon cgroup root, and
+         10.88.0.0/16 pod subnet; the shared 10.88.0.1 gateway is shadowed
+         inside this cell and the nested cells' egress is blackholed.
+         Re-run with 'KUKEON_PROFILE=dev make dev-init' for the supported
+         per-nest profile (dev.kukeon.io / /kukeon-dev / 10.89.0.0/16).
+
+EOF
+    fi
+
     # Snapshot the parent's per-container attach plumbing so the EXIT trap
     # can fail loud if anything we did clobbered it. The socket file and
     # metadata file are the parent's, populated by the parent's daemon at


### PR DESCRIPTION
## Summary

- `scripts/dev-init.sh` already redirects the nested daemon's socket to `/run/kukeon-dev/` automatically, but `docs/dev-init.md` documents that a nested run *without* `KUKEON_PROFILE=dev` is "not a supported configuration": the default profile reuses the parent host's `kukeon.io` namespaces, `/kukeon` cgroup root, and `10.88.0.0/16` pod subnet, and the shared `10.88.0.1` gateway is shadowed inside the cell — blackholing nested-cell egress. Until now that unsupported state was reachable as the silent *default* outcome of the documented command.
- Add a warning inside the existing nested-detection block (`if [ -e "${NESTED_PROBE}" ]`) that fires when `KUKEON_PROFILE != dev`, naming the supported-configuration contract and the `KUKEON_PROFILE=dev` opt-in. Emitted to stderr; the run continues.

## Design note

The issue offered two readings — print a warning, or auto-default `KUKEON_PROFILE=dev` in nested mode — and explicitly named the warning as the lower-blast-radius default. I took the warning: it preserves the historical behavior of this contributor-facing script (`make dev-init` operators rely on the default profile installing main against the host) while surfacing the unsupported state, consistent with dev CLAUDE.md's gate-vs-flip guidance. The auto-default reading is the bigger behavior change the maintainer can still opt into.

The warning lives entirely inside the nested-mode block, so **bare-host runs (probe absent) never reach it** — bare-host behavior is unchanged.

## Test plan

- [x] `bash -n scripts/dev-init.sh` — syntax clean
- [x] `make test` — both modules pass (TEST-EXIT=0); no Go code touched, included per the CI-target requirement
- [ ] `make dev-init` nested smoke — not run; requires a nested `kukeon-dev-root` cell + containerd + root, which this host can't host without disturbing the parent's attach plumbing. The added branch is guarded purely on the existing `${KUKEON_PROFILE}` value and gated by the existing nested probe.

## Acceptance criteria

- [x] Nested `make dev-init` without `KUKEON_PROFILE=dev` surfaces the unsupported-configuration contract (warning).
- [x] Bare-host behavior unchanged (warning is inside the nested-probe block).

Closes #1191
