### PR TITLE
docs: kuke build coverage — guide, source-build, storage paths, Pi

### DIFF
--- a/docs/site/architecture/storage-layout.md
+++ b/docs/site/architecture/storage-layout.md
@@ -87,6 +87,18 @@ Kukeon does **not** mirror containerd state into its own layout. Images, snapsho
 
 If you want to inspect what Kukeon pushed into containerd, use `ctr -n kukeon-<realm>` — see [containerd namespaces](../concepts/containerd-namespaces.md).
 
+## Build cache
+
+[`kuke build`](../cli/kuke-build.md) keeps its BuildKit state (layer cache, snapshot and content mappings) under `/var/lib/kukebuild`, one subdirectory per realm containerd namespace:
+
+```
+/var/lib/kukebuild/
+├── default.kukeon.io/
+└── kuke-system.kukeon.io/
+```
+
+The cache is namespace-scoped because it holds references into that namespace's snapshots and content store. `kuke uninstall` sweeps each realm's cache directory in the same pass that removes its containerd namespace — a stale cache left behind strands the next `kuke build` with "parent snapshot does not exist" or "content digest … not found" (see the full per-host teardown notes in [`docs/cli-use-cases.md`](https://github.com/eminwux/kukeon/blob/main/docs/cli-use-cases.md)).
+
 ## What gets cleaned up, and when
 
 | Operation                     | Removes                                                          |
@@ -95,7 +107,8 @@ If you want to inspect what Kukeon pushed into containerd, use `ctr -n kukeon-<r
 | `kuke delete space --cascade` | The space subtree, cgroups, CNI conflist                         |
 | `kuke delete cell --cascade`  | The cell subtree, cgroups, containerd containers                 |
 | `kuke purge <resource>`       | Same as delete but more aggressive: force-removes residual state |
-| Reboot                        | `/run/kukeon/*` disappears (tmpfs). `/opt/kukeon/*` persists.    |
+| `kuke uninstall`              | Everything above, plus `/var/lib/kukebuild/<namespace>/` for every realm whose containerd namespace was removed |
+| Reboot                        | `/run/kukeon/*` disappears (tmpfs). `/opt/kukeon/*` and `/var/lib/kukebuild/*` persist. |
 
 In-process runs of the same commands do exactly the same thing on disk — they just skip the socket and execute the controller in-process (reach in-process mode via `--run-path`, `KUKEON_NO_DAEMON=true`, or `--no-daemon` on the commands that still ship it: `init`, `uninstall`, `purge`, every `get <kind>`).
 

--- a/docs/site/cli/kuke-build.md
+++ b/docs/site/cli/kuke-build.md
@@ -4,9 +4,7 @@
 kuke build [-f Dockerfile] [-t name:tag] [--realm <name>] [--build-arg K=V]... [--secret id=NAME,src=PATH]... [--cache-to type=local,dest=PATH]... [--cache-from type=local,src=PATH]... [--platform os/arch,...] [--push] <context>
 ```
 
-Build an OCI image from a Dockerfile into a realm's containerd namespace.
-
-Build an OCI image from a Dockerfile using kukeon's native builder.
+Build an OCI image from a Dockerfile into a realm's containerd namespace using kukeon's native builder.
 
 `kuke build` is a thin shim: it locates the `kukebuild` binary on PATH and exec's it. `kukebuild` embeds BuildKit, builds the context with the Dockerfile frontend, and writes the resulting image into the containerd namespace mapped to `--realm` (`<realm>.kukeon.io`), ready for `kuke get image` and `kuke create`.
 

--- a/docs/site/guides/run-claude-code.md
+++ b/docs/site/guides/run-claude-code.md
@@ -9,22 +9,28 @@ The example does **not** bake API keys into the image and does not configure aut
 ## Prerequisites
 
 - A host that has been bootstrapped with [`kuke init`](init-and-reset.md). `kuke get realms` shows both `default` and `kuke-system` Ready.
-- A local Docker (or `nerdctl build`) install for building the image.
+- The `kukebuild` binary on `PATH` — `kuke build` exec's it. It is not part of the release artifacts yet; build it from a checkout with `make kukebuild` (see [Build from source](../install/build-from-source.md#build-kukebuild-for-kuke-build)).
 - A copy of the three files under `docs/examples/claude-code/`:
   - [`Dockerfile`](https://github.com/eminwux/kukeon/blob/main/docs/examples/claude-code/Dockerfile)
   - [`cell.yaml`](https://github.com/eminwux/kukeon/blob/main/docs/examples/claude-code/cell.yaml)
   - [`blueprint.yaml`](https://github.com/eminwux/kukeon/blob/main/docs/examples/claude-code/blueprint.yaml) (the daemon-stored replacement for the pre-#626 `profile.yaml`)
 
-## Step 1 — Build the image
+## Step 1 — Build the image into the `default` realm
 
-The example `Dockerfile` installs `nodejs` + `npm` + the `@anthropic-ai/claude-code` package as a non-root `claude` user on `debian:trixie-slim`:
+The example `Dockerfile` installs `nodejs` + `npm` + the `@anthropic-ai/claude-code` package as a non-root `claude` user on `debian:trixie-slim`. [`kuke build`](../cli/kuke-build.md) builds it with kukeon's native builder and writes the result straight into the `default` realm's containerd namespace — no docker daemon and no separate load step:
 
 ```bash
 cd docs/examples/claude-code
-docker build -t claude-code:latest .
+sudo kuke build -t claude-code:latest .
 ```
 
-`nerdctl build -t claude-code:latest .` works the same way if you don't run Docker.
+`--realm default` is the default, so it can be omitted. The tag normalizes to `docker.io/library/claude-code:latest` — the exact reference `cell.yaml` and `blueprint.yaml` use. Verify:
+
+```bash
+sudo kuke get images | grep claude-code
+```
+
+If you already have a pre-built image tarball instead, load it with `kuke image load` — see [`kuke image`](../cli/kuke-image.md) for the `kuke image load --from-docker <name:tag>` and `… save | sudo kuke image load -` forms.
 
 ### What's in the image that the smoke path doesn't need
 
@@ -35,23 +41,7 @@ The `Dockerfile` carries a handful of fleet-runner extras the Claude Code smoke 
 
 The smoke path needs only `nodejs`, `npm`, the `@anthropic-ai/claude-code` package, and the non-root `claude` user.
 
-## Step 2 — Load the image into the `default` realm
-
-Every realm maps to its own containerd namespace ([Containerd namespaces](../concepts/containerd-namespaces.md)). User workloads live in `default.kukeon.io`, so the cell's image has to be loaded into that namespace before `kuke apply` / `kuke run` can pull it:
-
-```bash
-sudo kuke image load --from-docker claude-code:latest
-```
-
-`--realm default` is the default, so it can be omitted. Verify:
-
-```bash
-sudo kuke get images | grep claude-code
-```
-
-If you don't run Docker, use the `nerdctl save … | sudo kuke image load -` form documented in [`kuke image`](../cli/kuke-image.md).
-
-## Step 3 — Apply and attach the Cell
+## Step 2 — Apply and attach the Cell
 
 `cell.yaml` is a single Attachable `Cell` with two containers: a `busybox` root keeping the cell alive (`sleep infinity`) and a `work` container running the Claude Code image, marked `attachable: true` so `kuke attach` can connect a TTY to it.
 
@@ -98,7 +88,7 @@ The smoke path above keeps Claude Code's per-user state inside the cell's overla
 
 This is optional — the smoke flow above does not need it.
 
-## Step 4 — One-shot prompts via a `CellBlueprint`
+## Step 3 — One-shot prompts via a `CellBlueprint`
 
 For "fire one prompt, tear the cell down on exit" jobs, apply the example blueprint to the daemon and drive it with `kuke run --from-blueprint`. A [CellBlueprint](../manifests/blueprint.md) is a daemon-stored, scoped cell template.
 

--- a/docs/site/install/build-from-source.md
+++ b/docs/site/install/build-from-source.md
@@ -24,6 +24,17 @@ ln -sf kuke kukeond
 
 `make kuke` writes the binary into the repository root.
 
+## Build `kukebuild` (for `kuke build`)
+
+[`kuke build`](../cli/kuke-build.md) is a thin shim that locates the `kukebuild` binary on `PATH` and exec's it. `kukebuild` is **not** part of the release artifacts — building it from source is currently the only way to obtain it, and a `kuke build` without it on `PATH` fails fast with `errdefs.ErrKukebuildNotFound`:
+
+```bash
+make kukebuild
+sudo ln -sf "$(pwd)/kukebuild" /usr/local/bin/kukebuild
+```
+
+`make kukebuild` writes the binary into the repository root (it lives in its own Go module under `cmd/kukebuild/`); the symlink puts it on `PATH` so `sudo kuke build` can resolve it.
+
 ## Run against a local binary
 
 For one-off tests you can run the binaries from the checkout:

--- a/docs/site/install/prerequisites.md
+++ b/docs/site/install/prerequisites.md
@@ -51,6 +51,26 @@ sudo ctr version
 
 Kukeon uses its own containerd namespaces (one per realm: `<realm>.kukeon.io`). `kuke init` provisions two by default — `default.kukeon.io` for user workloads and `kuke-system.kukeon.io` for the `kukeond` daemon. Kukeon does not interfere with existing containerd namespaces used by Docker, nerdctl, or other tools.
 
+## Raspberry Pi
+
+arm64 is a first-class release target: every release ships `kuke-linux-arm64`, `kukeond-linux-arm64`, and `kukepause-linux-arm64` binaries plus multi-arch (`linux/amd64`, `linux/arm64`) container images, and the [one-line installer](install-linux.md) auto-detects `aarch64`/`arm64` via `uname -m` — no Pi-specific install flags needed.
+
+Raspberry Pi OS is Debian-based, so containerd installs the same way as the Debian/Ubuntu line above:
+
+```bash
+sudo apt-get install -y containerd
+sudo systemctl enable --now containerd
+```
+
+!!! warning "Untested on real hardware — verify with `kuke doctor cgroups`"
+    The boot-parameter steps below are documented from upstream Raspberry Pi OS conventions and have **not** been verified on a physical Pi. Raspberry Pi OS historically ships with the cgroup **memory controller disabled** by default. If `sudo kuke doctor cgroups` reports `memory` missing from the delegated controllers, append the following to the single line in `/boot/firmware/cmdline.txt` (`/boot/cmdline.txt` on older releases) and reboot:
+
+    ```
+    cgroup_enable=memory cgroup_memory=1
+    ```
+
+    After the reboot, `sudo kuke doctor cgroups` should pass and `sudo kuke init` should complete normally. If your results differ, please [open an issue](https://github.com/eminwux/kukeon/issues).
+
 ## CNI plugins (for in-process mode only)
 
 The `kukeond` container image bundles the CNI reference plugins at `/opt/cni/bin` inside the container, and the daemon invokes them from there. The standard install path (`kuke init` → daemon-mediated operations) therefore does **not** require host-side CNI plugins.
@@ -86,8 +106,9 @@ See [Getting Started → Daily use without sudo](../getting-started.md#daily-use
 | `/run/kukeon/kukeond.pid`   | Daemon PID file.                                                                                          |
 | `/etc/cni/net.d`            | Generated CNI conflists for each space.                                                                   |
 | `/sys/fs/cgroup/kukeon/...` | Kukeon's cgroup subtree.                                                                                  |
+| `/var/lib/kukebuild/<namespace>/` | BuildKit build cache, written by `kuke build` — one subdirectory per realm containerd namespace. Swept per-namespace by `kuke uninstall`. |
 
-Nothing is written outside those paths without an explicit flag.
+Nothing is written outside the paths in this table without an explicit flag.
 
 ## Next
 


### PR DESCRIPTION
## Summary
Best-effort documentation update applied from issue #1229.
Mode: best-effort — the issue body identified files and sections but did not provide paste-ready Before/After wording, so wording was authored to match the issue's Proposal and Acceptance criteria.

## Files changed
- `docs/site/guides/run-claude-code.md` — Prerequisites + Steps 1–2 (merged into a single `kuke build` step; later steps renumbered)
- `docs/site/install/build-from-source.md` — new "Build `kukebuild` (for `kuke build`)" section after "Build the binaries"
- `docs/site/architecture/storage-layout.md` — new "Build cache" section + `kuke uninstall` row in the cleanup table
- `docs/site/install/prerequisites.md` — new "Raspberry Pi" section, `/var/lib/kukebuild/<namespace>/` row in "Disk paths kukeon touches", corrected the "nothing outside those paths" line
- `docs/site/cli/kuke-build.md` — intro deduped

## Editorial choices
- The guide's old Steps 1–2 collapse into one step, so old Steps 3–4 renumber to 2–3; no external links target the old step anchors (grepped `docs/site` + `mkdocs.yml`).
- Added a `kukebuild`-on-PATH prerequisite bullet to the guide (linking the new build-from-source section) — without it the rewritten Step 1 fails with `ErrKukebuildNotFound`, the exact trap the issue's Context names.
- Stated the tag normalization (`claude-code:latest` → `docker.io/library/claude-code:latest`) in the guide so readers can see the built ref matches what `cell.yaml`/`blueprint.yaml` reference — verified against `normalizeImageName` in `cmd/kukebuild/build.go`.
- Kept `kuke image load` as a pre-built-tarball aside per the Proposal, pointing at the `kuke image` reference for both forms.
- The Pi section's verifiable claims (arm64 binaries, multi-arch images, installer `uname -m` auto-detection) are grounded in `.github/workflows/release.yaml` and `scripts/install.sh`. The cmdline.txt memory-controller step is shipped under a `!!! warning "Untested on real hardware"` admonition per the issue's explicit either/or AC — it could not be verified on a physical Pi, and the admonition routes readers to `kuke doctor cgroups` for self-verification.
- The build-cache path and `kuke uninstall` sweep semantics are grounded in `internal/consts/consts.go` (`KukebuildBaseDir`), `cmd/kukebuild/main.go`, and the #904 notes in `docs/cli-use-cases.md`.

## Acceptance criteria check
- [x] run-claude-code guide has no Docker prerequisite; image is produced by `kuke build` straight into the `default` realm — done
- [x] build-from-source documents building `kukebuild` and putting it on PATH — done
- [x] `/var/lib/kukebuild/<namespace>/` appears in both storage-path references; the "nothing outside these paths" claim is corrected — done
- [x] Prerequisites gains a Raspberry Pi subsection; every hardware-specific step is either verified on-device or explicitly labeled untested — done (boot-parameter step explicitly labeled untested)
- [x] kuke-build.md intro reads as a single sentence — done

Closes #1229