### PR TITLE
docs: drop eminwux/crew references from the Claude Code guide and example Dockerfile

### DIFF
--- a/docs/examples/claude-code/Dockerfile
+++ b/docs/examples/claude-code/Dockerfile
@@ -1,9 +1,9 @@
 # Claude Code image used by the run-claude-code guide.
 #
-# Derived verbatim from eminwux/crew images/claude/Dockerfile so the example
-# tracks what is actually running at fleet scale. The companion guide at
+# Tracks what runs at fleet scale so the example stays drop-in usable on a
+# full agent-runner host. The companion guide at
 # docs/site/guides/run-claude-code.md explains which pieces are kukeon-cell
-# essentials (Node + the npm package, the `claude` user) versus crew-fleet
+# essentials (Node + the npm package, the `claude` user) versus fleet-runner
 # extras carried over for parity (gh, git signing tooling, golang, jq/yq,
 # the `kukeon` gid 988 stanza). Trim freely for your own image — the bits
 # the guide's smoke path needs are Node, the `@anthropic-ai/claude-code`
@@ -41,9 +41,9 @@ RUN apt-get update \
  && rm -rf /var/lib/apt/lists/*
 
 # Non-root claude user. The `kukeon` gid 988 stanza matches the host
-# containerd-socket group on crew's fleet hosts; on a freshly-`kuke init`-ed
+# containerd-socket group on a fleet host; on a freshly-`kuke init`-ed
 # host you don't need it for the smoke path in the companion guide. Left in
-# verbatim so this Dockerfile stays usable on a fleet host without edits —
+# so this Dockerfile stays usable on a fleet host without edits —
 # the guide explains the tradeoff and how to drop it when you don't.
 RUN useradd --create-home --shell /bin/bash claude \
  && groupadd -g 988 kukeon \

--- a/docs/site/guides/run-claude-code.md
+++ b/docs/site/guides/run-claude-code.md
@@ -4,7 +4,7 @@ This guide walks a freshly-`kuke init`-ed host from zero to a live Claude Code p
 
 [Claude Code](https://docs.claude.com/en/docs/claude-code/overview) is named in the [Vision](../vision.md) as the canonical agent workload kukeon's isolation primitives are measured against. The companion artifacts under [`docs/examples/claude-code/`](https://github.com/eminwux/kukeon/tree/main/docs/examples/claude-code) are the smallest end-to-end shape: an image, a Cell, and a CellBlueprint.
 
-The example does **not** bake API keys into the image and does not configure auth — bring your own per the upstream [setup docs](https://docs.claude.com/en/docs/claude-code/setup). For the full agent-runner shape (SSH bind, signed commits, agents/project-repo clones), see [`eminwux/crew`](https://github.com/eminwux/crew) — this guide is derived from `crew/images/claude/Dockerfile` and `crew/agents/pm/profiles/pm.yaml` with that plumbing stripped out.
+The example does **not** bake API keys into the image and does not configure auth — bring your own per the upstream [setup docs](https://docs.claude.com/en/docs/claude-code/setup). It is the smallest end-to-end shape — an image, a Cell, and a CellBlueprint — with the broader fleet-runner plumbing (SSH bind, signed commits, agents/project-repo clones) deliberately stripped out.
 
 ## Prerequisites
 
@@ -17,7 +17,7 @@ The example does **not** bake API keys into the image and does not configure aut
 
 ## Step 1 — Build the image
 
-The example `Dockerfile` is the upstream `crew` image verbatim. It installs `nodejs` + `npm` + the `@anthropic-ai/claude-code` package as a non-root `claude` user on `debian:trixie-slim`:
+The example `Dockerfile` installs `nodejs` + `npm` + the `@anthropic-ai/claude-code` package as a non-root `claude` user on `debian:trixie-slim`:
 
 ```bash
 cd docs/examples/claude-code
@@ -26,12 +26,12 @@ docker build -t claude-code:latest .
 
 `nerdctl build -t claude-code:latest .` works the same way if you don't run Docker.
 
-### What's in the upstream image that the smoke path doesn't need
+### What's in the image that the smoke path doesn't need
 
-The crew Dockerfile carries a handful of fleet-runner extras the Claude Code smoke does not exercise; they are kept verbatim so this Dockerfile remains drop-in usable on a crew-style host:
+The `Dockerfile` carries a handful of fleet-runner extras the Claude Code smoke does not exercise; they are kept so this Dockerfile remains drop-in usable on a full agent-runner host:
 
-- **`golang`, `gh`, `pre-commit`, `gnupg`, `ssh`, `jq`, `yq`, `make`, `gettext-base`** — the toolchain crew's `/dispatch` agents need to clone repos, sign commits, and run pre-commit. The smoke in this guide does not invoke any of them; trim them if you want a leaner image.
-- **`groupadd -g 988 kukeon` / `usermod -aG kukeon claude`** — fleet-specific. On crew's hosts gid 988 matches the host containerd socket group, so the `claude` user inside the cell can talk to a host-mounted socket. On a freshly-`kuke init`-ed host you do not bind-mount the containerd socket into the cell, so the supplementary group is inert. Leave it in if you ever expect to bind the socket; drop it for a strictly-Claude-Code image.
+- **`golang`, `gh`, `pre-commit`, `gnupg`, `ssh`, `jq`, `yq`, `make`, `gettext-base`** — the toolchain a full agent-runner needs to clone repos, sign commits, and run pre-commit. The smoke in this guide does not invoke any of them; trim them if you want a leaner image.
+- **`groupadd -g 988 kukeon` / `usermod -aG kukeon claude`** — fleet-specific. On a fleet host where gid 988 matches the host containerd socket group, the `claude` user inside the cell can talk to a host-mounted socket. On a freshly-`kuke init`-ed host you do not bind-mount the containerd socket into the cell, so the supplementary group is inert. Leave it in if you ever expect to bind the socket; drop it for a strictly-Claude-Code image.
 
 The smoke path needs only `nodejs`, `npm`, the `@anthropic-ai/claude-code` package, and the non-root `claude` user.
 
@@ -127,6 +127,5 @@ See [`kuke run`](../cli/kuke-run.md) for the full flag surface, including `--nam
 
 ## Where to go next
 
-- **The full crew agent-runner shape.** [`eminwux/crew`](https://github.com/eminwux/crew) — SSH bind, GPG-signed commits, agents-repo clone, project-repo clone, the orchestrator that dispatches per-call cells. Two layers up from this guide.
 - **Cell teardown verbs.** [`docs/cli-use-cases.md`](https://github.com/eminwux/kukeon/blob/main/docs/cli-use-cases.md) — the full operator workflow reference, including `stop` / `kill` / `delete` / `purge --cascade` for cells.
 - **Manifest reference.** [Applying manifests](apply-manifests.md) — multi-doc manifests, why `kuke apply` always requires the daemon, blueprint parameter resolution order.


### PR DESCRIPTION
## Summary
Best-effort documentation update applied from issue #1217.
Mode: best-effort — the issue body identified files and sections but did not provide paste-ready Before/After wording, so wording was authored to match the issue's Proposal and Acceptance criteria.

Removes every reference to the external `eminwux/crew` agent-runner repo from the Claude Code guide and its example Dockerfile so both stand on their own. All standalone technical content (build / load / attach / blueprint steps, the toolchain-extras explanation, the gid 988 stanza note) is preserved.

## Files changed
- `docs/site/guides/run-claude-code.md` — intro framing, Step 1, the "What's in the image…" section, and "Where to go next"
- `docs/examples/claude-code/Dockerfile` — header comment and the `claude` user comment

## Editorial choices
- Reframed the line-7 "derived from `crew/...`" clause as "the smallest end-to-end shape … with the broader fleet-runner plumbing deliberately stripped out" — keeps the bring-your-own-auth point and the "this is a minimal slice" framing without naming the external repo.
- Replaced "upstream `crew` image" / "crew Dockerfile" / "crew's `/dispatch` agents" / "crew's hosts" / "crew-style host" with generic "the Dockerfile" / "a full agent-runner" / "a fleet host" wording.
- Renamed the section heading "What's in the upstream image…" → "What's in the image…".
- Deleted the "The full crew agent-runner shape — `eminwux/crew` …" bullet from "Where to go next" entirely (it existed only to point at the external repo).
- Dockerfile: "Derived verbatim from eminwux/crew …" → "Tracks what runs at fleet scale …"; "crew-fleet extras" → "fleet-runner extras"; "crew's fleet hosts" → "a fleet host".

## Acceptance criteria check
- [x] `grep -rn "eminwux/crew" docs/` returns nothing — done
- [x] `grep -rni "crew" docs/site/guides/run-claude-code.md docs/examples/claude-code/Dockerfile` returns nothing — done
- [x] All build/load/attach/blueprint steps and the toolchain-extras + gid 988 explanations remain intact and accurate — done

Closes #1217