### PR TITLE
fix(runner): skip CNI detach for host-network root cells and guard self-netns DEL

### DIFF
--- a/internal/controller/runner/detach_network_test.go
+++ b/internal/controller/runner/detach_network_test.go
@@ -32,6 +32,7 @@ import (
 	"github.com/containerd/containerd/v2/pkg/cio"
 	"github.com/eminwux/kukeon/internal/cni"
 	"github.com/eminwux/kukeon/internal/errdefs"
+	intmodel "github.com/eminwux/kukeon/internal/modelhub"
 )
 
 // deadTaskContainer is a near-empty containerd.Container whose Task() reports
@@ -160,5 +161,157 @@ func TestDetachRootContainerFromNetwork_DeadTaskReleasesReservation(t *testing.T
 			"reservation %s not released on the dead-task path (stat err=%v); CNI DEL was not issued with an empty netns",
 			reservation, err,
 		)
+	}
+}
+
+// liveTaskContainer is a containerd.Container whose Task() reports a live root
+// task pinned to a chosen PID, driving rootContainerNetnsPath to resolve a
+// /proc/<pid>/ns/net path (the live-task path issue #1219 is about). Reuses the
+// recreateCellTask Pid()-only fake from recreate_cell_test.go.
+type liveTaskContainer struct {
+	containerd.Container
+	pid uint32
+}
+
+func (c liveTaskContainer) Task(context.Context, cio.Attach) (containerd.Task, error) {
+	return recreateCellTask{pid: c.pid}, nil
+}
+
+// liveTaskClient returns a live container record whose root task PID is fixed,
+// so rootContainerNetnsPath resolves to /proc/<pid>/ns/net.
+type liveTaskClient struct {
+	deleteCellFakeClient
+	pid uint32
+}
+
+func (c *liveTaskClient) GetContainer(string, string) (containerd.Container, error) {
+	return liveTaskContainer{pid: c.pid}, nil
+}
+
+// writeNetnsRecordingCNIPlugin drops an executable CNI plugin that records the
+// CNI_NETNS it was invoked with on DEL into markerPath (empty content when the
+// DEL carries no netns), so a test can assert exactly which netns a plugin-chain
+// DEL targeted.
+func writeNetnsRecordingCNIPlugin(t *testing.T, binDir, pluginType, markerPath string) {
+	t.Helper()
+	script := fmt.Sprintf(`#!/bin/sh
+case "$CNI_COMMAND" in
+  DEL) printf '%%s' "$CNI_NETNS" > "%s"; exit 0 ;;
+  VERSION) echo '{"cniVersion":"1.0.0","supportedVersions":["0.1.0","0.2.0","0.3.0","0.3.1","0.4.0","1.0.0"]}'; exit 0 ;;
+  *) echo '{"cniVersion":"0.4.0"}'; exit 0 ;;
+esac
+`, markerPath)
+	path := filepath.Join(binDir, pluginType)
+	if err := os.WriteFile(path, []byte(script), 0o755); err != nil { //nolint:gosec // test-only executable fake plugin
+		t.Fatalf("write fake CNI plugin: %v", err)
+	}
+}
+
+// TestDetachRootContainerFromNetwork_DropsRunnerOwnNetns is the issue #1219
+// guard: when a cell's root task shares the daemon's own netns (the HostNetwork
+// kukeond case — here modeled by pinning the root task PID to this test process,
+// so rootContainerNetnsPath resolves to /proc/<self>/ns/net == /proc/self/ns/net),
+// detach must NOT run the plugin-chain DEL against that netns. The sanitize
+// chokepoint drops it to an empty netns, so the recorded CNI_NETNS must be empty
+// — proving the bridge plugin's `ip link del eth0` and the loopback plugin's
+// `lo` DOWN never fire in the runner's netns.
+func TestDetachRootContainerFromNetwork_DropsRunnerOwnNetns(t *testing.T) {
+	tmp := t.TempDir()
+	binDir := filepath.Join(tmp, "bin")
+	confDir := filepath.Join(tmp, "conf")
+	cacheDir := filepath.Join(tmp, "cache")
+	for _, d := range []string{binDir, confDir, cacheDir} {
+		if err := os.MkdirAll(d, 0o755); err != nil {
+			t.Fatalf("mkdir %s: %v", d, err)
+		}
+	}
+
+	const pluginType = "kukeon-netns-rec"
+	marker := filepath.Join(tmp, "del-netns")
+	writeNetnsRecordingCNIPlugin(t, binDir, pluginType, marker)
+
+	confPath := filepath.Join(confDir, "kukeon-test.conflist")
+	conflist := fmt.Sprintf(`{"cniVersion":"0.4.0","name":"kukeon-test","plugins":[{"type":"%s"}]}`, pluginType)
+	if err := os.WriteFile(confPath, []byte(conflist), 0o600); err != nil {
+		t.Fatalf("write conflist: %v", err)
+	}
+
+	// Root task PID == this process: rootContainerNetnsPath resolves to
+	// /proc/<self>/ns/net, which is the runner's own netns by inode.
+	r := &Exec{
+		ctx:       context.Background(),
+		logger:    slog.New(slog.NewTextHandler(io.Discard, nil)),
+		ctrClient: &liveTaskClient{pid: uint32(os.Getpid())}, //nolint:gosec // PID fits uint32
+		cniConf:   &cni.Conf{CniBinDir: binDir, CniConfigDir: confDir, CniCacheDir: cacheDir},
+	}
+
+	r.detachRootContainerFromNetwork(
+		"kukeon_kukeon_kukeond_root", confPath, "kuke-system.kukeon.io",
+		"kukeond", "kukeond", "kukeon", "kuke-system",
+	)
+
+	got, err := os.ReadFile(marker)
+	if err != nil {
+		t.Fatalf("CNI DEL was not invoked (marker absent): %v", err)
+	}
+	if string(got) != "" {
+		t.Fatalf(
+			"CNI DEL ran against netns %q; want empty — the runner's own netns must be dropped (issue #1219)",
+			string(got),
+		)
+	}
+}
+
+// TestDelNetnsIsRunnerOwn pins the inode-identity check the sanitize chokepoint
+// relies on: the runner's own netns (by /proc/self and by /proc/<self-pid>)
+// matches; an empty path, a missing path, and an unrelated regular file do not.
+func TestDelNetnsIsRunnerOwn(t *testing.T) {
+	if !delNetnsIsRunnerOwn("/proc/self/ns/net") {
+		t.Error("delNetnsIsRunnerOwn(/proc/self/ns/net) = false, want true")
+	}
+	if !delNetnsIsRunnerOwn(fmt.Sprintf("/proc/%d/ns/net", os.Getpid())) {
+		t.Error("delNetnsIsRunnerOwn(/proc/<self-pid>/ns/net) = false, want true")
+	}
+	if delNetnsIsRunnerOwn("") {
+		t.Error(`delNetnsIsRunnerOwn("") = true, want false`)
+	}
+	if delNetnsIsRunnerOwn(filepath.Join(t.TempDir(), "missing")) {
+		t.Error("delNetnsIsRunnerOwn(nonexistent) = true, want false")
+	}
+	other := filepath.Join(t.TempDir(), "regular")
+	if err := os.WriteFile(other, nil, 0o600); err != nil {
+		t.Fatalf("write regular file: %v", err)
+	}
+	if delNetnsIsRunnerOwn(other) {
+		t.Error("delNetnsIsRunnerOwn(regular file) = true, want false")
+	}
+}
+
+// TestRootContainerHostNetwork pins the call-site predicate that mirrors the
+// ADD-side rootContainerWantsCNI guard: stop/kill skip CNI detach when the
+// cell's root container is host-network (issue #1219).
+func TestRootContainerHostNetwork(t *testing.T) {
+	hostNet := intmodel.Cell{Spec: intmodel.CellSpec{
+		RootContainerID: "root",
+		Containers: []intmodel.ContainerSpec{
+			{ID: "root", Root: true, HostNetwork: true},
+			{ID: "web"},
+		},
+	}}
+	if !rootContainerHostNetwork(hostNet) {
+		t.Error("rootContainerHostNetwork = false for a host-network root, want true")
+	}
+
+	bridged := intmodel.Cell{Spec: intmodel.CellSpec{
+		RootContainerID: "root",
+		Containers:      []intmodel.ContainerSpec{{ID: "root", Root: true, HostNetwork: false}},
+	}}
+	if rootContainerHostNetwork(bridged) {
+		t.Error("rootContainerHostNetwork = true for a bridged root, want false")
+	}
+
+	noRoot := intmodel.Cell{Spec: intmodel.CellSpec{RootContainerID: "root"}}
+	if rootContainerHostNetwork(noRoot) {
+		t.Error("rootContainerHostNetwork = true when the root spec is absent, want false")
 	}
 }

