### PR TITLE
docs: onboarding v0.6.0 version-string re-baseline (post-tag)

### DIFF
--- a/docs/site/getting-started.md
+++ b/docs/site/getting-started.md
@@ -1,6 +1,6 @@
 # Getting Started
 
-This guide walks you through installing Kukeon (v0.5.0 beta) on a Linux host, bootstrapping the runtime, and running a simple cell.
+This guide walks you through installing Kukeon (v0.6.0 beta) on a Linux host, bootstrapping the runtime, and running a simple cell.
 
 ## 1. Check prerequisites
 
@@ -33,6 +33,8 @@ sudo kuke init
 
 `kuke init` provisions the two default realms (`default` for user workloads, `kuke-system` for the `kukeond` daemon cell), sets up CNI dirs, pulls the `kukeond` image into the `kuke-system` realm's containerd namespace, and starts the daemon. It touches `/opt/kukeon`, cgroups, and containerd, so it needs root.
 
+Once `kuke init` returns, run [`kuke status`](cli/kuke-status.md) to confirm the daemon is healthy and both realms are Ready.
+
 Expected tail of the output:
 
 ```
@@ -40,12 +42,12 @@ Initialized Kukeon runtime
 Realm: default (namespace: default.kukeon.io)
 System realm: kuke-system (namespace: kuke-system.kukeon.io)
 Run path: /opt/kukeon
-Kukeond image: ghcr.io/eminwux/kukeon:v0.5.0
+Kukeond image: ghcr.io/eminwux/kukeon:v0.6.0
 Actions:
   ...
   System hierarchy:
     - realm "kuke-system": created
-    - cell "kukeond": created (image ghcr.io/eminwux/kukeon:v0.5.0)
+    - cell "kukeond": created (image ghcr.io/eminwux/kukeon:v0.6.0)
     - cell cgroup: created
     - cell root container: created
     - cell containers: started

--- a/docs/site/index.md
+++ b/docs/site/index.md
@@ -8,7 +8,7 @@ _Agent-native orchestration. Self-hosted. No walled garden._
 
 Your agent's context, state, and workspace live on **your** machines — not behind a SaaS login. Kukeon is a containerd-native runtime for AI agents on any Linux host: your cloud VM, your homelab, your laptop. Declarative sessions with bounded lifetime, PTY-attached workloads, and clean teardown — all on infrastructure you control.
 
-!!! info "v0.5.0 beta — core primitives stable; API not yet frozen"
+!!! info "v0.6.0 beta — core primitives stable; API not yet frozen"
 The Realm / Space / Stack / Cell / Container hierarchy, `kuke apply`, attach/log, the `kukeond` daemon, and the manifest schema are stable enough for daily homelab and single-host use. Production use is not recommended. Some kinds and flags are still moving — see [Release notes](https://github.com/eminwux/kukeon/releases) and the [v1.0 roadmap](faq.md#when-is-v10).
 
 `kukeond` is a small daemon over containerd + CNI + cgroups. `kuke` is the CLI. Agent-native primitives — `Session`, `Interactive` containers, scoped secrets, default-deny networking — are declared in YAML and reconciled on a single host.

--- a/docs/site/install/install-linux.md
+++ b/docs/site/install/install-linux.md
@@ -1,6 +1,6 @@
 # Install on Linux
 
-Kukeon (v0.5.0 beta) ships a single static binary per platform. The same binary behaves as `kuke` (the CLI) or `kukeond` (the daemon) depending on the name it is invoked under: you install the binary once and create a hard link for the second name. The one-line installer below does both for you.
+Kukeon (v0.6.0 beta) ships a single static binary per platform. The same binary behaves as `kuke` (the CLI) or `kukeond` (the daemon) depending on the name it is invoked under: you install the binary once and create a hard link for the second name. The one-line installer below does both for you.
 
 Before installing, confirm cgroups v2 and containerd are in place — see [Prerequisites](prerequisites.md). The installer also checks them and exits with a distro-aware hint on any miss.
 
@@ -42,7 +42,7 @@ If you would rather drive each step yourself — e.g. installing onto an air-gap
 # Pick your platform
 export OS=linux             # Options: linux
 export ARCH=amd64           # Options: amd64, arm64
-export KUKE_VERSION=v0.5.0  # Or the release you want to pin
+export KUKE_VERSION=v0.6.0  # Or the release you want to pin
 
 # Download, install, and hard-link
 curl -L -o kuke "https://github.com/eminwux/kukeon/releases/download/${KUKE_VERSION}/kuke-${OS}-${ARCH}"
@@ -60,7 +60,7 @@ The hard link is required: `main.go` dispatches to `kuke` or `kukeond` by lookin
 
 ```bash
 $ kuke version
-v0.5.0
+v0.6.0
 
 $ kukeond --help
 Kukeon daemon: hosts the kukeonv1 API over a unix socket

--- a/docs/site/install/prerequisites.md
+++ b/docs/site/install/prerequisites.md
@@ -1,6 +1,6 @@
 # Prerequisites
 
-Kukeon (v0.5.0 beta) runs on a single Linux host and relies on two things being present before you install the binary:
+Kukeon (v0.6.0 beta) runs on a single Linux host and relies on two things being present before you install the binary:
 
 1. A kernel with **cgroups v2** enabled
 2. A running **containerd** daemon


### PR DESCRIPTION
## Summary
Best-effort documentation update applied from issue #1214.
Mode: best-effort — §1 (version-string bumps) carried paste-ready Before/After wording and was applied character-for-character; §2 (the `kuke status` cross-link) was authored to match the issue's Proposal and Acceptance criteria. Classified best-effort overall because §2 has no verbatim contract.

Gated on the v0.6.0 tag: confirmed published (latest release, cut 2026-06-11) before bumping any literal.

## Files changed
- `docs/site/index.md` — `!!! info` beta banner (L11)
- `docs/site/getting-started.md` — intro line (L3), `kuke init` expected-tail image refs (L43, L48), plus the new `kuke status` post-init line
- `docs/site/install/prerequisites.md` — intro line (L3)
- `docs/site/install/install-linux.md` — intro line (L3), `KUKE_VERSION` export (L45), `kuke version` output (L63)

## Editorial choices
- §1 version bumps applied verbatim from the issue's Before/After snippets — no wording divergence.
- §2: inserted `Once \`kuke init\` returns, run [\`kuke status\`](cli/kuke-status.md) to confirm the daemon is healthy and both realms are Ready.` immediately after the `kuke init` paragraph in "## 3. Bootstrap the runtime", matching the issue's suggested wording. Confirmed the link target `docs/site/cli/kuke-status.md` exists.

## Acceptance criteria check
- [x] `rg -n 'v0\.5\.0' docs/site/index.md docs/site/getting-started.md docs/site/install/` returns zero hits — verified.
- [x] `rg -n 'kuke status' docs/site/getting-started.md` has at least one hit — verified (L36).
- [ ] `mkdocs build --strict` clean — mkdocs not installed in this environment; deferred to CI.

Closes #1214