### PR TITLE
docs(team): document kuketeam.yaml realm/space/stack scope fields

### DIFF
--- a/docs/site/concepts/team.md
+++ b/docs/site/concepts/team.md
@@ -134,6 +134,15 @@ time. When unset, the clone dir falls back to `metadata.name`. The value is
 validated as a safe path basename that does not collide with the reserved
 `agents` slot directory.
 
+### Scoping the team's cells
+
+`ProjectTeam.spec.realm`, `spec.space`, and `spec.stack` (in the committed
+`kuketeam.yaml`) are the optional scope coordinates the team's rendered cells
+bind to. Each **defaults to `default`** when omitted, and the renderer stamps
+the defaulted value onto every rendered Blueprint/Config so the persisted
+Config scope matches the live cell. Set them to place a project's team cells
+under a non-`default` realm/space/stack.
+
 ## Secrets: two `secrets.env` layers render to `kind: Secret`
 
 Team secret material is composed from two `secrets.env` layers and rendered as
@@ -161,6 +170,9 @@ kind: ProjectTeam
 metadata: { name: sbsh }
 spec:
   source: { repo: github.com/eminwux/agents, tag: v1.4.0 } # pinned (tag)
+  realm: default # optional scope coords; each defaults to `default` when omitted
+  space: default
+  stack: default
   defaults: { harnesses: [claude, opencode] }
   roles:
     - { ref: dev, needs: { image: [go] } }


### PR DESCRIPTION
## Summary
- PR #1134 (the fix for #1133) added optional `realm`/`space`/`stack` scope fields to the public `ProjectTeamSpec` (`pkg/api/model/kuketeams/projectteam.go`), declarable in `kuketeam.yaml`, but `docs/site/concepts/team.md`'s example block and field notes never documented them — an operator reading the docs wouldn't learn the scope fields exist.
- Added the three fields to the `kuketeam.yaml` example block with an inline note that each defaults to `default`.
- Added a `### Scoping the team's cells` field-note subsection (mirroring the existing `projectDir` subsection) explaining the fields are optional scope coordinates the rendered cells bind to, each defaulting to `default`, with the renderer stamping the defaulted value onto every rendered Blueprint/Config.

Verified against `origin/main`: the `Realm`/`Space`/`Stack` fields exist on `ProjectTeamSpec` and each defaults to `default` (per the godoc + teamrender `DefaultRealm`/`DefaultSpace`/`DefaultStack`). The issue cited `docs/site/concepts/team.md:117-128` but the example block has since shifted to ~line 162; documented the fields at the current location.

## Test plan
- [x] Docs-only markdown change; no code, tests, or behavior touched — no build/smoke required.
- [x] Verified the documented field names + `default` defaults match `pkg/api/model/kuketeams/projectteam.go` on `origin/main`.

Closes #1135