### PR TITLE
release: ship kukebuild in release artifacts + installer

### DIFF
--- a/.github/workflows/installer.yaml
+++ b/.github/workflows/installer.yaml
@@ -101,6 +101,10 @@ jobs:
   # the test doesn't drift with future releases. Checksum verification is
   # skipped because pre-issue-#62 releases shipped without .sha256 assets;
   # once a release lands with .sha256 published, drop the skip.
+  # KUKE_SKIP_KUKEBUILD is set for the same reason: v0.4.0 predates the
+  # kukebuild release asset (issue #1227), so the installer would 404 fetching
+  # it. Once the pinned tag ships kukebuild-linux-*, bump KUKE_VERSION and drop
+  # this skip to exercise the kukebuild install path here.
   install-skip-init:
     name: full install (KUKE_SKIP_INIT=1) against a real release
     runs-on: ubuntu-latest
@@ -108,6 +112,7 @@ jobs:
       KUKE_VERSION: v0.4.0
       KUKE_SKIP_INIT: "1"
       KUKE_SKIP_CHECKSUM: "1"
+      KUKE_SKIP_KUKEBUILD: "1"
     steps:
       - uses: actions/checkout@v4
       - name: Run installer (download + install, skip init)

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -23,11 +23,32 @@ jobs:
       - name: Check out the repo
         uses: actions/checkout@v4
 
+      # kukebuild lives in its own Go module (cmd/kukebuild/go.mod, issue #655)
+      # pinned to a newer Go than the root module; `make release-build-kukebuild`
+      # cds into that module and lets GOTOOLCHAIN auto-fetch the pinned
+      # toolchain. setup-go with go-version-file: go.mod gives a known base Go
+      # for that auto-fetch — mirrors the test.yaml job's proven pattern.
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
+
       - name: Build artifacts
         run: |
           make release-build \
             KUKEON_VERSION=$KUKEON_VERSION \
             KUKEON_IMAGE_REPO=$KUKEON_IMAGE_REPO
+
+      # kukebuild is the docker-free image builder `kuke build` execs (embeds
+      # BuildKit as a library, writes straight into the realm's containerd
+      # namespace). It is built from its own Go module via a separate target so
+      # the installer can ship it on PATH alongside `kuke` — without it a fresh
+      # installer user hits errdefs.ErrKukebuildNotFound on `kuke build`
+      # (issue #1227).
+      - name: Build kukebuild artifacts
+        run: |
+          make release-build-kukebuild
 
       # The one-line installer (https://kukeon.io/install.sh, issue #62)
       # downloads the per-arch `.sha256` companion file and verifies it
@@ -38,7 +59,8 @@ jobs:
         run: |
           for f in kuke-linux-amd64 kuke-linux-arm64 \
                    kukeond-linux-amd64 kukeond-linux-arm64 \
-                   kukepause-linux-amd64 kukepause-linux-arm64; do
+                   kukepause-linux-amd64 kukepause-linux-arm64 \
+                   kukebuild-linux-amd64 kukebuild-linux-arm64; do
             sha256sum "$f" > "$f.sha256"
           done
 
@@ -50,9 +72,11 @@ jobs:
           ./kuke-linux-amd64 ./kuke-linux-arm64 \
           ./kukeond-linux-amd64 ./kukeond-linux-arm64 \
           ./kukepause-linux-amd64 ./kukepause-linux-arm64 \
+          ./kukebuild-linux-amd64 ./kukebuild-linux-arm64 \
           ./kuke-linux-amd64.sha256 ./kuke-linux-arm64.sha256 \
           ./kukeond-linux-amd64.sha256 ./kukeond-linux-arm64.sha256 \
           ./kukepause-linux-amd64.sha256 ./kukepause-linux-arm64.sha256 \
+          ./kukebuild-linux-amd64.sha256 ./kukebuild-linux-arm64.sha256 \
           --title "${GITHUB_REF#refs/tags/}" \
           --generate-notes \
           --notes "Container images (multi-arch: linux/amd64, linux/arm64):

--- a/docs/site/install.sh
+++ b/docs/site/install.sh
@@ -19,6 +19,8 @@
 #   KUKE_INSTALL_PREFIX    install dir (default: /usr/local/bin)
 #   KUKE_SKIP_INIT=1       skip the `kuke init` step
 #   KUKE_SKIP_CHECKSUM=1   skip .sha256 verification (NOT recommended)