--- a/internal/controller/runner/helpers.go
+++ b/internal/controller/runner/helpers.go
@@ -24,6 +24,7 @@ import (
 	"path/filepath"
 	"regexp"
 	"strings"
+	"syscall"
 	"time"
 
 	"github.com/containerd/containerd/v2/pkg/namespaces"
@@ -41,6 +42,11 @@ import (
 // It always attempts cleanup even if the container is already deleted or network namespace is invalid.
 func (r *Exec) purgeCNIForContainer(containerID, netnsPath, networkName string) error {
 	var purged []string
+
+	// Never run the plugin-chain DEL against the daemon's own netns (issue
+	// #1219); the IPAM-file purge below is unaffected and still releases the
+	// lease.
+	netnsPath = r.sanitizeDELNetns(netnsPath)
 
 	// Always try to call CNI DEL if network name is available
 	// Some CNI plugins may handle empty/invalid netns gracefully
@@ -489,7 +495,7 @@ func (r *Exec) buildRootCNINetworkName(realmName, spaceName string) string {
 func (r *Exec) detachRootContainerFromNetwork(
 	rootContainerID, cniConfigPath, namespace, cellID, cellName, spaceID, realmID string,
 ) {
-	netnsPath := r.rootContainerNetnsPath(namespace, rootContainerID)
+	netnsPath := r.sanitizeDELNetns(r.rootContainerNetnsPath(namespace, rootContainerID))
 
 	cniMgr, mgrErr := cni.NewManager(
 		r.cniConf.CniBinDir,
@@ -536,6 +542,67 @@ func (r *Exec) rootContainerNetnsPath(namespace, rootContainerID string) string 
 		return fmt.Sprintf("/proc/%d/ns/net", rootPID)
 	}
 	return ""
+}
+
+// sanitizeDELNetns drops a CNI DEL target netns that resolves to the daemon's
+// own network namespace, returning "" so libcni issues its netns-optional DEL
+// (which still releases the host-local IPAM lease and any chained-plugin
+// resources from the cached ADD result) instead of running the plugin chain
+// against the runner's own netns.
+//
+// A HostNetwork root container (kukeond, and any future host-scope cell) shares
+// the daemon host's netns, so its live-task netns path resolves to the runner's
+// own. Running the conflist's DEL there makes the bridge plugin delete the
+// interface hard-coded as IfName ("eth0") in that netns and the loopback plugin
+// set "lo" DOWN — on a bare host that is latent, but in nested mode (the agent's
+// `make dev-init` inside a kukeon-dev-root cell) the "host netns" is the parent
+// cell's, whose uplink veth is literally named eth0, so `kuke daemon reset`
+// severs the parent cell's network (issue #1219). This is defense in depth
+// behind the call-site HostNetwork skip: it also guards every other teardown
+// path (purge/delete/recreate) and any future caller that resolves a self netns.
+func (r *Exec) sanitizeDELNetns(netnsPath string) string {
+	if delNetnsIsRunnerOwn(netnsPath) {
+		r.logger.WarnContext(
+			r.ctx,
+			"refusing CNI DEL against the daemon's own netns; issuing a netns-less DEL instead",
+			"netns", netnsPath,
+		)
+		return ""
+	}
+	return netnsPath
+}
+
+// delNetnsIsRunnerOwn reports whether netnsPath refers to the same network
+// namespace as the daemon's own (/proc/self/ns/net), compared by (device,
+// inode) — the canonical way to test two /proc/<pid>/ns/net handles for
+// namespace identity. Returns false on an empty path or any stat error: an
+// unstattable path cannot be confirmed equal to self, and preserving the
+// resolved netns keeps the pre-existing DEL behavior for every non-self path.
+func delNetnsIsRunnerOwn(netnsPath string) bool {
+	if netnsPath == "" {
+		return false
+	}
+	var target, self syscall.Stat_t
+	if err := syscall.Stat(netnsPath, &target); err != nil {
+		return false
+	}
+	if err := syscall.Stat("/proc/self/ns/net", &self); err != nil {
+		return false
+	}
+	return target.Dev == self.Dev && target.Ino == self.Ino
+}
+
+// rootContainerHostNetwork reports whether the cell's root container runs on the
+// host netns. It mirrors the ADD-side rootContainerWantsCNI guard for the DEL
+// side: the stop/kill teardown paths skip CNI detach for a host-network root so
+// the DEL never targets the daemon's own netns (issue #1219).
+func rootContainerHostNetwork(cell intmodel.Cell) bool {
+	for i := range cell.Spec.Containers {
+		if cell.Spec.Containers[i].ID == cell.Spec.RootContainerID {
+			return cell.Spec.Containers[i].HostNetwork
+		}
+	}
+	return false
 }
 
 func appendCellLogFields(fields []any, cellID, cellName string) []any {

--- a/internal/controller/runner/kill.go
+++ b/internal/controller/runner/kill.go
@@ -174,16 +174,26 @@ func (r *Exec) killCellLocked(cell intmodel.Cell) (intmodel.Cell, error) {
 	// corrupt (issue #685). The name is a pure function of (realm, space).
 	networkName := r.buildRootCNINetworkName(realmID, spaceID)
 
-	// Detach root container from CNI network before killing (needed for CNI detach)
-	r.detachRootContainerFromNetwork(
-		rootContainerID,
-		cniConfigPath,
-		internalRealm.Spec.Namespace,
-		cellID,
-		cellName,
-		spaceID,
-		realmID,
-	)
+	// Detach root container from CNI network before killing (needed for CNI
+	// detach). Skip it for a host-network root: that cell shares the daemon's
+	// own netns (no per-veth, no IPAM lease — CNI ADD was skipped by
+	// rootContainerWantsCNI), so issuing the conflist DEL there would delete
+	// eth0 / down lo in the runner's netns (issue #1219).
+	if rootContainerHostNetwork(internalCell) {
+		fields := appendCellLogFields([]any{"id", rootContainerID}, cellID, cellName)
+		fields = append(fields, "space", spaceID, "realm", realmID)
+		r.logger.InfoContext(r.ctx, "skipping CNI detach for host-network root cell", fields...)
+	} else {
+		r.detachRootContainerFromNetwork(
+			rootContainerID,
+			cniConfigPath,
+			internalRealm.Spec.Namespace,
+			cellID,
+			cellName,
+			spaceID,
+			realmID,
+		)
+	}
 
 	// Kill root container
 	err = r.killContainerTask(internalRealm.Spec.Namespace, rootContainerID)

--- a/internal/controller/runner/lifecycle.go
+++ b/internal/controller/runner/lifecycle.go
@@ -47,7 +47,10 @@ func (r *Exec) detachRootContainerFromCNI(
 			// Task exists, get PID and detach from CNI
 			rootPID := rootTask.Pid()
 			if rootPID > 0 {
-				netnsPath := fmt.Sprintf("/proc/%d/ns/net", rootPID)
+				// Drop the netns when it resolves to the daemon's own (a
+				// host-network root shares it); a plugin-chain DEL there would
+				// delete eth0 / down lo in the runner's netns (issue #1219).
+				netnsPath := r.sanitizeDELNetns(fmt.Sprintf("/proc/%d/ns/net", rootPID))
 
 				// Create CNI manager and detach from network
 				cniMgr, mgrErr := cni.NewManager(

--- a/internal/controller/runner/stop.go
+++ b/internal/controller/runner/stop.go
@@ -196,16 +196,26 @@ func (r *Exec) stopCellLocked(cell intmodel.Cell) (intmodel.Cell, error) {
 	// corrupt (issue #685). The name is a pure function of (realm, space).
 	networkName := r.buildRootCNINetworkName(realmName, spaceName)
 
-	// Detach root container from CNI network before stopping (needed for CNI detach)
-	r.detachRootContainerFromNetwork(
-		rootContainerID,
-		cniConfigPath,
-		namespace,
-		cellID,
-		cellName,
-		spaceName,
-		realmName,
-	)
+	// Detach root container from CNI network before stopping (needed for CNI
+	// detach). Skip it for a host-network root: that cell shares the daemon's
+	// own netns (no per-veth, no IPAM lease — CNI ADD was skipped by
+	// rootContainerWantsCNI), so issuing the conflist DEL there would delete
+	// eth0 / down lo in the runner's netns (issue #1219).
+	if rootContainerHostNetwork(internalCell) {
+		fields := appendCellLogFields([]any{"id", rootContainerID}, cellID, cellName)
+		fields = append(fields, "space", spaceName, "realm", realmName)
+		r.logger.InfoContext(r.ctx, "skipping CNI detach for host-network root cell", fields...)
+	} else {
+		r.detachRootContainerFromNetwork(
+			rootContainerID,
+			cniConfigPath,
+			namespace,
+			cellID,
+			cellName,
+			spaceName,
+			realmName,
+		)
+	}
 
 	// Stop root container
 	timeout := 5 * time.Second

--- a/scripts/dev-init.sh
+++ b/scripts/dev-init.sh
@@ -191,6 +191,60 @@ verify_parent_attach_intact() {
     return 0
 }
 
+# detect_uplink_state reports the dev cell's uplink as "<eth0> <default>", each
+# 0|1, using `ip` when present and falling back to sysfs + /proc/net/route. The
+# fallback matters because the #1219 incident saw `ip` missing inside the cell
+# *after* the break, which masked diagnosis — the guard must not itself depend
+# on a tool the break can leave absent.
+detect_uplink_state() {
+    local have_eth0=0 have_default=0
+    if command -v ip >/dev/null 2>&1; then
+        if ip -4 addr show eth0 >/dev/null 2>&1; then have_eth0=1; fi
+        if [ -n "$(ip -4 route show default 2>/dev/null)" ]; then have_default=1; fi
+    else
+        if [ -e /sys/class/net/eth0 ]; then have_eth0=1; fi
+        # /proc/net/route: the default route is the row whose Destination
+        # (column 2) is 00000000.
+        if awk 'NR>1 && $2=="00000000"{f=1} END{exit !f}' /proc/net/route 2>/dev/null; then have_default=1; fi
+    fi
+    printf '%s %s' "${have_eth0}" "${have_default}"
+}
+
+# verify_parent_uplink_intact is the nested-mode regression guard for issue
+# #1219. Before #1219's fix, `kuke daemon reset` on a prior HostNetwork kukeond
+# cell issued a CNI DEL against the daemon's own netns — which nested is *this*
+# dev cell's netns, whose uplink veth is named eth0 — deleting eth0 and downing
+# lo and severing the cell's network. The break otherwise surfaces two phases
+# later as a confusing `kukebuild: ... network is unreachable`; this asserts the
+# uplink survived the reset and fails fast with the real cause. It mirrors the
+# existing `verify_parent_attach_intact` post-flight and only fires nested (bare
+# hosts rarely name their primary NIC eth0). Only the present->absent transition
+# is a regression — an uplink already absent pre-reset is a pre-existing
+# condition.
+verify_parent_uplink_intact() {
+    [ -e "${NESTED_PROBE}" ] || return 0
+    local pre_eth0 pre_def post_eth0 post_def
+    read -r pre_eth0 pre_def <<<"$1"
+    read -r post_eth0 post_def <<<"$(detect_uplink_state)"
+    local broke=0
+    if [ "${pre_eth0}" = "1" ] && [ "${post_eth0}" != "1" ]; then broke=1; fi
+    if [ "${pre_def}" = "1" ] && [ "${post_def}" != "1" ]; then broke=1; fi
+    if [ "${broke}" -eq 1 ]; then
+        cat >&2 <<EOF
+
+POST-RESET: 'kuke daemon reset' severed this dev cell's uplink
+            (eth0 ${pre_eth0}->${post_eth0}, default route ${pre_def}->${post_def}).
+            This is the issue #1219 signature: a HostNetwork-cell CNI DEL ran
+            against this cell's own netns, deleting eth0 and/or downing lo. The
+            break would otherwise surface two phases later as a confusing
+            'kukebuild: ... network is unreachable'. Re-plumb the uplink (see
+            issue #1219's manual-recovery steps) before re-running.
+EOF
+        exit 1
+    fi
+    echo "post-reset: dev cell uplink (eth0 + default route) survived the reset"
+}
+
 # Register the post-flight check BEFORE any state-mutating step so an
 # early failure (e.g. during `make kuke`, `kuke build`, or the first
 # `kuke init`) still surfaces a disturbance of the parent's attach
@@ -337,9 +391,15 @@ fi
 # is the same anti-pattern but doesn't bite today — its first-pass init
 # is idempotent on a pre-bootstrapped host.
 if sudo test -d "${KUKEOND_CELL_DIR}"; then
+    # Snapshot the dev cell's uplink before the reset so the post-reset guard
+    # below can fail loud if `kuke daemon reset` severed it (issue #1219). Only
+    # the prior-cell branch can hit the bug — the detach only fires destructively
+    # against a previously-inited HostNetwork kukeond cell with a live root task.
+    UPLINK_PRE="$(detect_uplink_state)"
     step "Reset prior kukeond cell"
     sudo --preserve-env="${PRESERVE_ENV_ADMIN}" ./kuke daemon reset \
         "${SERVER_CONFIG_FLAGS[@]}"
+    verify_parent_uplink_intact "${UPLINK_PRE}"
 else
     step "No prior kukeond cell at ${KUKEOND_CELL_DIR}; skipping reset"
 fi


### PR DESCRIPTION
## Summary

`StopCell`/`KillCell` (and the other teardown paths) issued a CNI DEL for **every** cell's root container, including `HostNetwork` cells (the kukeond system cell). For a HostNetwork root the live task's netns **is the daemon host's netns**, so the conflist DEL ran against the host netns: the bridge plugin deletes the interface hard-coded as `eth0`, and the loopback plugin sets `lo` DOWN.

On bare metal this is latent. **Nested** — the canonical agent workflow of `make dev-init` inside a `kukeon-dev-root` cell — the "host netns" is the parent cell's netns and its uplink veth is literally named `eth0`, so the dev-init reset phase (`kuke daemon reset`) deleted the parent cell's uplink and downed `lo`, severing the cell's network while its workload kept running (issue #1219).

The ADD side already had the guard the DEL side was missing (`rootContainerWantsCNI`, `start.go`). This PR adds the symmetric DEL-side protection in two layers, plus a nested-mode regression guard and unit tests.

## What changed

1. **Explicit HostNetwork skip at the named call sites** (`stop.go`, `kill.go`) — new `rootContainerHostNetwork(cell)` predicate mirrors `rootContainerWantsCNI`; a host-network root cell skips `detachRootContainerFromNetwork` entirely (it has no per-veth and no IPAM lease, since ADD was skipped). Logs `skipping CNI detach for host-network root cell`.
2. **Defense-in-depth self-netns guard** (`helpers.go`) — new `sanitizeDELNetns` / `delNetnsIsRunnerOwn`: before any DEL, if the target netns is the same `(dev, inode)` as `/proc/self/ns/net`, drop it to the empty-netns DEL (still netns-optional — releases IPAM + chained-plugin resources). Wired into **all three** netns-bearing DEL chokepoints: `detachRootContainerFromNetwork`, `purgeCNIForContainer`, and `detachRootContainerFromCNI` (`lifecycle.go`). This covers the recreate/purge/delete paths and any future caller that resolves a self netns — without threading a flag through every site.
3. **Nested-mode regression guard in `scripts/dev-init.sh`** — after the `kuke daemon reset` phase, assert the dev cell's uplink (`eth0` + a default route) survived the reset and fail fast with the real cause; today the break surfaces two phases later as a confusing `kukebuild: ... network is unreachable`. Snapshots pre-reset state and only flags the present→absent transition. Falls back to sysfs + `/proc/net/route` when `ip` is absent (the incident saw `ip` missing post-break). Mirrors the existing `verify_parent_attach_intact` post-flight; only fires nested.
4. **Unit tests** (`detach_network_test.go`) — `TestDetachRootContainerFromNetwork_DropsRunnerOwnNetns` pins the root-task PID to the test process so the resolved netns *is* the runner's own, and asserts (via a netns-recording fake CNI plugin) that the DEL carries an empty netns; plus direct tests for `delNetnsIsRunnerOwn` and `rootContainerHostNetwork`.

### Non-obvious calls (for reviewer push-back)

- **Why both layers (issue items 1 + 2):** the explicit skip gives intent symmetry with the ADD guard at the two incident paths; the inode guard is the universal safety net. The inode guard alone would functionally fix the bug everywhere (a HostNetwork root's netns *is* the runner's own → dropped); item 1 is the readable, log-clear guard the issue names first.
- **recreate/purge/delete paths** are covered by the layer-2 chokepoint guard (item 2) rather than an explicit per-site HostNetwork skip — issue item 1 names only `stop.go:200` / `kill.go:178`, so the call-site skip is scoped to those; everything else rides the universal `sanitizeDELNetns`.
- **`syscall.Stat` for inode compare** — std, depguard-allowed; `(Dev, Ino)` is the canonical netns-identity test. Fails open (keeps the netns) on any stat error to preserve pre-existing DEL behavior for every non-self path.

## Test plan

- [x] `GOWORK=off make test` equivalent — `go test $(go list ./... | grep -v /e2e)` (root) **and** `cd cmd/kukebuild && go test ./...` — both pass. (`go.work` workspace mismatch breaks bare `go build`; `GOWORK=off`, which the Makefile exports, is green.)
- [x] `go vet` + `gofmt -l` clean on all changed Go files.
- [x] New unit tests pass: `TestDetachRootContainerFromNetwork_DropsRunnerOwnNetns`, `TestDelNetnsIsRunnerOwn`, `TestRootContainerHostNetwork`, plus the existing `detach_network_test.go` guards.
- [x] `bash -n scripts/dev-init.sh` clean; `detect_uplink_state` / `verify_parent_uplink_intact` exercised standalone (this dev container is itself nested — probe present, `eth0` + default route detected, guard reports uplink intact).
- [ ] Full `make dev-init` nested smoke not run end-to-end here — it rebuilds/reinits the daemon on this live nested host, which would disrupt the running session; the new guard is unit/standalone-verified and the reset-phase assertion is non-destructive by construction.

Closes #1219