### PR TITLE
feat: render focused diff for divergent args/command/env notices

### DIFF
--- a/cmd/kuke/run/focused_diff_test.go
+++ b/cmd/kuke/run/focused_diff_test.go
@@ -1,0 +1,151 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package run
+
+import (
+	"strings"
+	"testing"
+
+	v1beta1 "github.com/eminwux/kukeon/pkg/api/model/v1beta1"
+)
+
+// TestFocusedSliceDiffMultiLineScriptOneTokenChange is the AC's headline case
+// (issue #1193): a one-token change inside a multi-line `sh -c` script must
+// surface the changed token without the operator hand-diffing two walls of
+// escaped shell text.
+func TestFocusedSliceDiffMultiLineScriptOneTokenChange(t *testing.T) {
+	script := func(port string) string {
+		return "set -e\n" +
+			"while true; do\n" +
+			"  echo serving on " + port + "\n" +
+			"  nc -l -p " + port + " -e /bin/cat\n" +
+			"  sleep 1\n" +
+			"done\n"
+	}
+	actual := []string{"-c", script("8080")}
+	desired := []string{"-c", script("8081")}
+
+	got := focusedSliceDiff("args", actual, desired)
+
+	// The changed token on both sides must be visible.
+	if !strings.Contains(got, "8080") || !strings.Contains(got, "8081") {
+		t.Errorf("focused diff omits the changed token:\n%s", got)
+	}
+	// The common leading element ("-c") must be summarized, not dumped.
+	if !strings.Contains(got, "1 leading") {
+		t.Errorf("focused diff does not summarize the identical leading element:\n%s", got)
+	}
+	// Truncation around the diff must have kicked in for the long element.
+	if !strings.Contains(got, "…") {
+		t.Errorf("focused diff did not window the long element:\n%s", got)
+	}
+	// And the result must be dramatically shorter than dumping both scripts
+	// verbatim, which is the wall-of-text the issue is about.
+	fullDump := sliceDiff("args", actual, desired)
+	if len(got) >= len(fullDump) {
+		t.Errorf("focused diff (%d bytes) is not shorter than the full both-sides dump (%d bytes):\n%s",
+			len(got), len(fullDump), got)
+	}
+}
+
+// TestFocusedSliceDiffElidesCommonFraming covers AC item 2: identical
+// leading/trailing elements are elided/summarized and only the differing
+// index is named.
+func TestFocusedSliceDiffElidesCommonFraming(t *testing.T) {
+	actual := []string{"sh", "-c", "x", "--port", "8080"}
+	desired := []string{"sh", "-c", "x", "--port", "8081"}
+
+	got := focusedSliceDiff("args", actual, desired)
+
+	if !strings.Contains(got, "4 leading, 0 trailing identical") {
+		t.Errorf("expected leading/trailing summary, got:\n%s", got)
+	}
+	if !strings.Contains(got, "[4]") {
+		t.Errorf("expected the differing index [4] to be named, got:\n%s", got)
+	}
+	if !strings.Contains(got, `"8080"`) || !strings.Contains(got, `"8081"`) {
+		t.Errorf("expected both sides of the changed element, got:\n%s", got)
+	}
+	// The unchanged framing elements must not be repeated verbatim.
+	if strings.Contains(got, `"sh"`) {
+		t.Errorf("focused diff repeated an elided framing element, got:\n%s", got)
+	}
+}
+
+// TestFocusedSliceDiffAddRemove names the index range and contents when the
+// slices differ in length (an element added or removed).
+func TestFocusedSliceDiffAddRemove(t *testing.T) {
+	actual := []string{"a", "b", "c"}
+	desired := []string{"a", "c"}
+
+	got := focusedSliceDiff("args", actual, desired)
+
+	if !strings.Contains(got, "actual[1:2]") || !strings.Contains(got, "desired[1:1]") {
+		t.Errorf("expected index ranges for the add/remove case, got:\n%s", got)
+	}
+	if !strings.Contains(got, `"b"`) {
+		t.Errorf("expected the removed element in the actual window, got:\n%s", got)
+	}
+}
+
+// TestFocusedScalarDiffShortVerbatim keeps the verbatim both-sides shape for
+// short scalar fields (command) so the common case is unchanged.
+func TestFocusedScalarDiffShortVerbatim(t *testing.T) {
+	got := focusedScalarDiff("command", "/bin/sh", "/bin/bash")
+	if !strings.Contains(got, `"/bin/sh"`) || !strings.Contains(got, `"/bin/bash"`) {
+		t.Errorf("short scalar diff should print both sides verbatim, got:\n%s", got)
+	}
+	if strings.Contains(got, "…") {
+		t.Errorf("short scalar diff should not truncate, got:\n%s", got)
+	}
+}
+
+// TestFocusedScalarDiffLongTruncates windows a long scalar around the first
+// differing rune.
+func TestFocusedScalarDiffLongTruncates(t *testing.T) {
+	prefix := strings.Repeat("a", 80)
+	got := focusedScalarDiff("command", prefix+"X"+prefix, prefix+"Y"+prefix)
+	if !strings.Contains(got, "…") {
+		t.Errorf("long scalar diff should truncate, got:\n%s", got)
+	}
+	if !strings.Contains(got, "X") || !strings.Contains(got, "Y") {
+		t.Errorf("long scalar diff should keep the changed rune visible, got:\n%s", got)
+	}
+}
+
+// TestDivergedContainerFieldsUsesFocusedArgs is the end-to-end assertion that
+// the divergence notice (the surface the operator actually sees) carries the
+// focused diff for args while still naming the field.
+func TestDivergedContainerFieldsUsesFocusedArgs(t *testing.T) {
+	long := strings.Repeat("echo step; ", 30)
+	actual := v1beta1.ContainerSpec{ID: "web", Args: []string{"-c", long + "-p 8080"}}
+	desired := v1beta1.ContainerSpec{ID: "web", Args: []string{"-c", long + "-p 8081"}}
+
+	fields := divergedContainerFields(actual, desired)
+	if len(fields) != 1 {
+		t.Fatalf("expected exactly the args field to diverge, got %v", fields)
+	}
+	if !strings.HasPrefix(fields[0], "args (") {
+		t.Errorf("field should still be named args, got:\n%s", fields[0])
+	}
+	if !strings.Contains(fields[0], "8080") || !strings.Contains(fields[0], "8081") {
+		t.Errorf("focused args diff should keep the changed token, got:\n%s", fields[0])
+	}
+	if !strings.Contains(fields[0], "…") {
+		t.Errorf("focused args diff should window the long element, got:\n%s", fields[0])
+	}
+}

