### PR TITLE
fix(apply): re-materialize on kill→apply and fail when reconcile leaves cell Failed

### DIFF
--- a/internal/controller/apply/diff.go
+++ b/internal/controller/apply/diff.go
@@ -794,7 +794,18 @@ func diffContainerSpec(desired, actual *intmodel.ContainerSpec, rootContainer bo
 		)
 	}
 
-	if desired.CNIConfigPath != actual.CNIConfigPath {
+	// Only a *non-empty* desired cniConfigPath counts as a change — same
+	// guard the cell-level spec.cniConfigPath diff above applies. The runner
+	// stamps every container's cniConfigPath at provision time
+	// (ResolveSpaceCNIConfigPath, #1136), so the persisted/actual container
+	// carries it while a user-authored YAML omits it. Without this guard the
+	// omitted (empty) desired value reads as "clear the path", reporting a
+	// spurious `cniConfigPath` change on every `kuke apply -f` of an unchanged
+	// file. That phantom diff routes a post-`kuke kill` apply through UpdateCell
+	// instead of the re-materialize branch, which recreates the workload
+	// container against the dead root's namespaces and fails the cell
+	// (lstat /proc/<dead-pid>/ns/ipc) — issue #1185.
+	if desired.CNIConfigPath != "" && desired.CNIConfigPath != actual.CNIConfigPath {
 		result.HasChanges = true
 		if result.ChangeType == ChangeTypeNone {
 			result.ChangeType = ChangeTypeCompatible

--- a/internal/controller/apply/diff_test.go
+++ b/internal/controller/apply/diff_test.go
@@ -337,6 +337,115 @@ func TestDiffCell_SynthesizedRoot_NoChange(t *testing.T) {
 	}
 }
 
+// TestDiffCell_RunnerInjectedCNIConfigPath_NoChange pins issue #1185: the
+// runner stamps every container's cniConfigPath at provision time
+// (ResolveSpaceCNIConfigPath, #1136), so the persisted/actual container carries
+// it while a user-authored YAML omits it (empty). An omitted desired value must
+// NOT read as a change — same guard the cell-level spec.cniConfigPath diff
+// applies. Without it, every `kuke apply -f` of an unchanged file reports a
+// spurious `cniConfigPath` diff, which (post-`kuke kill`) routes apply through
+// UpdateCell instead of the re-materialize branch and fails the cell against
+// the dead root's namespaces.
+func TestDiffCell_RunnerInjectedCNIConfigPath_NoChange(t *testing.T) {
+	desired := intmodel.Cell{
+		Metadata: intmodel.CellMetadata{Name: "hello-world"},
+		Spec: intmodel.CellSpec{
+			RealmName: "default",
+			SpaceName: "default",
+			StackName: "default",
+			Containers: []intmodel.ContainerSpec{
+				{ID: "root", Root: true, Image: "busybox:latest"},
+				{ID: "web", Image: "busybox:latest"},
+			},
+		},
+	}
+
+	actual := intmodel.Cell{
+		Metadata: intmodel.CellMetadata{Name: "hello-world"},
+		Spec: intmodel.CellSpec{
+			RealmName: "default",
+			SpaceName: "default",
+			StackName: "default",
+			Containers: []intmodel.ContainerSpec{
+				{
+					ID:            "root",
+					Root:          true,
+					Image:         "busybox:latest",
+					CNIConfigPath: "/opt/kukeon/data/default/default/network.conflist",
+				},
+				{
+					ID:            "web",
+					Image:         "busybox:latest",
+					CNIConfigPath: "/opt/kukeon/data/default/default/network.conflist",
+				},
+			},
+		},
+	}
+
+	diff := apply.DiffCell(desired, actual)
+	if diff.HasChanges {
+		t.Errorf("runner-injected cniConfigPath must not register as a change on an unchanged apply; got %+v", diff)
+	}
+	for _, cd := range diff.Containers {
+		for _, f := range cd.ChangedFields {
+			if f == "cniConfigPath" {
+				t.Errorf("container %q reported spurious cniConfigPath drift", cd.Name)
+			}
+		}
+	}
+}
+
+// TestDiffCell_ExplicitCNIConfigPath_StillDetectsDrift makes sure the
+// empty-desired guard above does not mask a genuine, user-authored
+// cniConfigPath change: when desired carries a non-empty value that differs
+// from actual, the diff must still surface it.
+func TestDiffCell_ExplicitCNIConfigPath_StillDetectsDrift(t *testing.T) {
+	desired := intmodel.Cell{
+		Metadata: intmodel.CellMetadata{Name: "hello-world"},
+		Spec: intmodel.CellSpec{
+			RealmName: "default",
+			SpaceName: "default",
+			StackName: "default",
+			Containers: []intmodel.ContainerSpec{
+				{ID: "root", Root: true, Image: "busybox:latest"},
+				{ID: "web", Image: "busybox:latest", CNIConfigPath: "/custom/new.conflist"},
+			},
+		},
+	}
+
+	actual := intmodel.Cell{
+		Metadata: intmodel.CellMetadata{Name: "hello-world"},
+		Spec: intmodel.CellSpec{
+			RealmName: "default",
+			SpaceName: "default",
+			StackName: "default",
+			Containers: []intmodel.ContainerSpec{
+				{ID: "root", Root: true, Image: "busybox:latest", CNIConfigPath: "/custom/old.conflist"},
+				{ID: "web", Image: "busybox:latest", CNIConfigPath: "/custom/old.conflist"},
+			},
+		},
+	}
+
+	diff := apply.DiffCell(desired, actual)
+	if !diff.HasChanges {
+		t.Fatal("expected a genuine non-empty cniConfigPath change to be detected")
+	}
+	found := false
+	for _, cd := range diff.Containers {
+		if cd.Name != "web" {
+			continue
+		}
+		for _, f := range cd.ChangedFields {
+			if f == "cniConfigPath" {
+				found = true
+			}
+		}
+	}
+	if !found {
+		t.Errorf("expected web container to report cniConfigPath drift, got %+v", diff.Containers)
+	}
+}
+
 // TestDiffCell_NonRootContainerImage_InPlaceUpdate pins issue #485: a
 // non-root container `image` change must NOT classify as breaking — the
 // runner's UpdateCell path stops, removes, recreates, and starts the

--- a/internal/controller/apply/reconcile.go
+++ b/internal/controller/apply/reconcile.go
@@ -252,8 +252,92 @@ func ReconcileStack(r runner.Runner, desired intmodel.Stack) (ReconcileResult, e
 	return result, nil
 }
 
-// ReconcileCell reconciles a desired cell state with the actual state.
+// failedCellReconcileError converts a Failed end-state into a terminal error
+// so apply never reports a success action over a dead cell (#1185). A
+// compatible change (cniConfigPath, labels, …) routes through UpdateCell,
+// which persists the desired spec without restarting a killed/dead cell; and
+// the spec-in-sync "unchanged" branch walks away from an already-Failed cell.
+// Both would otherwise return a nil error and exit 0 while the workload stays
+// dead. Returning the wrapped sentinel makes ApplyDocuments stamp the resource
+// `failed` and `kuke apply` exit non-zero with an actionable message.
+// StartCell/RecreateCell failures already surface their own error (passed
+// through here unchanged); this is the net for the success-action-but-Failed
+// gap. Pulled out of ReconcileCell so the guard's branches don't inflate that
+// function's cyclomatic complexity.
+func failedCellReconcileError(result ReconcileResult, cellName string, err error) error {
+	if err != nil {
+		return err
+	}
+	cell, ok := result.Resource.(intmodel.Cell)
+	if !ok || cell.Status.State != intmodel.CellStateFailed {
+		return err
+	}
+	return fmt.Errorf(
+		"%w: cell %q — inspect with `kuke get cell %s -o yaml` and `kuke log`",
+		errdefs.ErrCellReconcileFailed, cellName, cellName,
+	)
+}
+
+// ensureCellParents idempotently materializes the realm, space, and stack a
+// cell hangs off of, creating each that is absent and surfacing every other
+// get/create failure as a wrapped error. Pulled out of ReconcileCell so the
+// three near-identical get-or-create blocks don't inflate that function's
+// length and cyclomatic complexity.
+func ensureCellParents(r runner.Runner, desired intmodel.Cell) error {
+	realm := intmodel.Realm{
+		Metadata: intmodel.RealmMetadata{Name: desired.Spec.RealmName},
+	}
+	if _, err := r.GetRealm(realm); err != nil {
+		if !errors.Is(err, errdefs.ErrRealmNotFound) {
+			return fmt.Errorf("failed to get parent realm %q: %w", desired.Spec.RealmName, err)
+		}
+		if _, createErr := r.CreateRealm(realm); createErr != nil {
+			return fmt.Errorf("failed to create parent realm %q: %w", desired.Spec.RealmName, createErr)
+		}
+	}
+
+	space := intmodel.Space{
+		Metadata: intmodel.SpaceMetadata{Name: desired.Spec.SpaceName},
+		Spec:     intmodel.SpaceSpec{RealmName: desired.Spec.RealmName},
+	}
+	if _, err := r.GetSpace(space); err != nil {
+		if !errors.Is(err, errdefs.ErrSpaceNotFound) {
+			return fmt.Errorf("failed to get parent space %q: %w", desired.Spec.SpaceName, err)
+		}
+		if _, createErr := r.CreateSpace(space); createErr != nil {
+			return fmt.Errorf("failed to create parent space %q: %w", desired.Spec.SpaceName, createErr)
+		}
+	}
+
+	stack := intmodel.Stack{
+		Metadata: intmodel.StackMetadata{Name: desired.Spec.StackName},
+		Spec: intmodel.StackSpec{
+			RealmName: desired.Spec.RealmName,
+			SpaceName: desired.Spec.SpaceName,
+		},
+	}
+	if _, err := r.GetStack(stack); err != nil {
+		if !errors.Is(err, errdefs.ErrStackNotFound) {
+			return fmt.Errorf("failed to get parent stack %q: %w", desired.Spec.StackName, err)
+		}
+		if _, createErr := r.CreateStack(stack); createErr != nil {
+			return fmt.Errorf("failed to create parent stack %q: %w", desired.Spec.StackName, createErr)
+		}
+	}
+
+	return nil
+}
+
+// ReconcileCell reconciles a desired cell state with the actual state. AC2
+// (#1185): apply must never report a success action (created/updated/unchanged)
+// for a cell whose reconcile left it Failed, so the inner result is run through
+// failedCellReconcileError before returning — see its doc for the rationale.
 func ReconcileCell(r runner.Runner, desired intmodel.Cell) (ReconcileResult, error) {
+	result, err := reconcileCell(r, desired)
+	return result, failedCellReconcileError(result, desired.Metadata.Name, err)
+}
+
+func reconcileCell(r runner.Runner, desired intmodel.Cell) (ReconcileResult, error) {
 	result := ReconcileResult{
 		Action: "unchanged",
 		Kind:   "Cell",
@@ -261,82 +345,18 @@ func ReconcileCell(r runner.Runner, desired intmodel.Cell) (ReconcileResult, err
 	}
 
 	// Ensure parent resources exist
-	realm := intmodel.Realm{
-		Metadata: intmodel.RealmMetadata{
-			Name: desired.Spec.RealmName,
-		},
-	}
-	_, err := r.GetRealm(realm)
-	if err != nil {
-		if errors.Is(err, errdefs.ErrRealmNotFound) {
-			_, createErr := r.CreateRealm(realm)
-			if createErr != nil {
-				return result, fmt.Errorf("failed to create parent realm %q: %w", desired.Spec.RealmName, createErr)
-			}
-		} else {
-			return result, fmt.Errorf("failed to get parent realm %q: %w", desired.Spec.RealmName, err)
-		}
-	}
-
-	space := intmodel.Space{
-		Metadata: intmodel.SpaceMetadata{
-			Name: desired.Spec.SpaceName,
-		},
-		Spec: intmodel.SpaceSpec{
-			RealmName: desired.Spec.RealmName,
-		},
-	}
-	_, err = r.GetSpace(space)
-	if err != nil {
-		if errors.Is(err, errdefs.ErrSpaceNotFound) {
-			_, createErr := r.CreateSpace(space)
-			if createErr != nil {
-				return result, fmt.Errorf("failed to create parent space %q: %w", desired.Spec.SpaceName, createErr)
-			}
-		} else {
-			return result, fmt.Errorf("failed to get parent space %q: %w", desired.Spec.SpaceName, err)
-		}
-	}
-
-	stack := intmodel.Stack{
-		Metadata: intmodel.StackMetadata{
-			Name: desired.Spec.StackName,
-		},
-		Spec: intmodel.StackSpec{
-			RealmName: desired.Spec.RealmName,
-			SpaceName: desired.Spec.SpaceName,
-		},
-	}
-	_, err = r.GetStack(stack)
-	if err != nil {
-		if errors.Is(err, errdefs.ErrStackNotFound) {
-			_, createErr := r.CreateStack(stack)
-			if createErr != nil {
-				return result, fmt.Errorf("failed to create parent stack %q: %w", desired.Spec.StackName, createErr)
-			}
-		} else {
-			return result, fmt.Errorf("failed to get parent stack %q: %w", desired.Spec.StackName, err)
-		}
+	if err := ensureCellParents(r, desired); err != nil {
+		return result, err
 	}
 
 	// Get actual state
 	actual, err := r.GetCell(desired)
 	if err != nil {
 		if errors.Is(err, errdefs.ErrCellNotFound) {
-			// Cell doesn't exist, create it
-			created, createErr := r.CreateCell(desired)
+			// Cell doesn't exist, create and start it.
+			started, createErr := createAndStartCell(r, desired)
 			if createErr != nil {
-				return result, fmt.Errorf("failed to create cell: %w", createErr)
-			}
-			// Start the newly created cell (containers are created but not started)
-			// This matches the behavior of controller.CreateCell which also starts cells
-			started, startErr := r.StartCell(created)
-			if startErr != nil {
-				return result, fmt.Errorf("failed to start cell after creation: %w", startErr)
-			}
-			// Update cell metadata (status already set by runner)
-			if updateErr := r.UpdateCellMetadata(started); updateErr != nil {
-				return result, fmt.Errorf("failed to update cell metadata after start: %w", updateErr)
+				return result, createErr
 			}
 			result.Action = actionCreated
 			result.Resource = started
@@ -409,37 +429,61 @@ func ReconcileCell(r runner.Runner, desired intmodel.Cell) (ReconcileResult, err
 
 	result.Action = "updated"
 	result.Resource = updated
-	result.Changes = diff.ChangedFields
+	result.Changes = appendContainerChangeSummaries(diff.ChangedFields, diff)
 	result.Details = diff.Details
 
-	// Add container change details. The update branch surfaces the changed
-	// fields so `kuke apply -f` of an image bump reports
-	// `container "web" updated: image` instead of an opaque
-	// `container "web" updated` — the issue-#485 per-component summary the
-	// docs/cli-use-cases.md "apply updates a divergent existing cell" claim
-	// promises.
+	return result, nil
+}
+
+// createAndStartCell materializes a not-yet-existing cell: CreateCell stages
+// its containers, StartCell brings them up (matching controller.CreateCell,
+// which also starts cells), and UpdateCellMetadata persists the runner-set
+// status. Pulled out of ReconcileCell to keep that function under the funlen
+// budget.
+func createAndStartCell(r runner.Runner, desired intmodel.Cell) (intmodel.Cell, error) {
+	created, createErr := r.CreateCell(desired)
+	if createErr != nil {
+		return intmodel.Cell{}, fmt.Errorf("failed to create cell: %w", createErr)
+	}
+	started, startErr := r.StartCell(created)
+	if startErr != nil {
+		return intmodel.Cell{}, fmt.Errorf("failed to start cell after creation: %w", startErr)
+	}
+	if updateErr := r.UpdateCellMetadata(started); updateErr != nil {
+		return intmodel.Cell{}, fmt.Errorf("failed to update cell metadata after start: %w", updateErr)
+	}
+	return started, nil
+}
+
+// appendContainerChangeSummaries renders the per-component update summary onto
+// the running change list. The update branch surfaces the changed fields so
+// `kuke apply -f` of an image bump reports `container "web" updated: image`
+// instead of an opaque `container "web" updated` — the issue-#485 per-component
+// summary the docs/cli-use-cases.md "apply updates a divergent existing cell"
+// claim promises. Pulled out of ReconcileCell to keep that function under the
+// funlen budget.
+func appendContainerChangeSummaries(changes []string, diff CellDiffResult) []string {
 	for _, containerDiff := range diff.Containers {
 		switch containerDiff.Action {
 		case "add":
-			result.Changes = append(result.Changes, fmt.Sprintf("container %q added", containerDiff.Name))
+			changes = append(changes, fmt.Sprintf("container %q added", containerDiff.Name))
 		case "update":
 			fields := append([]string{}, containerDiff.ChangedFields...)
 			fields = append(fields, containerDiff.BreakingChanges...)
 			if len(fields) > 0 {
-				result.Changes = append(
-					result.Changes,
+				changes = append(
+					changes,
 					fmt.Sprintf("container %q updated: %s", containerDiff.Name, strings.Join(fields, ", ")),
 				)
 			} else {
-				result.Changes = append(result.Changes, fmt.Sprintf("container %q updated", containerDiff.Name))
+				changes = append(changes, fmt.Sprintf("container %q updated", containerDiff.Name))
 			}
 		}
 	}
 	for _, orphan := range diff.Orphans {
-		result.Changes = append(result.Changes, fmt.Sprintf("container %q removed", orphan))
+		changes = append(changes, fmt.Sprintf("container %q removed", orphan))
 	}
-
-	return result, nil
+	return changes
 }
 
 // ReconcileContainer reconciles a desired container state with the actual state.

--- a/internal/controller/apply_rematerialize_test.go
+++ b/internal/controller/apply_rematerialize_test.go
@@ -19,10 +19,12 @@
 package controller_test
 
 import (
+	"errors"
 	"strings"
 	"testing"
 
 	applypkg "github.com/eminwux/kukeon/internal/controller/apply"
+	"github.com/eminwux/kukeon/internal/errdefs"
 	intmodel "github.com/eminwux/kukeon/internal/modelhub"
 )
 
@@ -135,6 +137,14 @@ func TestReconcileCell_NoRegressionForReadyCell(t *testing.T) {
 // the user (not apply) should investigate — a silent recreate would mask
 // the original failure cause that markCellFailedAfterStartupFailure went
 // out of its way to record in Status.Reason/Message.
+//
+// Issue #1185 layers AC2 on top of that contract: not re-materializing is
+// still correct, but ReconcileCell must no longer report success for a cell
+// it leaves Failed. The spec-in-sync "unchanged" branch over an already-Failed
+// cell now returns a terminal error wrapping errdefs.ErrCellReconcileFailed so
+// `kuke apply` exits non-zero and says so, instead of the misleading
+// `Cell <name>: unchanged`, exit 0 it printed before. StartCell still must not
+// be invoked — the Failed state is surfaced, not silently recreated.
 func TestReconcileCell_FailedCellDoesNotRematerialize(t *testing.T) {
 	desired := buildTestCell("test-cell", "test-realm", "test-space", "test-stack")
 	actual := desired
@@ -151,11 +161,73 @@ func TestReconcileCell_FailedCellDoesNotRematerialize(t *testing.T) {
 		},
 	}
 
+	_, err := applypkg.ReconcileCell(f, desired)
+	if err == nil {
+		t.Fatal("expected a terminal error for a cell left in Failed state, got nil")
+	}
+	if !errors.Is(err, errdefs.ErrCellReconcileFailed) {
+		t.Errorf("expected error wrapping ErrCellReconcileFailed, got %v", err)
+	}
+}
+
+// TestReconcileCell_CNIConfigPathDriftRematerializes is the issue-#1185
+// regression for the kill→apply path (AC1). The runner stamps every
+// container's cniConfigPath at provision time, so a killed cell's persisted
+// (actual) spec carries it on the workload container while the user's
+// re-applied YAML omits it. Before the diff guard, that phantom field made
+// DiffCell report changes, routing the apply through UpdateCell — which
+// recreates the workload container against the dead root's namespaces and
+// fails the cell — instead of the re-materialize branch. With the guard the
+// diff is empty, the Stopped cell re-materializes via StartCell, and apply
+// reports `updated` with the cell back to Ready.
+func TestReconcileCell_CNIConfigPathDriftRematerializes(t *testing.T) {
+	desired := buildTestCell("test-cell", "test-realm", "test-space", "test-stack")
+	desired.Spec.Containers = []intmodel.ContainerSpec{
+		{ID: "root", Root: true, Image: "alpine:latest"},
+		{ID: "web", Image: "nginx:latest"},
+	}
+
+	// actual mirrors a killed cell: Stopped, with the runner-injected
+	// cniConfigPath on every container that the user YAML never authored.
+	actual := desired
+	actual.Status.State = intmodel.CellStateStopped
+	actual.Spec.Containers = []intmodel.ContainerSpec{
+		{ID: "root", Root: true, Image: "alpine:latest", CNIConfigPath: "/opt/kukeon/data/x/network.conflist"},
+		{ID: "web", Image: "nginx:latest", CNIConfigPath: "/opt/kukeon/data/x/network.conflist"},
+	}
+
+	var startCellCalled bool
+	f := &fakeRunner{
+		GetRealmFn: func(realm intmodel.Realm) (intmodel.Realm, error) { return realm, nil },
+		GetSpaceFn: func(space intmodel.Space) (intmodel.Space, error) { return space, nil },
+		GetStackFn: func(stack intmodel.Stack) (intmodel.Stack, error) { return stack, nil },
+		GetCellFn:  func(_ intmodel.Cell) (intmodel.Cell, error) { return actual, nil },
+		StartCellFn: func(cell intmodel.Cell) (intmodel.Cell, error) {
+			startCellCalled = true
+			cell.Status.State = intmodel.CellStateReady
+			return cell, nil
+		},
+		UpdateCellFn: func(_ intmodel.Cell) (intmodel.Cell, error) {
+			t.Fatal("UpdateCell must not be called: runner-injected cniConfigPath is not a real change")
+			return intmodel.Cell{}, nil
+		},
+	}
+
 	result, err := applypkg.ReconcileCell(f, desired)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if result.Action != "unchanged" {
-		t.Errorf("expected action %q for Failed cell, got %q", "unchanged", result.Action)
+	if !startCellCalled {
+		t.Error("expected StartCell to re-materialize the Stopped cell")
+	}
+	if result.Action != "updated" {
+		t.Errorf("expected action %q, got %q", "updated", result.Action)
+	}
+	resCell, ok := result.Resource.(intmodel.Cell)
+	if !ok {
+		t.Fatalf("expected result.Resource to be a Cell, got %T", result.Resource)
+	}
+	if resCell.Status.State != intmodel.CellStateReady {
+		t.Errorf("expected cell Ready after re-materialize, got %v", resCell.Status.State)
 	}
 }

--- a/internal/errdefs/errdefs.go
+++ b/internal/errdefs/errdefs.go
@@ -158,6 +158,17 @@ var (
 	// of the misleading Ready→Stopped→reaped cycle. Issue #851.
 	ErrCellWindDownImmediate = errors.New("cell wound down immediately after start")
 
+	// ErrCellReconcileFailed is the apply-layer sentinel raised when a cell's
+	// reconcile completed without a runner-level error yet left the cell in
+	// CellStateFailed. A compatible-change apply that routes through UpdateCell
+	// (or the spec-in-sync "unchanged" branch over an already-Failed cell)
+	// persists the desired spec without bringing the workload up, so it would
+	// otherwise return success and exit 0 while the cell stays dead. Converting
+	// that end-state into this sentinel makes ApplyDocuments stamp the resource
+	// `failed` and `kuke apply` exit non-zero — apply must never report
+	// `updated`/`unchanged` over a Failed cell. Issue #1185.
+	ErrCellReconcileFailed = errors.New("cell reconciled to Failed state")
+
 	// ErrCellSpecHashDrift is the StartCell sentinel raised when the
 	// existing containerd container record carries a `kukeon.io/spec-hash`
 	// label whose value disagrees with the SHA-256 over the on-disk


### PR DESCRIPTION
## Summary

Fixes the `kuke kill <cell>` → `kuke apply -f <same spec>` flow on two fronts (issue #1185):

- **AC1 — kill→apply now heals to Ready in one invocation.** Root cause (diverges from the issue's stated hypothesis — see below): the runner stamps every container's `cniConfigPath` at provision time (#1136), so a killed cell's persisted (actual) spec carries it while the user's re-applied YAML omits it. The **container-level** diff in `internal/controller/apply/diff.go` lacked the `desired != ""` guard the cell-level check already had, so that phantom field read as drift → `DiffCell` reported changes → apply routed through `UpdateCell`, which recreates the workload container joined to the **dead** root's namespaces (`lstat /proc/<dead-pid>/ns/ipc: no such file or directory`) and flips the cell to Failed. The guard now treats an empty desired `CNIConfigPath` as "runner will inject" rather than "user cleared it", the diff is empty, and the existing Stopped→re-materialize branch (`StartCell`, #486) brings the cell back to Ready.

- **AC2 — apply that leaves a cell Failed now exits non-zero and says so.** `ReconcileCell` previously returned a success action (`unchanged`/`updated`) with a nil error even when the cell ended Failed, so a follow-up apply printed `Cell "<name>": updated`, exit 0, while the cell stayed dead. A new `errdefs.ErrCellReconcileFailed` sentinel is now returned (via `failedCellReconcileError`) whenever reconcile leaves the resource in `CellStateFailed`, so `kuke apply` exits non-zero with an actionable `inspect with kuke get cell … -o yaml` message.

### Divergence from the issue's stated root cause
The issue hypothesised the re-materialize path "reuses persisted namespace references". Live reproduction showed the Stopped→`StartCell` re-materialize path actually works correctly — the real defect is the **diff misrouting** kill→apply to `UpdateCell` instead of re-materialize, caused by the runner-injected `cniConfigPath`. Intent (heal kill→apply) is unchanged; the fix lands one layer up from where the issue pointed.

### Design choice for AC2 (Failed → surface, not auto-recover)
`cellNeedsRematerialize` deliberately excludes `CellStateFailed` (a sticky startup-failure signal the user should inspect — see the existing contract + #486). Rather than weaken that to auto-recreate a Failed cell (which would mask the original failure cause recorded in `Status.Reason`/`Message`), AC2 is satisfied by making apply *surface* the Failed state as a non-zero exit. The kill→apply happy path (AC1) never reaches Failed because the diff fix routes it to re-materialize first.

## Refactor note
`ReconcileCell` exceeded `funlen`/`gocyclo` after adding the guard (it was already near the cap pre-change). Extracted three pure helpers — `ensureCellParents`, `createAndStartCell`, `appendContainerChangeSummaries` — and split the AC2 guard into a thin exported wrapper over an inner `reconcileCell` (avoids a `nonamedreturns` violation). No behavior change in the extracts.

## Test plan
- [x] `make test-root` (full CI target) — pass (`CITEST-EXIT=0`)
- [x] `go test ./internal/controller/apply/... ./internal/controller/` — pass
- [x] `pre-commit run --files <5 changed files>` — all hooks pass (golangci-lint incl. funlen/gocyclo/nonamedreturns)
- [x] New regression tests (AC3): `TestDiffCell_RunnerInjectedCNIConfigPath_NoChange`, `TestDiffCell_ExplicitCNIConfigPath_StillDetectsDrift` (diff guard), `TestReconcileCell_CNIConfigPathDriftRematerializes` (kill→apply re-materializes via StartCell, not UpdateCell), and updated `TestReconcileCell_FailedCellDoesNotRematerialize` (Failed → wrapped `ErrCellReconcileFailed`, StartCell still not called)
- [x] Runtime verification (earlier this session): fixed binary run as an isolated host process reproduced kill→apply healing to Ready. The `make dev-init` daemon smoke could not be re-run at PR time — the host's containerd bridge/networking was left broken by an earlier smoke attempt (no Docker Hub egress), and re-running `make dev-init`/`kuke daemon reset` would have further disrupted unrelated state on the shared host

Closes #1185
