### PR TITLE
fix(get): add camelCase yaml/json tags to image describe output

### DIFF
--- a/cmd/kuke/get/image/image_test.go
+++ b/cmd/kuke/get/image/image_test.go
@@ -169,6 +169,15 @@ func TestImageCmd_DescribeSingleImageYAMLDefault(t *testing.T) {
 	if !strings.Contains(out, "digest: "+want.Digest) {
 		t.Errorf("expected yaml describe to carry digest, got:\n%s", out)
 	}
+	// camelCase keys must match the CLI's convention (#1194): the default
+	// yaml.v3 struct-name lowering would otherwise collapse these to
+	// `createdat:` / `mediatype:`, which breaks `yq .createdAt`.
+	if !strings.Contains(out, "mediaType: "+want.MediaType) {
+		t.Errorf("expected camelCase mediaType key, got:\n%s", out)
+	}
+	if strings.Contains(out, "mediatype:") || strings.Contains(out, "createdat:") {
+		t.Errorf("collapsed lowercase keys must not appear, got:\n%s", out)
+	}
 }
 
 func TestImageCmd_DescribeSingleImageJSON(t *testing.T) {
@@ -183,8 +192,8 @@ func TestImageCmd_DescribeSingleImageJSON(t *testing.T) {
 	if err != nil {
 		t.Fatalf("run: %v", err)
 	}
-	if !strings.Contains(out, "\"Name\":") || !strings.Contains(out, want.Name) {
-		t.Errorf("expected json describe to carry Name field, got:\n%s", out)
+	if !strings.Contains(out, "\"name\":") || !strings.Contains(out, want.Name) {
+		t.Errorf("expected json describe to carry camelCase name field, got:\n%s", out)
 	}
 }
 

--- a/pkg/api/kukeonv1/types.go
+++ b/pkg/api/kukeonv1/types.go
@@ -815,12 +815,12 @@ type LoadImageResult struct {
 // effort: -1 is emitted when containerd cannot resolve the size locally so
 // the CLI renders "-" rather than "0 B".
 type ImageInfo struct {
-	Name      string
-	Size      int64
-	CreatedAt time.Time
-	Digest    string
-	MediaType string
-	Labels    map[string]string
+	Name      string            `json:"name"      yaml:"name"`
+	Size      int64             `json:"size"      yaml:"size"`
+	CreatedAt time.Time         `json:"createdAt" yaml:"createdAt"`
+	Digest    string            `json:"digest"    yaml:"digest"`
+	MediaType string            `json:"mediaType" yaml:"mediaType"`
+	Labels    map[string]string `json:"labels"    yaml:"labels"`
 }
 
 // ListImagesResult lists the images present in a realm's containerd


### PR DESCRIPTION
## Summary

- `kukeonv1.ImageInfo` carried no struct tags, so `kuke get image <ref> -o yaml` rendered `createdat:` / `mediatype:` (yaml.v3's default struct-name lowering collapses multi-word fields) while every other resource kind emits camelCase. `yq .createdAt` returned null against image YAML.
- Added explicit `json:`/`yaml:` camelCase tags to all six `ImageInfo` fields (`name`, `size`, `createdAt`, `digest`, `mediaType`, `labels`), matching the convention used by the other tagged structs in `pkg/api/kukeonv1/types.go`.

## Notes / scope calls

- **JSON output now camelCase too.** AC2 names "image YAML/JSON output", and the convention the issue points at (other resource kinds) tags both `json:` and `yaml:`. Without `json:` tags the describe JSON emitted PascalCase (`"Name"`, `"CreatedAt"`) — not "collapsed lowercase", but not camelCase either. Tagging both brings JSON into line. `TestImageCmd_DescribeSingleImageJSON` asserted the old `"Name":` key and was updated to `"name":`.
- **Scope = the named struct.** The describe path prints `ImageInfo` directly; the parent `ListImagesResult`/`GetImageResult` carry only single-word fields (`realm`, `namespace`, `images`) that don't collapse, so they're left untouched per the issue's "sweep the struct" framing.

## Test plan

- [x] `make test` (full CI suite, `GOWORK=off`) — exit 0
- [x] `GOWORK=off go test ./cmd/kuke/get/image/... ./pkg/api/kukeonv1/...` — pass
- [x] Strengthened `TestImageCmd_DescribeSingleImageYAMLDefault` to assert `mediaType:` present and `mediatype:`/`createdat:` absent

## Acceptance criteria

- [x] `kuke get image <ref> -o yaml` emits `createdAt:` and `mediaType:` (camelCase) keys.
- [x] No remaining all-lowercase collapsed multi-word keys in image YAML/JSON output.

Closes #1194