--- a/cmd/kuke/run/run.go
+++ b/cmd/kuke/run/run.go
@@ -33,6 +33,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"strconv"
 	"strings"
 
 	"github.com/eminwux/kukeon/cmd/config"
@@ -954,16 +955,16 @@ func divergedContainerFields(actual, desired v1beta1.ContainerSpec) []string {
 		fields = append(fields, scalarDiff("image", actual.Image, desired.Image))
 	}
 	if actual.Command != desired.Command {
-		fields = append(fields, scalarDiff("command", actual.Command, desired.Command))
+		fields = append(fields, focusedScalarDiff("command", actual.Command, desired.Command))
 	}
 	if !stringSlicesEqual(actual.Args, desired.Args) {
-		fields = append(fields, sliceDiff("args", actual.Args, desired.Args))
+		fields = append(fields, focusedSliceDiff("args", actual.Args, desired.Args))
 	}
 	if actual.WorkingDir != desired.WorkingDir {
 		fields = append(fields, scalarDiff("workingDir", actual.WorkingDir, desired.WorkingDir))
 	}
 	if !stringSlicesEqual(actual.Env, desired.Env) {
-		fields = append(fields, sliceDiff("env", actual.Env, desired.Env))
+		fields = append(fields, focusedSliceDiff("env", actual.Env, desired.Env))
 	}
 	if !stringSlicesEqual(actual.Ports, desired.Ports) {
 		fields = append(fields, sliceDiff("ports", actual.Ports, desired.Ports))
@@ -1029,6 +1030,142 @@ func sliceDiff(name string, actual, desired []string) string {
 // the divergence, not a bare positional `{[…] …}`.
 func valueDiff(name string, actual, desired interface{}) string {
 	return fmt.Sprintf("%s (actual=%+v, desired=%+v)", name, actual, desired)
+}
+
+// Focused-diff tuning (issue #1193). diffElemMax is the rune length at or under
+// which a single element prints verbatim; longer elements are windowed to
+// diffContext runes on each side of the first character that differs, so a
+// one-token change inside a multi-line `sh -c` script stays visible instead of
+// drowning in escaped shell text.
+const (
+	diffContext = 24
+	diffElemMax = 56
+)
+
+// focusedScalarDiff is scalarDiff's focused sibling for long scalar fields
+// (command). A short value renders verbatim (`actual=%q desired=%q`); a long
+// one is truncated around the first differing rune so the changed token stays
+// visible. The full spec remains inspectable via `kuke get cell -o yaml`.
+func focusedScalarDiff(name, actual, desired string) string {
+	a, d := truncateAroundDiff(actual, desired)
+	return fmt.Sprintf("%s (actual=%s desired=%s)", name, a, d)
+}
+
+// focusedSliceDiff renders a string-slice divergence (args, env) as a focused
+// diff rather than dumping both sides verbatim. With multi-line script args a
+// full `%q` of both slices buries the one changed token in a wall of escaped
+// shell text (issue #1193); this elides identical leading/trailing elements,
+// names only the differing indices, and truncates long individual elements
+// around the first character that differs so the changed token stays visible.
+// The full spec remains inspectable via `kuke get cell -o yaml`.
+func focusedSliceDiff(name string, actual, desired []string) string {
+	// Identical leading elements.
+	p := 0
+	for p < len(actual) && p < len(desired) && actual[p] == desired[p] {
+		p++
+	}
+	// Identical trailing elements (not overlapping the common prefix).
+	s := 0
+	for s < len(actual)-p && s < len(desired)-p &&
+		actual[len(actual)-1-s] == desired[len(desired)-1-s] {
+		s++
+	}
+
+	actMid := actual[p : len(actual)-s]
+	desMid := desired[p : len(desired)-s]
+
+	var b strings.Builder
+	b.WriteString(name)
+	b.WriteString(" (")
+	if p > 0 || s > 0 {
+		fmt.Fprintf(&b, "%d leading, %d trailing identical; ", p, s)
+	}
+
+	if len(actMid) == len(desMid) {
+		// Same-length window: report each differing index pairwise so the
+		// reader sees only the elements that actually changed.
+		parts := make([]string, 0, len(actMid))
+		for i := range actMid {
+			if actMid[i] == desMid[i] {
+				continue
+			}
+			a, d := truncateAroundDiff(actMid[i], desMid[i])
+			parts = append(parts, fmt.Sprintf("[%d] actual=%s desired=%s", p+i, a, d))
+		}
+		// Defensive: a same-length window with no differing element can only
+		// arise if the slices were equal, which the caller already excluded.
+		if len(parts) == 0 {
+			parts = append(parts, "elements reordered")
+		}
+		b.WriteString(strings.Join(parts, "; "))
+	} else {
+		// Add/remove: the differing windows have different lengths, so name
+		// the index range and the (per-element truncated) contents of each.
+		fmt.Fprintf(&b, "actual[%d:%d]=%s desired[%d:%d]=%s",
+			p, len(actual)-s, quoteSliceTrunc(actMid),
+			p, len(desired)-s, quoteSliceTrunc(desMid))
+	}
+	b.WriteString(")")
+	return b.String()
+}
+
+// truncateAroundDiff quotes two strings, windowing each to diffContext runes on
+// either side of the first rune that differs when either side exceeds
+// diffElemMax. Short strings print verbatim. An elided side is marked with a
+// `…` ellipsis so the truncation is visible.
+func truncateAroundDiff(a, b string) (string, string) {
+	ra, rb := []rune(a), []rune(b)
+	if len(ra) <= diffElemMax && len(rb) <= diffElemMax {
+		return strconv.Quote(a), strconv.Quote(b)
+	}
+	i := 0
+	for i < len(ra) && i < len(rb) && ra[i] == rb[i] {
+		i++
+	}
+	return windowAround(ra, i), windowAround(rb, i)
+}
+
+// windowAround quotes the diffContext-rune neighbourhood of index i in r,
+// prefixing/suffixing a `…` ellipsis when content was elided on that side.
+func windowAround(r []rune, i int) string {
+	lo := i - diffContext
+	hi := i + diffContext
+	prefixElided := lo > 0
+	suffixElided := hi < len(r)
+	if lo < 0 {
+		lo = 0
+	}
+	if hi > len(r) {
+		hi = len(r)
+	}
+	q := strconv.Quote(string(r[lo:hi]))
+	if prefixElided {
+		q = "…" + q
+	}
+	if suffixElided {
+		q += "…"
+	}
+	return q
+}
+
+// quoteSliceTrunc renders a string slice as a space-joined list of quoted
+// elements, truncating any element longer than diffElemMax to its leading
+// diffElemMax runes with a `…` ellipsis. Used for the add/remove branch of
+// focusedSliceDiff where there is no per-element diff partner to window around.
+func quoteSliceTrunc(elems []string) string {
+	if len(elems) == 0 {
+		return "[]"
+	}
+	parts := make([]string, len(elems))
+	for i, e := range elems {
+		r := []rune(e)
+		if len(r) <= diffElemMax {
+			parts[i] = strconv.Quote(e)
+			continue
+		}
+		parts[i] = strconv.Quote(string(r[:diffElemMax])) + "…"
+	}
+	return "[" + strings.Join(parts, " ") + "]"
 }
 
 // containerSecretsEqual compares two ContainerSecret slices field-by-field.


### PR DESCRIPTION
## Summary
- The `kuke run -f` / `--require-synced` divergence notice rendered `args`/`env`/`command` divergences by dumping the **entire** both-sides value via `%q`. With a multi-line `sh -c` script in `args`, the changed token (e.g. `-p 8080` → `-p 8081`) was buried in dozens of wrapped lines of escaped shell text (#1193).
- New focused-diff formatters in `cmd/kuke/run/run.go` replace the verbatim dumps for `args`, `env` (slices) and `command` (scalar):
  - **Slices** (`focusedSliceDiff`): elide identical leading/trailing elements (summarized as `N leading, M trailing identical`), name only the differing index, and window long elements around the first differing rune.
  - **Scalar** (`focusedScalarDiff`): window long values around the first differing rune; short values still print verbatim.
  - Add/remove (length-differing) slices name the changed index range and per-element-truncated contents.
- Scope is limited to `args`/`command`/`env` per the AC ("Same treatment for command and env"). Short identifier fields (`ports`, `networks`, `image`, `workingDir`, `restartPolicy`) keep the existing verbatim `sliceDiff`/`scalarDiff` rendering — they don't carry multi-line payloads, so the wall-of-text problem doesn't apply.

Example (multi-line script, one-token change):

```
before: args (actual=["-c" "set -e\nwhile true; do\n  nc -l -p 8080 -e /bin/cat\n  sleep 1\ndone\n"], desired=["-c" "set -e\nwhile true; do\n  nc -l -p 8081 -e /bin/cat\n  sleep 1\ndone\n"])
after:  args (1 leading, 0 trailing identical; [1] actual=…" true; do\n  nc -l -p 8080 -e /bin/cat\n  sleep 1\n"… desired=…" true; do\n  nc -l -p 8081 -e /bin/cat\n  sleep 1\n"…)
```

Notes for the reviewer:
- The overall notice shape (`notice: cell "<name>" is OutOfSync with on-disk spec (diverging: <fields>); …`) is unchanged — only the per-field rendering inside `<fields>` changes. `docs/cli-use-cases.md` documents that as `(diverging: ...)` with an abstract placeholder, so no doc update is required.
- AC item 3 (full spec inspectable via `kuke get cell -o yaml`) needs no code change — that path is untouched; documented in the focused-diff godoc.

## Test plan
- [x] `make test` (full CI suite: `test-root` + `test-kukebuild`) — green.
- [x] `GOWORK=off go test ./cmd/kuke/run/` — green, including new `focused_diff_test.go` covering: multi-line-script one-token change keeps the token visible and is shorter than the full dump; common-framing elision; add/remove index ranges; scalar verbatim-vs-truncated; and the end-to-end `divergedContainerFields` integration.

Closes #1193