+#   KUKE_SKIP_KUKEBUILD=1  skip downloading/installing kukebuild (disables
+#                          `kuke build`; for release tags predating its asset)
 
 set -euo pipefail
 
@@ -27,6 +29,7 @@ KUKE_INSTALL_PREFIX="${KUKE_INSTALL_PREFIX:-/usr/local/bin}"
 KUKE_VERSION="${KUKE_VERSION:-}"
 KUKE_SKIP_INIT="${KUKE_SKIP_INIT:-}"
 KUKE_SKIP_CHECKSUM="${KUKE_SKIP_CHECKSUM:-}"
+KUKE_SKIP_KUKEBUILD="${KUKE_SKIP_KUKEBUILD:-}"
 
 MODE="install"
 
@@ -52,7 +55,7 @@ usage() {
     cat <<EOF
 Usage: install.sh [--check] [--help]
 
-Installs kukeon (kuke + kukeond) on a Linux host.
+Installs kukeon (kuke + kukeond + kukebuild) on a Linux host.
 
   --check    Run prerequisite checks only; do not touch the system.
   --help     Show this help.
@@ -63,6 +66,7 @@ Env overrides:
   KUKE_INSTALL_PREFIX    Install dir (default: /usr/local/bin).
   KUKE_SKIP_INIT=1       Skip the post-install \`kuke init\` step.
   KUKE_SKIP_CHECKSUM=1   Skip .sha256 verification (NOT recommended).
+  KUKE_SKIP_KUKEBUILD=1  Skip kukebuild (disables \`kuke build\`).
 EOF
 }
 
@@ -253,48 +257,41 @@ cleanup_tmpdir() {
     fi
 }
 
-do_install() {
-    local arch asset_url sha_url bin_path sha_path
-    arch="$(detect_platform)"
-
-    step "Resolving release version"
-    if [ -z "$KUKE_VERSION" ]; then
-        KUKE_VERSION="$(resolve_latest_version)"
-    fi
-    ok "version: ${KUKE_VERSION}"
-
-    asset_url="https://github.com/${KUKE_REPO}/releases/download/${KUKE_VERSION}/kuke-linux-${arch}"
+# fetch_verified <asset-name> <dest-path>
+# Downloads the per-arch release asset to <dest-path>, fetches its `.sha256`
+# companion and verifies the digest (honoring KUKE_SKIP_CHECKSUM). Factored out
+# of do_install so `kuke` and `kukebuild` share one download+verify path rather
+# than duplicating the checksum logic per binary.
+fetch_verified() {
+    local asset="$1" dest="$2"
+    local asset_url sha_url sha_path
+    asset_url="https://github.com/${KUKE_REPO}/releases/download/${KUKE_VERSION}/${asset}"
     sha_url="${asset_url}.sha256"
+    sha_path="${dest}.sha256"
 
-    INSTALL_TMPDIR="$(mktemp -d -t kuke-install.XXXXXX)"
-    trap cleanup_tmpdir EXIT
-    bin_path="${INSTALL_TMPDIR}/kuke"
-    sha_path="${INSTALL_TMPDIR}/kuke.sha256"
-
-    step "Downloading kuke ${KUKE_VERSION} (linux/${arch})"
-    if ! curl -fsSL -o "$bin_path" "$asset_url"; then
+    step "Downloading ${asset} ${KUKE_VERSION}"
+    if ! curl -fsSL -o "$dest" "$asset_url"; then
         fail "download failed: ${asset_url}"
         printf '    Confirm KUKE_VERSION=%s exists at\n' "$KUKE_VERSION" >&2
         printf '      https://github.com/%s/releases\n' "$KUKE_REPO" >&2
         exit 1
     fi
-    ok "downloaded $(wc -c <"$bin_path" | tr -d ' ') bytes"
+    ok "downloaded $(wc -c <"$dest" | tr -d ' ') bytes"
 
-    step "Verifying checksum"
+    step "Verifying checksum (${asset})"
     if [ -n "$KUKE_SKIP_CHECKSUM" ]; then
         warn "KUKE_SKIP_CHECKSUM=1 set — skipping verification (not recommended)."
     elif curl -fsSL -o "$sha_path" "$sha_url" 2>/dev/null; then
         # Releases publish the .sha256 in `sha256sum` format ("<hex>  <name>"),
-        # so we substitute our local path and let `sha256sum -c` do the
-        # comparison rather than hand-rolling the parser.
-        local expected
+        # so we take the first field and compare it to a local digest rather
+        # than hand-rolling the parser.
+        local expected actual
         expected="$(awk '{print $1}' "$sha_path")"
         if [ -z "$expected" ]; then
             fail ".sha256 asset at ${sha_url} is empty or malformed."
             exit 1
         fi
-        local actual
-        actual="$(sha256sum "$bin_path" | awk '{print $1}')"
+        actual="$(sha256sum "$dest" | awk '{print $1}')"
         if [ "$expected" != "$actual" ]; then
             fail "checksum mismatch for ${asset_url}"
             printf '    expected: %s\n' "$expected" >&2
@@ -308,16 +305,57 @@ do_install() {
         printf '    that ships a checksum.\n' >&2
         exit 1
     fi
+}
 
-    chmod +x "$bin_path"
+do_install() {
+    local arch kuke_path kukebuild_path
+    arch="$(detect_platform)"
+
+    step "Resolving release version"
+    if [ -z "$KUKE_VERSION" ]; then
+        KUKE_VERSION="$(resolve_latest_version)"
+    fi
+    ok "version: ${KUKE_VERSION}"
+
+    INSTALL_TMPDIR="$(mktemp -d -t kuke-install.XXXXXX)"
+    trap cleanup_tmpdir EXIT
+    kuke_path="${INSTALL_TMPDIR}/kuke"
+    kukebuild_path="${INSTALL_TMPDIR}/kukebuild"
+
+    # kuke is the CLI + daemon (argv[0]-dispatched to kukeond); kukebuild is the
+    # docker-free image builder `kuke build` execs. Ship both so a fresh
+    # installer host can build images without a source checkout (issue #1227) —
+    # without kukebuild, `kuke build` fails with errdefs.ErrKukebuildNotFound.
+    #
+    # Both assets are downloaded + verified into the tmpdir before anything is
+    # placed on the system, so a fetch/verify failure leaves the host untouched.
+    # KUKE_SKIP_KUKEBUILD skips kukebuild entirely — release tags predating its
+    # asset (#1227) have no kukebuild-linux-* to fetch, so an old KUKE_VERSION
+    # pin sets it to install kuke alone rather than 404 on the missing asset.
+    fetch_verified "kuke-linux-${arch}" "$kuke_path"
+    chmod +x "$kuke_path"
+    if [ -n "$KUKE_SKIP_KUKEBUILD" ]; then
+        warn "KUKE_SKIP_KUKEBUILD=1 set — skipping kukebuild (\`kuke build\` will be unavailable)."
+    else
+        fetch_verified "kukebuild-linux-${arch}" "$kukebuild_path"
+        chmod +x "$kukebuild_path"
+    fi
 
     step "Installing to ${KUKE_INSTALL_PREFIX}"
-    $SUDO install -m 0755 "$bin_path" "${KUKE_INSTALL_PREFIX}/kuke"
+    $SUDO install -m 0755 "$kuke_path" "${KUKE_INSTALL_PREFIX}/kuke"
     # Hardlink — not symlink — because the binary dispatches on argv[0]
     # basename and we want `kukeond` resolved as a real path, not as
     # `kuke -> kukeond` indirection that some shells resolve.
     $SUDO ln -f "${KUKE_INSTALL_PREFIX}/kuke" "${KUKE_INSTALL_PREFIX}/kukeond"
-    ok "installed kuke + kukeond at ${KUKE_INSTALL_PREFIX}"
+    if [ -n "$KUKE_SKIP_KUKEBUILD" ]; then
+        ok "installed kuke + kukeond at ${KUKE_INSTALL_PREFIX}"
+    else
+        # kukebuild is a distinct binary (its own Go module embedding BuildKit),
+        # not an argv[0] alias of kuke — install it as a real file so `kuke
+        # build` resolves it on PATH.
+        $SUDO install -m 0755 "$kukebuild_path" "${KUKE_INSTALL_PREFIX}/kukebuild"
+        ok "installed kuke + kukeond + kukebuild at ${KUKE_INSTALL_PREFIX}"
+    fi
 
     if [ -n "$KUKE_SKIP_INIT" ]; then
         warn "KUKE_SKIP_INIT=1 set — skipping \`kuke init\`. Run it manually:"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -19,6 +19,8 @@
 #   KUKE_INSTALL_PREFIX    install dir (default: /usr/local/bin)
 #   KUKE_SKIP_INIT=1       skip the `kuke init` step
 #   KUKE_SKIP_CHECKSUM=1   skip .sha256 verification (NOT recommended)
+#   KUKE_SKIP_KUKEBUILD=1  skip downloading/installing kukebuild (disables
+#                          `kuke build`; for release tags predating its asset)
 
 set -euo pipefail
 
@@ -27,6 +29,7 @@ KUKE_INSTALL_PREFIX="${KUKE_INSTALL_PREFIX:-/usr/local/bin}"
 KUKE_VERSION="${KUKE_VERSION:-}"
 KUKE_SKIP_INIT="${KUKE_SKIP_INIT:-}"
 KUKE_SKIP_CHECKSUM="${KUKE_SKIP_CHECKSUM:-}"
+KUKE_SKIP_KUKEBUILD="${KUKE_SKIP_KUKEBUILD:-}"
 
 MODE="install"
 
@@ -52,7 +55,7 @@ usage() {
     cat <<EOF
 Usage: install.sh [--check] [--help]
 
-Installs kukeon (kuke + kukeond) on a Linux host.
+Installs kukeon (kuke + kukeond + kukebuild) on a Linux host.
 
   --check    Run prerequisite checks only; do not touch the system.
   --help     Show this help.
@@ -63,6 +66,7 @@ Env overrides:
   KUKE_INSTALL_PREFIX    Install dir (default: /usr/local/bin).
   KUKE_SKIP_INIT=1       Skip the post-install \`kuke init\` step.
   KUKE_SKIP_CHECKSUM=1   Skip .sha256 verification (NOT recommended).
+  KUKE_SKIP_KUKEBUILD=1  Skip kukebuild (disables \`kuke build\`).
 EOF
 }
 
@@ -253,48 +257,41 @@ cleanup_tmpdir() {
     fi
 }
 
-do_install() {
-    local arch asset_url sha_url bin_path sha_path
-    arch="$(detect_platform)"
-
-    step "Resolving release version"
-    if [ -z "$KUKE_VERSION" ]; then
-        KUKE_VERSION="$(resolve_latest_version)"
-    fi
-    ok "version: ${KUKE_VERSION}"
-
-    asset_url="https://github.com/${KUKE_REPO}/releases/download/${KUKE_VERSION}/kuke-linux-${arch}"
+# fetch_verified <asset-name> <dest-path>
+# Downloads the per-arch release asset to <dest-path>, fetches its `.sha256`
+# companion and verifies the digest (honoring KUKE_SKIP_CHECKSUM). Factored out
+# of do_install so `kuke` and `kukebuild` share one download+verify path rather
+# than duplicating the checksum logic per binary.
+fetch_verified() {
+    local asset="$1" dest="$2"
+    local asset_url sha_url sha_path
+    asset_url="https://github.com/${KUKE_REPO}/releases/download/${KUKE_VERSION}/${asset}"
     sha_url="${asset_url}.sha256"
+    sha_path="${dest}.sha256"
 
-    INSTALL_TMPDIR="$(mktemp -d -t kuke-install.XXXXXX)"
-    trap cleanup_tmpdir EXIT
-    bin_path="${INSTALL_TMPDIR}/kuke"
-    sha_path="${INSTALL_TMPDIR}/kuke.sha256"
-
-    step "Downloading kuke ${KUKE_VERSION} (linux/${arch})"
-    if ! curl -fsSL -o "$bin_path" "$asset_url"; then
+    step "Downloading ${asset} ${KUKE_VERSION}"
+    if ! curl -fsSL -o "$dest" "$asset_url"; then
         fail "download failed: ${asset_url}"
         printf '    Confirm KUKE_VERSION=%s exists at\n' "$KUKE_VERSION" >&2
         printf '      https://github.com/%s/releases\n' "$KUKE_REPO" >&2
         exit 1
     fi
-    ok "downloaded $(wc -c <"$bin_path" | tr -d ' ') bytes"
+    ok "downloaded $(wc -c <"$dest" | tr -d ' ') bytes"
 
-    step "Verifying checksum"
+    step "Verifying checksum (${asset})"
     if [ -n "$KUKE_SKIP_CHECKSUM" ]; then
         warn "KUKE_SKIP_CHECKSUM=1 set — skipping verification (not recommended)."
     elif curl -fsSL -o "$sha_path" "$sha_url" 2>/dev/null; then
         # Releases publish the .sha256 in `sha256sum` format ("<hex>  <name>"),
-        # so we substitute our local path and let `sha256sum -c` do the
-        # comparison rather than hand-rolling the parser.
-        local expected
+        # so we take the first field and compare it to a local digest rather
+        # than hand-rolling the parser.
+        local expected actual
         expected="$(awk '{print $1}' "$sha_path")"
         if [ -z "$expected" ]; then
             fail ".sha256 asset at ${sha_url} is empty or malformed."
             exit 1
         fi
-        local actual
-        actual="$(sha256sum "$bin_path" | awk '{print $1}')"
+        actual="$(sha256sum "$dest" | awk '{print $1}')"
         if [ "$expected" != "$actual" ]; then
             fail "checksum mismatch for ${asset_url}"
             printf '    expected: %s\n' "$expected" >&2
@@ -308,16 +305,57 @@ do_install() {
         printf '    that ships a checksum.\n' >&2
         exit 1
     fi
+}
 
-    chmod +x "$bin_path"
+do_install() {
+    local arch kuke_path kukebuild_path
+    arch="$(detect_platform)"
+
+    step "Resolving release version"
+    if [ -z "$KUKE_VERSION" ]; then
+        KUKE_VERSION="$(resolve_latest_version)"
+    fi
+    ok "version: ${KUKE_VERSION}"
+
+    INSTALL_TMPDIR="$(mktemp -d -t kuke-install.XXXXXX)"
+    trap cleanup_tmpdir EXIT
+    kuke_path="${INSTALL_TMPDIR}/kuke"
+    kukebuild_path="${INSTALL_TMPDIR}/kukebuild"
+
+    # kuke is the CLI + daemon (argv[0]-dispatched to kukeond); kukebuild is the
+    # docker-free image builder `kuke build` execs. Ship both so a fresh
+    # installer host can build images without a source checkout (issue #1227) —
+    # without kukebuild, `kuke build` fails with errdefs.ErrKukebuildNotFound.
+    #
+    # Both assets are downloaded + verified into the tmpdir before anything is
+    # placed on the system, so a fetch/verify failure leaves the host untouched.
+    # KUKE_SKIP_KUKEBUILD skips kukebuild entirely — release tags predating its
+    # asset (#1227) have no kukebuild-linux-* to fetch, so an old KUKE_VERSION
+    # pin sets it to install kuke alone rather than 404 on the missing asset.
+    fetch_verified "kuke-linux-${arch}" "$kuke_path"
+    chmod +x "$kuke_path"
+    if [ -n "$KUKE_SKIP_KUKEBUILD" ]; then
+        warn "KUKE_SKIP_KUKEBUILD=1 set — skipping kukebuild (\`kuke build\` will be unavailable)."
+    else
+        fetch_verified "kukebuild-linux-${arch}" "$kukebuild_path"
+        chmod +x "$kukebuild_path"
+    fi
 
     step "Installing to ${KUKE_INSTALL_PREFIX}"
-    $SUDO install -m 0755 "$bin_path" "${KUKE_INSTALL_PREFIX}/kuke"
+    $SUDO install -m 0755 "$kuke_path" "${KUKE_INSTALL_PREFIX}/kuke"
     # Hardlink — not symlink — because the binary dispatches on argv[0]
     # basename and we want `kukeond` resolved as a real path, not as
     # `kuke -> kukeond` indirection that some shells resolve.
     $SUDO ln -f "${KUKE_INSTALL_PREFIX}/kuke" "${KUKE_INSTALL_PREFIX}/kukeond"
-    ok "installed kuke + kukeond at ${KUKE_INSTALL_PREFIX}"
+    if [ -n "$KUKE_SKIP_KUKEBUILD" ]; then
+        ok "installed kuke + kukeond at ${KUKE_INSTALL_PREFIX}"
+    else
+        # kukebuild is a distinct binary (its own Go module embedding BuildKit),
+        # not an argv[0] alias of kuke — install it as a real file so `kuke
+        # build` resolves it on PATH.
+        $SUDO install -m 0755 "$kukebuild_path" "${KUKE_INSTALL_PREFIX}/kukebuild"
+        ok "installed kuke + kukeond + kukebuild at ${KUKE_INSTALL_PREFIX}"
+    fi
 
     if [ -n "$KUKE_SKIP_INIT" ]; then
         warn "KUKE_SKIP_INIT=1 set — skipping \`kuke init\`. Run it manually:"


### PR DESCRIPTION
## Summary

- `kuke build` is kukeon's docker-free image build path — it execs `kukebuild` (BuildKit-as-a-library). That story only worked for source checkouts: the release workflow published only `kuke`/`kukeond`/`kukepause`, and `install.sh` downloaded only `kuke`. A fresh installer user running `kuke build` hit `errdefs.ErrKukebuildNotFound` whose hint assumes a source tree they don't have.
- **release.yaml**: build `kukebuild-linux-{amd64,arm64}` via the existing `make release-build-kukebuild` target, checksum them, and publish all four assets (binaries + `.sha256`) alongside the existing `kuke` assets. Added a `setup-go` step (mirroring `test.yaml`) so `GOTOOLCHAIN` can auto-fetch kukebuild's pinned Go (its own module is `go 1.25.5` vs root `1.24.5`).
- **install.sh** (canonical `scripts/install.sh`, regenerated `docs/site/install.sh` via `make install.sh`): refactored the download+verify into a shared `fetch_verified` helper, then download/verify/install `kukebuild` next to `kuke`/`kukeond`. Both assets are fetched+verified into the tmpdir before anything is placed on the host, preserving the "fetch failure touches nothing" property.

### Non-obvious calls (please push back if you disagree)

- **AC item 3 (`kuke uninstall` removes kukebuild) — codebase conflict, proceeding per [heads-up comment](https://github.com/eminwux/kukeon/issues/1227#issuecomment-4685705373).** `kuke uninstall` **deliberately does not remove any installed binary** — `cmd/kuke/uninstall/uninstall.go:95-96`: *"The /usr/local/bin/kuke binary and the kukeond symlink are NOT removed — uninstalling runtime state is not the same as uninstalling the binary."* Making it delete `kukebuild` while leaving `kuke`/`kukeond` in the same prefix would contradict that documented invariant and be asymmetric. The actual binary-removal mechanism — `make uninstall-dev` (`Makefile:252`) — **already removes `kukebuild`**. So this PR keeps the `kuke uninstall` invariant unchanged and treats item 3 as satisfied by the existing `make uninstall-dev` coverage. If you instead want `kuke uninstall` to start removing binaries, that's a broader change (should cover `kuke`/`kukeond` too) for a separate issue.
- **`KUKE_SKIP_KUKEBUILD` opt-out (new env var).** Releases predating this PR have no `kukebuild-linux-*` asset, so an unconditional fetch would 404 and break installs pinned to older `KUKE_VERSION` — including the `installer.yaml` `install-skip-init` smoke pinned at `v0.4.0`. Matching the existing `KUKE_SKIP_CHECKSUM` escape-hatch convention, kukebuild download/verify/install is the default; `KUKE_SKIP_KUKEBUILD=1` skips it. Set in the `install-skip-init` job (same rationale as the existing `KUKE_SKIP_CHECKSUM=1` there); bump the pinned tag + drop the skip once a release ships kukebuild.

## Test plan

- [x] `make test` (root + kukebuild modules) — passed, exit 0.
- [x] `make release-build-kukebuild` — produces `kukebuild-linux-amd64` + `kukebuild-linux-arm64` locally.
- [x] `bash -n` on `scripts/install.sh` and `docs/site/install.sh` — clean.
- [x] `make install.sh` sync check — `scripts/install.sh` and `docs/site/install.sh` byte-identical (the `installer.yaml` sync job's invariant).
- [x] `install.sh --check` and `--help` unaffected — `--check` still touches nothing (AC item 4).
- [x] Opt-out install e2e against real `v0.4.0` release (mirrors the `install-skip-init` CI job): `KUKE_SKIP_KUKEBUILD=1` → installs `kuke`+`kukeond`, skips `kukebuild` with no 404.
- [x] `release.yaml` / `installer.yaml` YAML validated.
- [ ] Positive kukebuild install e2e (fresh install downloads+installs kukebuild; `kuke build` succeeds) — **not runnable until the first kukebuild-bearing release exists** (chicken-and-egg: the asset is produced by this PR's workflow on the next tag). The kukebuild install path is structurally identical to the verified `kuke` path (same `fetch_verified` helper + `install -m 0755`), and `make release-build-kukebuild` is confirmed to produce the asset locally. Once a release ships kukebuild, bump the `install-skip-init` smoke tag and drop `KUKE_SKIP_KUKEBUILD` to assert it in CI.

Closes #1227