### PR TITLE
docs(team): note spec.projectDir as the NAME source in kuke-team-init table

### DIFF
--- a/docs/site/cli/kuke-team-init.md
+++ b/docs/site/cli/kuke-team-init.md
@@ -72,11 +72,11 @@ Per-project scope: the value is the team-label / on-disk source-tree path /
 agents-source path the current `kuke team init` invocation is composing
 for.
 
-| Key           | Source                                               | Default               |
-| ------------- | ---------------------------------------------------- | --------------------- |
-| `NAME`        | `kuketeam.yaml` `metadata.name`                      | empty (validated)     |
-| `PROJECT_DIR` | `composeTeam`'s `projectDir` argument (`os.Getwd()`) | the calling cwd       |
-| `AGENTS_REPO` | resolved agents source's `<owner>/<repo>` path       | empty when unresolved |
+| Key           | Source                                                                         | Default                                               |
+| ------------- | ------------------------------------------------------------------------------ | ----------------------------------------------------- |
+| `NAME`        | `kuketeam.yaml` `spec.projectDir`, falling back to `metadata.name` when unset  | `metadata.name` (the team label; validated non-empty) |
+| `PROJECT_DIR` | `composeTeam`'s `projectDir` argument (`os.Getwd()`)                           | the calling cwd                                       |
+| `AGENTS_REPO` | resolved agents source's `<owner>/<repo>` path                                 | empty when unresolved                                 |
 
 ## Exit codes
 


### PR DESCRIPTION
## Summary
- Follow-up nit from #1167. The `.project.*` reference table in `docs/site/cli/kuke-team-init.md` listed `NAME`'s Source as only `kuketeam.yaml metadata.name`, so a YAML author reading the table would not learn that `spec.projectDir` overrides it.
- Verified against the codebase: `internal/teamrender/teamrender.go:832-835` defaults `.project.NAME` to `project` (the team label) and overrides it with `spec.projectDir` (`in.ProjectCloneDir`) when set; `cmd/kuke/team/init.go:211` defines `project := strings.TrimSpace(pt.Metadata.Name)`, confirming the fallback is `metadata.name`.
- Updated the `NAME` row's Source to `spec.projectDir, falling back to metadata.name when unset` and the Default to `metadata.name (the team label; validated non-empty)`. Re-padded the table for alignment.

## Test plan
- [x] Pure markdown edit — no executable code, tests, or behavior text changed. Confirmed the documented contract against `teamrender.go` and `init.go` (cited above).

Closes #1168