### PR TITLE
feat: add standalone Volume resource (step 1)

### DIFF
--- a/internal/apischeme/volume.go
+++ b/internal/apischeme/volume.go
@@ -1,0 +1,84 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package apischeme
+
+import (
+	"fmt"
+
+	intmodel "github.com/eminwux/kukeon/internal/modelhub"
+	ext "github.com/eminwux/kukeon/pkg/api/model/v1beta1"
+)
+
+// ConvertVolumeDocToInternal converts an external VolumeDoc to the internal hub
+// carrier (issue #1018). Unlike a CellBlueprint there is no body to serialize —
+// a Volume's spec is empty and the resource is the on-host directory — so this
+// is a flat copy of the scope coordinates onto the metadata.
+func ConvertVolumeDocToInternal(in ext.VolumeDoc) (intmodel.Volume, error) {
+	switch in.APIVersion {
+	case VersionV1Beta1, "": // default/empty treated as v1beta1
+		return intmodel.Volume{
+			Metadata: intmodel.VolumeMetadata{
+				Name:  in.Metadata.Name,
+				Realm: in.Metadata.Realm,
+				Space: in.Metadata.Space,
+				Stack: in.Metadata.Stack,
+			},
+		}, nil
+	default:
+		return intmodel.Volume{}, fmt.Errorf("unsupported apiVersion for Volume: %s", in.APIVersion)
+	}
+}
+
+// NormalizeVolume takes an external VolumeDoc request and returns an internal
+// carrier and the chosen apiVersion.
+func NormalizeVolume(req ext.VolumeDoc) (intmodel.Volume, ext.Version, error) {
+	version := DefaultVersion(req.APIVersion)
+	internal, err := ConvertVolumeDocToInternal(req)
+	if err != nil {
+		return intmodel.Volume{}, "", err
+	}
+	return internal, version, nil
+}
+
+// ConvertVolumeToExternal builds a metadata-only external VolumeDoc from the
+// internal carrier (issue #1018). A Volume has no body, so the external doc is
+// its canonical apiVersion/kind plus the scope coordinates and name.
+func ConvertVolumeToExternal(in intmodel.Volume) ext.VolumeDoc {
+	return ext.VolumeDoc{
+		APIVersion: ext.APIVersionV1Beta1,
+		Kind:       ext.KindVolume,
+		Metadata: ext.VolumeMetadata{
+			Name:  in.Metadata.Name,
+			Realm: in.Metadata.Realm,
+			Space: in.Metadata.Space,
+			Stack: in.Metadata.Stack,
+		},
+	}
+}
+
+// ConvertVolumeListToExternal maps a slice of internal Volumes to metadata-only
+// external VolumeDocs (issue #1018).
+func ConvertVolumeListToExternal(in []intmodel.Volume) []ext.VolumeDoc {
+	if in == nil {
+		return nil
+	}
+	out := make([]ext.VolumeDoc, len(in))
+	for i := range in {
+		out[i] = ConvertVolumeToExternal(in[i])
+	}
+	return out
+}

--- a/internal/apply/parser/parser.go
+++ b/internal/apply/parser/parser.go
@@ -44,6 +44,7 @@ type Document struct {
 	SecretDoc        *v1beta1.SecretDoc
 	CellBlueprintDoc *v1beta1.CellBlueprintDoc
 	CellConfigDoc    *v1beta1.CellConfigDoc
+	VolumeDoc        *v1beta1.VolumeDoc
 }
 
 // ValidationError represents a validation error for a specific document.
@@ -188,6 +189,14 @@ func ParseDocument(index int, raw []byte) (*Document, error) {
 		doc.CellConfigDoc = &configDoc
 		doc.APIVersion = configDoc.APIVersion
 
+	case v1beta1.KindVolume:
+		var volumeDoc v1beta1.VolumeDoc
+		if unmarshalErr := yaml.Unmarshal(raw, &volumeDoc); unmarshalErr != nil {
+			return nil, fmt.Errorf("document %d: failed to parse Volume: %w", index, unmarshalErr)
+		}
+		doc.VolumeDoc = &volumeDoc
+		doc.APIVersion = volumeDoc.APIVersion
+
 	default:
 		// kind: CellProfile was removed in #626. Give the operator an
 		// explicit migration pointer instead of the generic unknown-kind
@@ -228,7 +237,7 @@ func ValidateDocument(doc *Document) *ValidationError {
 	switch doc.Kind {
 	case v1beta1.KindRealm, v1beta1.KindSpace, v1beta1.KindStack, v1beta1.KindCell,
 		v1beta1.KindContainer, v1beta1.KindSecret, v1beta1.KindCellBlueprint,
-		v1beta1.KindCellConfig:
+		v1beta1.KindCellConfig, v1beta1.KindVolume:
 		// Valid kind
 	default:
 		return &ValidationError{
@@ -474,6 +483,11 @@ func ValidateDocument(doc *Document) *ValidationError {
 		if validationErr := validateConfig(doc); validationErr != nil {
 			return validationErr
 		}
+
+	case v1beta1.KindVolume:
+		if validationErr := validateVolume(doc); validationErr != nil {
+			return validationErr
+		}
 	}
 
 	return nil
@@ -545,6 +559,80 @@ func validateBlueprintScope(md v1beta1.CellBlueprintMetadata) error {
 	}
 	if stack != "" && space == "" {
 		return fmt.Errorf("%w (stack set without space)", errdefs.ErrBlueprintScopeIncomplete)
+	}
+	return nil
+}
+
+// validateVolume enforces the structural contract for a kind: Volume document
+// (issue #1018): name + scope coordinates, with cell scope structurally
+// rejected. The scope reachability gate (the named realm/space/stack must
+// exist) runs at reconcile time against the runner — the same split the Secret
+// and Blueprint kinds use, since only the daemon can read /opt/kukeon.
+func validateVolume(doc *Document) *ValidationError {
+	if doc.VolumeDoc == nil {
+		return &ValidationError{Index: doc.Index, Kind: doc.Kind, Err: errors.New("volume document is nil")}
+	}
+	vol := doc.VolumeDoc
+	if strings.TrimSpace(vol.Metadata.Name) == "" {
+		return &ValidationError{Index: doc.Index, Kind: doc.Kind, Err: errdefs.ErrVolumeNameRequired}
+	}
+	if scopeErr := validateVolumeScope(vol.Metadata); scopeErr != nil {
+		return &ValidationError{Index: doc.Index, Kind: doc.Kind, Name: vol.Metadata.Name, Err: scopeErr}
+	}
+	return nil
+}
+
+// validateVolumeScope enforces the Volume scope-coordinate contract:
+// metadata.realm is always required, a deeper coordinate may only be set when
+// every shallower one is, and — like a CellBlueprint, unlike a Secret — a
+// Volume may not be cell-scoped (a `cell:` coordinate is structurally absent
+// from VolumeMetadata, so this guards the realm/space/stack chain). Each
+// non-empty coordinate plus the name is additionally checked for path-segment
+// safety: a Volume provisions a real directory, so a "/" or ".." in any segment
+// would escape the volumes tree once fs.VolumePath joins it (mirrors the
+// Secret-coordinate guard from #673).
+func validateVolumeScope(md v1beta1.VolumeMetadata) error {
+	realm := strings.TrimSpace(md.Realm)
+	space := strings.TrimSpace(md.Space)
+	stack := strings.TrimSpace(md.Stack)
+
+	if realm == "" {
+		return errdefs.ErrVolumeRealmRequired
+	}
+	if stack != "" && space == "" {
+		return fmt.Errorf("%w (stack set without space)", errdefs.ErrVolumeScopeIncomplete)
+	}
+	for _, seg := range []struct{ field, value string }{
+		{"metadata.name", strings.TrimSpace(md.Name)},
+		{"metadata.realm", realm},
+		{"metadata.space", space},
+		{"metadata.stack", stack},
+	} {
+		if err := validateVolumeSegment(seg.value); err != nil {
+			return fmt.Errorf("%w (%s)", err, seg.field)
+		}
+	}
+	return nil
+}
+
+// validateVolumeSegment rejects a single volume name or scope coordinate that
+// would escape the volumes tree once fs.VolumePath filepath.Join's it into a
+// host path: a "/" or "\" separator, a "." or ".." element, or a NUL byte.
+// Empty values are the caller's concern (a missing coordinate is legal; an
+// empty name is rejected separately), so this only guards non-empty segments.
+// Mirrors validateSecretSegment (#673).
+func validateVolumeSegment(value string) error {
+	if value == "" {
+		return nil
+	}
+	if value == "." || value == ".." {
+		return errdefs.ErrVolumeCoordUnsafe
+	}
+	if strings.ContainsRune(value, 0) ||
+		strings.ContainsRune(value, '/') ||
+		strings.ContainsRune(value, '\\') ||
+		strings.ContainsRune(value, filepath.Separator) {
+		return errdefs.ErrVolumeCoordUnsafe
 	}
 	return nil
 }

--- a/internal/apply/parser/volume_test.go
+++ b/internal/apply/parser/volume_test.go
@@ -1,0 +1,108 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package parser_test
+
+import (
+	"testing"
+
+	"github.com/eminwux/kukeon/internal/apply/parser"
+	"github.com/eminwux/kukeon/internal/errdefs"
+	v1beta1 "github.com/eminwux/kukeon/pkg/api/model/v1beta1"
+)
+
+func parseVolume(t *testing.T, yaml string) *parser.Document {
+	t.Helper()
+	doc, err := parser.ParseDocument(0, []byte(yaml))
+	if err != nil {
+		t.Fatalf("ParseDocument failed: %v", err)
+	}
+	if doc.Kind != v1beta1.KindVolume {
+		t.Fatalf("kind = %q, want Volume", doc.Kind)
+	}
+	return doc
+}
+
+const validVolume = `apiVersion: v1beta1
+kind: Volume
+metadata:
+  name: data
+  realm: default
+  space: agents
+  stack: web
+`
+
+func TestValidateDocument_Volume_Valid(t *testing.T) {
+	doc := parseVolume(t, validVolume)
+	if err := parser.ValidateDocument(doc); err != nil {
+		t.Fatalf("expected valid volume, got: %v", err)
+	}
+	if doc.VolumeDoc == nil {
+		t.Fatalf("VolumeDoc is nil after parse")
+	}
+	if got := doc.VolumeDoc.Metadata.Stack; got != "web" {
+		t.Errorf("parsed stack = %q, want web", got)
+	}
+}
+
+func TestValidateDocument_Volume_RealmOnlyValid(t *testing.T) {
+	doc := parseVolume(t, "apiVersion: v1beta1\nkind: Volume\nmetadata:\n  name: data\n  realm: default\n")
+	if err := parser.ValidateDocument(doc); err != nil {
+		t.Fatalf("expected valid realm-scoped volume, got: %v", err)
+	}
+}
+
+func TestValidateDocument_Volume_NameRequired(t *testing.T) {
+	doc := parseVolume(t, "apiVersion: v1beta1\nkind: Volume\nmetadata:\n  realm: default\n")
+	requireValidationErr(t, parser.ValidateDocument(doc), errdefs.ErrVolumeNameRequired)
+}
+
+func TestValidateDocument_Volume_RealmRequired(t *testing.T) {
+	doc := parseVolume(t, "apiVersion: v1beta1\nkind: Volume\nmetadata:\n  name: data\n")
+	requireValidationErr(t, parser.ValidateDocument(doc), errdefs.ErrVolumeRealmRequired)
+}
+
+func TestValidateDocument_Volume_StackWithoutSpaceRejected(t *testing.T) {
+	doc := parseVolume(t, "apiVersion: v1beta1\nkind: Volume\nmetadata:\n  name: data\n  realm: default\n  stack: web\n")
+	requireValidationErr(t, parser.ValidateDocument(doc), errdefs.ErrVolumeScopeIncomplete)
+}
+
+// TestValidateDocument_Volume_CellScopeStructurallyRejected confirms a Volume
+// can never be cell-scoped: VolumeMetadata has no Cell field, so a `cell:`
+// coordinate in the YAML is dropped at unmarshal time and the volume is treated
+// as (at most) stack-scoped — the structural equivalent of validateBlueprint's
+// cell rejection. The document still validates (the realm/space/stack chain is
+// complete); the point is that the cell coordinate has no effect.
+func TestValidateDocument_Volume_CellScopeStructurallyRejected(t *testing.T) {
+	yaml := "apiVersion: v1beta1\nkind: Volume\nmetadata:\n  name: data\n  realm: default\n  space: agents\n  stack: web\n  cell: ignored\n"
+	doc := parseVolume(t, yaml)
+	if err := parser.ValidateDocument(doc); err != nil {
+		t.Fatalf("expected valid volume (cell coordinate ignored), got: %v", err)
+	}
+	// VolumeMetadata has no Cell field; the struct cannot carry a cell scope.
+	// Re-marshal-safe assertion: the deepest coordinate is the stack.
+	if doc.VolumeDoc.Metadata.Stack != "web" {
+		t.Errorf("stack = %q, want web", doc.VolumeDoc.Metadata.Stack)
+	}
+}
+
+// TestValidateDocument_Volume_UnsafeNameRejected confirms a path-traversal name
+// is rejected before it can escape the volumes tree (mirrors the Secret
+// coordinate guard, #673).
+func TestValidateDocument_Volume_UnsafeNameRejected(t *testing.T) {
+	doc := parseVolume(t, "apiVersion: v1beta1\nkind: Volume\nmetadata:\n  name: ../escape\n  realm: default\n")
+	requireValidationErr(t, parser.ValidateDocument(doc), errdefs.ErrVolumeCoordUnsafe)
+}

--- a/internal/consts/consts.go
+++ b/internal/consts/consts.go
@@ -64,6 +64,17 @@ const (
 	// root-owned but world-readable (0o755 / 0o644).
 	KukeonConfigsSubdir = "configs"
 
+	// KukeonVolumesSubdir is the basename of the per-scope subdirectory that
+	// owns daemon-managed `kind: Volume` directories (issue #1018). Like the
+	// secrets/blueprints/configs subdirs it lives inside the scope's metadata
+	// directory (e.g. <RunPath>/data/<realm>/volumes/) so the same os.RemoveAll
+	// that owning-scope cascade purge already runs on a scope's metadata dir
+	// reclaims its volumes too. Unlike those kinds — which store a single file
+	// per resource — each entry here is itself a directory the daemon
+	// provisions container-writable (root-owned, setgid to the kukeon group
+	// when configured) so a mounting container can write into it (#1016).
+	KukeonVolumesSubdir = "volumes"
+
 	// KukeonContainerTTYDir is the basename of the per-container directory
 	// that owns the sbsh terminal socket plus its capture and log siblings.
 	// kukeon bind-mounts this directory (not a single file) into the

--- a/internal/controller/apply.go
+++ b/internal/controller/apply.go
@@ -290,6 +290,28 @@ func (b *Exec) ApplyDocuments(docs []parser.Document, team string) (ApplyResult,
 				))
 			}
 
+		case v1beta1.KindVolume:
+			if doc.VolumeDoc == nil {
+				resourceResult.Action = actionFailed
+				resourceResult.Error = errors.New("volume document is nil")
+				result.Resources = append(result.Resources, resourceResult)
+				continue
+			}
+			// A Volume is deliberately not team-label-stamped or pruned: it is
+			// decoupled from any cell and outlives the apply that created it, so
+			// `kuke apply --prune` removing a volume would wipe persistent data.
+			// Volume reclaim is owning-scope cascade purge only (#1018); the
+			// `kukeon.io/team` lifecycle stays with the blueprint/config kinds.
+			volume, _, err := apischeme.NormalizeVolume(*doc.VolumeDoc)
+			if err != nil {
+				resourceResult.Action = actionFailed
+				resourceResult.Error = fmt.Errorf("%w: %w", errdefs.ErrConversionFailed, err)
+				result.Resources = append(result.Resources, resourceResult)
+				continue
+			}
+			resourceResult.Name = volume.Metadata.Name
+			reconcileResult, reconcileErr = applypkg.ReconcileVolume(b.runner, volume)
+
 		default:
 			resourceResult.Action = actionFailed
 			resourceResult.Error = fmt.Errorf("%w: %s", errdefs.ErrUnknownKind, doc.Kind)

--- a/internal/controller/apply/reconcile.go
+++ b/internal/controller/apply/reconcile.go
@@ -746,6 +746,81 @@ func blueprintScopeLookupError(err error, level, name string) error {
 	}
 }
 
+// ReconcileVolume reconciles a desired `kind: Volume` by verifying its scope
+// exists and provisioning its directory under the daemon-managed metadata tree
+// (issue #1018). Like ReconcileBlueprint it never auto-creates a missing scope:
+// a Volume targets an existing realm/space/stack, so an unreachable scope is an
+// apply-time error. The directory is provisioned idempotently — re-applying an
+// existing volume re-asserts the mode/owner and reports "updated".
+func ReconcileVolume(r runner.Runner, desired intmodel.Volume) (ReconcileResult, error) {
+	result := ReconcileResult{
+		Action: "unchanged",
+		Kind:   "Volume",
+		Name:   desired.Metadata.Name,
+	}
+
+	if err := ensureVolumeScopeExists(r, desired.Metadata); err != nil {
+		return result, err
+	}
+
+	created, writeErr := r.WriteVolume(desired)
+	if writeErr != nil {
+		return result, writeErr
+	}
+	if created {
+		result.Action = actionCreated
+	} else {
+		result.Action = actionUpdated
+	}
+	return result, nil
+}
+
+// ensureVolumeScopeExists verifies every scope coordinate the volume names is
+// reachable, deepest-first. A Volume is scopable at realm/space/stack only
+// (never cell), so the walk stops at the stack. A NotFound is translated to
+// errdefs.ErrVolumeScopeNotFound.
+func ensureVolumeScopeExists(r runner.Runner, md intmodel.VolumeMetadata) error {
+	if _, err := r.GetRealm(intmodel.Realm{
+		Metadata: intmodel.RealmMetadata{Name: md.Realm},
+	}); err != nil {
+		return volumeScopeLookupError(err, "realm", md.Realm)
+	}
+
+	if md.Space != "" {
+		if _, err := r.GetSpace(intmodel.Space{
+			Metadata: intmodel.SpaceMetadata{Name: md.Space},
+			Spec:     intmodel.SpaceSpec{RealmName: md.Realm},
+		}); err != nil {
+			return volumeScopeLookupError(err, "space", md.Space)
+		}
+	}
+
+	if md.Stack != "" {
+		if _, err := r.GetStack(intmodel.Stack{
+			Metadata: intmodel.StackMetadata{Name: md.Stack},
+			Spec:     intmodel.StackSpec{RealmName: md.Realm, SpaceName: md.Space},
+		}); err != nil {
+			return volumeScopeLookupError(err, "stack", md.Stack)
+		}
+	}
+
+	return nil
+}
+
+// volumeScopeLookupError maps a scope Get failure to a stable error. A NotFound
+// at any level becomes ErrVolumeScopeNotFound; any other error is propagated
+// with context so it is not masked as a missing scope.
+func volumeScopeLookupError(err error, level, name string) error {
+	switch {
+	case errors.Is(err, errdefs.ErrRealmNotFound),
+		errors.Is(err, errdefs.ErrSpaceNotFound),
+		errors.Is(err, errdefs.ErrStackNotFound):
+		return fmt.Errorf("%w: %s %q", errdefs.ErrVolumeScopeNotFound, level, name)
+	default:
+		return fmt.Errorf("failed to verify volume scope %s %q: %w", level, name, err)
+	}
+}
+
 // ReconcileConfig reconciles a desired `kind: CellConfig` by verifying its own
 // scope exists, resolving the referenced CellBlueprint from daemon storage,
 // validating the config's structural slot fills against that blueprint's

--- a/internal/controller/apply/reconcile_volume_test.go
+++ b/internal/controller/apply/reconcile_volume_test.go
@@ -1,0 +1,115 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package apply_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/eminwux/kukeon/internal/controller/apply"
+	"github.com/eminwux/kukeon/internal/controller/runner"
+	"github.com/eminwux/kukeon/internal/errdefs"
+	intmodel "github.com/eminwux/kukeon/internal/modelhub"
+)
+
+// volumeFakeRunner satisfies runner.Runner via the embedded interface and
+// overrides only the methods ReconcileVolume exercises: the scope Gets and
+// WriteVolume. realmExists/spaceExists/stackExists gate the scope lookups so a
+// test can simulate a missing scope; writeCreated drives the create-vs-update
+// branch.
+type volumeFakeRunner struct {
+	runner.Runner
+
+	realmErr error
+	spaceErr error
+	stackErr error
+
+	writeCreated bool
+	writeErr     error
+	writeCalled  bool
+	wrote        intmodel.Volume
+}
+
+func (f *volumeFakeRunner) GetRealm(realm intmodel.Realm) (intmodel.Realm, error) {
+	return realm, f.realmErr
+}
+
+func (f *volumeFakeRunner) GetSpace(space intmodel.Space) (intmodel.Space, error) {
+	return space, f.spaceErr
+}
+
+func (f *volumeFakeRunner) GetStack(stack intmodel.Stack) (intmodel.Stack, error) {
+	return stack, f.stackErr
+}
+
+func (f *volumeFakeRunner) WriteVolume(volume intmodel.Volume) (bool, error) {
+	f.writeCalled = true
+	f.wrote = volume
+	return f.writeCreated, f.writeErr
+}
+
+// TestReconcileVolume_CreateReportsCreated confirms a first apply provisions the
+// volume and reports "created".
+func TestReconcileVolume_CreateReportsCreated(t *testing.T) {
+	f := &volumeFakeRunner{writeCreated: true}
+	desired := intmodel.Volume{Metadata: intmodel.VolumeMetadata{Name: "data", Realm: "r1", Space: "s1"}}
+
+	res, err := apply.ReconcileVolume(f, desired)
+	if err != nil {
+		t.Fatalf("ReconcileVolume() error = %v", err)
+	}
+	if !f.writeCalled {
+		t.Errorf("WriteVolume was not called")
+	}
+	if res.Action != "created" {
+		t.Errorf("Action = %q, want created", res.Action)
+	}
+	if res.Kind != "Volume" {
+		t.Errorf("Kind = %q, want Volume", res.Kind)
+	}
+}
+
+// TestReconcileVolume_ReapplyReportsUpdated confirms a re-apply (WriteVolume
+// returns created=false) reports "updated" — the idempotency contract.
+func TestReconcileVolume_ReapplyReportsUpdated(t *testing.T) {
+	f := &volumeFakeRunner{writeCreated: false}
+	desired := intmodel.Volume{Metadata: intmodel.VolumeMetadata{Name: "data", Realm: "r1"}}
+
+	res, err := apply.ReconcileVolume(f, desired)
+	if err != nil {
+		t.Fatalf("ReconcileVolume() error = %v", err)
+	}
+	if res.Action != "updated" {
+		t.Errorf("Action = %q, want updated", res.Action)
+	}
+}
+
+// TestReconcileVolume_MissingScopeRejected confirms an unreachable scope is an
+// apply-time error and WriteVolume is never called — a Volume never auto-creates
+// its scope.
+func TestReconcileVolume_MissingScopeRejected(t *testing.T) {
+	f := &volumeFakeRunner{spaceErr: errdefs.ErrSpaceNotFound}
+	desired := intmodel.Volume{Metadata: intmodel.VolumeMetadata{Name: "data", Realm: "r1", Space: "missing"}}
+
+	_, err := apply.ReconcileVolume(f, desired)
+	if !errors.Is(err, errdefs.ErrVolumeScopeNotFound) {
+		t.Fatalf("ReconcileVolume() error = %v, want ErrVolumeScopeNotFound", err)
+	}
+	if f.writeCalled {
+		t.Errorf("WriteVolume must not be called when the scope is missing")
+	}
+}

--- a/internal/controller/controller_test.go
+++ b/internal/controller/controller_test.go
@@ -72,6 +72,12 @@ type fakeRunner struct {
 	ListBlueprintsFn  func(realmName, spaceName, stackName string) ([]intmodel.CellBlueprint, error)
 	DeleteBlueprintFn func(bp intmodel.CellBlueprint) error
 
+	// Volume methods
+	WriteVolumeFn  func(volume intmodel.Volume) (bool, error)
+	GetVolumeFn    func(volume intmodel.Volume) (intmodel.Volume, error)
+	ListVolumesFn  func(realmName, spaceName, stackName string) ([]intmodel.Volume, error)
+	DeleteVolumeFn func(volume intmodel.Volume) error
+
 	// Config methods
 	WriteConfigFn         func(config intmodel.CellConfig) (bool, error)
 	WriteConfigIfAbsentFn func(config intmodel.CellConfig) error
@@ -344,6 +350,36 @@ func (f *fakeRunner) DeleteBlueprint(bp intmodel.CellBlueprint) error {
 		return f.DeleteBlueprintFn(bp)
 	}
 	return errors.New("unexpected call to DeleteBlueprint")
+}
+
+// Volume methods
+
+func (f *fakeRunner) WriteVolume(volume intmodel.Volume) (bool, error) {
+	if f.WriteVolumeFn != nil {
+		return f.WriteVolumeFn(volume)
+	}
+	return false, errors.New("unexpected call to WriteVolume")
+}
+
+func (f *fakeRunner) GetVolume(volume intmodel.Volume) (intmodel.Volume, error) {
+	if f.GetVolumeFn != nil {
+		return f.GetVolumeFn(volume)
+	}
+	return intmodel.Volume{}, errors.New("unexpected call to GetVolume")
+}
+
+func (f *fakeRunner) ListVolumes(realmName, spaceName, stackName string) ([]intmodel.Volume, error) {
+	if f.ListVolumesFn != nil {
+		return f.ListVolumesFn(realmName, spaceName, stackName)
+	}
+	return nil, errors.New("unexpected call to ListVolumes")
+}
+
+func (f *fakeRunner) DeleteVolume(volume intmodel.Volume) error {
+	if f.DeleteVolumeFn != nil {
+		return f.DeleteVolumeFn(volume)
+	}
+	return errors.New("unexpected call to DeleteVolume")
 }
 
 // Config methods

--- a/internal/controller/documents.go
+++ b/internal/controller/documents.go
@@ -59,6 +59,14 @@ func SortDocumentsByKind(docs []parser.Document, reverse bool) []parser.Document
 	// exist). Evaluated after the CellBlueprint line so it lands one slot
 	// further out.
 	kindOrder[v1beta1.KindCellConfig] = len(kindOrder) + 1
+	// Volumes, like Secrets and CellBlueprints, target an existing scope
+	// (realm/space/stack) rather than creating one, so they sort after the
+	// hierarchy kinds: any scope bundled in the same apply file is materialized
+	// before a volume that targets it (reconcile rejects a volume whose scope
+	// does not yet exist). Evaluated after the CellConfig line so it lands one
+	// slot further out; the relative order among the scope-targeting kinds is
+	// immaterial since none reference another.
+	kindOrder[v1beta1.KindVolume] = len(kindOrder) + 1
 
 	// Sort by kind order, then by original index
 	sort.Slice(sorted, func(i, j int) bool {

--- a/internal/controller/runner/runner.go
+++ b/internal/controller/runner/runner.go
@@ -160,6 +160,29 @@ type Runner interface {
 	// errdefs.ErrBlueprintNotFound when the file is absent.
 	DeleteBlueprint(blueprint intmodel.CellBlueprint) error
 
+	// WriteVolume provisions a `kind: Volume`'s directory under the scope's
+	// metadata tree, root-owned and container-writable (issue #1018). Unlike the
+	// blueprint/secret writers — which write a single file — the resource is the
+	// directory itself, so MkdirAll is idempotent: re-applying re-asserts the
+	// mode/owner and reports created=false. The caller (ReconcileVolume) is
+	// responsible for having verified the scope exists.
+	WriteVolume(volume intmodel.Volume) (created bool, err error)
+	// GetVolume reports the metadata-only view of a single named, scoped
+	// `kind: Volume` and whether its directory exists on disk (issue #1018). A
+	// Volume carries no body, so the scope and name come from the path. Returns
+	// errdefs.ErrVolumeNotFound when the directory is absent.
+	GetVolume(volume intmodel.Volume) (intmodel.Volume, error)
+	// ListVolumes enumerates the metadata of every Volume bound to the filter
+	// scope or any scope nested within it (issue #1018). An empty realmName
+	// lists across all realms; the filter is a subtree prefix bounded at stack
+	// depth (a Volume is never cell-scoped). The returned carriers are
+	// metadata-only.
+	ListVolumes(realmName, spaceName, stackName string) ([]intmodel.Volume, error)
+	// DeleteVolume removes the daemon-provisioned directory for a single named,
+	// scoped Volume (issue #1018). Returns errdefs.ErrVolumeNotFound when the
+	// directory is absent.
+	DeleteVolume(volume intmodel.Volume) error
+
 	// WriteConfig persists a `kind: CellConfig`'s serialized document to the
 	// daemon-managed, root-owned, world-readable file under the scope's metadata
 	// tree (issue #624). Returns whether the file was newly created (vs.

--- a/internal/controller/runner/scope_children.go
+++ b/internal/controller/runner/scope_children.go
@@ -28,12 +28,13 @@ import (
 // reservedScopeSubdirs is the single source of truth for the per-scope
 // subdirectory names that hold resources (not child scopes) under
 // <RunPath>/data/<realm>/[<space>/[<stack>/[<cell>/]]]: secrets/ (#619),
-// blueprints/ (#620), and configs/ (#624). The subtree-list walkers in
-// secret.go / blueprint.go / config.go enumerate child scopes by reading the
-// scope dir and must skip every entry in this set, otherwise a reserved
-// resource subdir would be mistaken for a phantom space/stack/cell.
+// blueprints/ (#620), configs/ (#624), and volumes/ (#1018). The subtree-list
+// walkers in secret.go / blueprint.go / config.go / volume.go enumerate child
+// scopes by reading the scope dir and must skip every entry in this set,
+// otherwise a reserved resource subdir would be mistaken for a phantom
+// space/stack/cell.
 //
-// All three walkers consume this set via childScopeNames so a future reserved
+// All four walkers consume this set via childScopeNames so a future reserved
 // subdir is added in exactly one place — the inconsistency that motivated
 // issue #734 (blueprintChildScopeNames missed configs/, secret childScopeNames
 // missed blueprints/ and configs/) reappears the moment any walker
@@ -42,6 +43,7 @@ var reservedScopeSubdirs = map[string]struct{}{
 	consts.KukeonSecretsSubdir:    {},
 	consts.KukeonBlueprintsSubdir: {},
 	consts.KukeonConfigsSubdir:    {},
+	consts.KukeonVolumesSubdir:    {},
 }
 
 // childScopeNames returns the child-scope subdirectory names directly under

--- a/internal/controller/runner/volume.go
+++ b/internal/controller/runner/volume.go
@@ -1,0 +1,274 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package runner
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/eminwux/kukeon/internal/errdefs"
+	intmodel "github.com/eminwux/kukeon/internal/modelhub"
+	"github.com/eminwux/kukeon/internal/util/fs"
+)
+
+// volumesDirMode is the mode of the per-scope volumes/ container directory.
+// Root-owned and world-traversable (0o755), mirroring the blueprints/ dir: it
+// holds the per-volume directories but no data of its own, so a non-root party
+// only needs to traverse it to reach a volume it has been granted access to.
+const volumesDirMode os.FileMode = 0o755
+
+// volumeDirRootMode is the mode of an individual volume directory when the
+// kukeon group GID is configured: setgid + rwx for owner (root) and group
+// (kukeon), no world access. The setgid bit makes files a container creates
+// inside inherit the kukeon group, mirroring attachableTTYDirRootMode's
+// model — the directory is owned root:kukeon so the daemon and kuke-group
+// operators can manage it without exposing volume contents world-wide. The
+// mounting container's own uid is wired in at mount time in step 4 (#1016),
+// the same two-phase shape as attachablePostCreateChown.
+const volumeDirRootMode os.FileMode = os.ModeSetgid | 0o0770
+
+// volumeDirFallbackMode is the mode used when no kukeon group GID is
+// configured: rwx for owner (root) and group, no world access and no setgid
+// (there is no group to inherit). Mirrors attachableTTYDirInitialPerms's
+// gid==0 fallback.
+const volumeDirFallbackMode os.FileMode = 0o0770
+
+// volumeDirInitialPerms returns the (mode, gid) tuple to apply to a freshly
+// provisioned volume directory. When kukeonGroupGID is non-zero the directory
+// is root:kukeon with the setgid mode; otherwise it stays root:root without
+// setgid. Mirrors attachableTTYDirInitialPerms (issue #1018, #1016).
+func volumeDirInitialPerms(kukeonGroupGID int) (os.FileMode, int) {
+	if kukeonGroupGID > 0 {
+		return volumeDirRootMode, kukeonGroupGID
+	}
+	return volumeDirFallbackMode, 0
+}
+
+// WriteVolume provisions a Volume's directory at
+// <RunPath>/data/<scope>/volumes/<name>, root-owned and container-writable
+// (issue #1018). The per-scope volumes/ container dir is created world-
+// traversable; the volume dir itself is created setgid root:kukeon (group-
+// writable) when the kukeon GID is configured, root:root 0o770 otherwise.
+// MkdirAll is idempotent, so re-applying an existing volume re-asserts the
+// mode/owner and reports created=false. The caller (ReconcileVolume) is
+// responsible for having verified the scope exists.
+func (r *Exec) WriteVolume(volume intmodel.Volume) (bool, error) {
+	md := volume.Metadata
+	dir := fs.VolumesDir(r.opts.RunPath, md.Realm, md.Space, md.Stack)
+	path := fs.VolumePath(r.opts.RunPath, md.Realm, md.Space, md.Stack, md.Name)
+
+	if err := os.MkdirAll(dir, volumesDirMode); err != nil {
+		return false, fmt.Errorf("%w: create volumes dir: %w", errdefs.ErrWriteVolume, err)
+	}
+	// MkdirAll honors only the rwx bits and leaves a pre-existing directory's
+	// mode intact; chmod unconditionally so the world-traversable contract
+	// holds even when a parent created the dir with tighter bits or the umask
+	// stripped them.
+	if err := os.Chmod(dir, volumesDirMode); err != nil {
+		return false, fmt.Errorf("%w: chmod volumes dir: %w", errdefs.ErrWriteVolume, err)
+	}
+
+	info, statErr := os.Stat(path)
+	created := errors.Is(statErr, os.ErrNotExist)
+	if statErr != nil && !created {
+		return false, fmt.Errorf("%w: stat volume: %w", errdefs.ErrWriteVolume, statErr)
+	}
+	if statErr == nil && !info.IsDir() {
+		// A non-directory squatting on the volume path is a corrupt state, not
+		// a volume — refuse rather than chmod a stray file into place.
+		return false, fmt.Errorf("%w: %q exists and is not a directory", errdefs.ErrWriteVolume, path)
+	}
+
+	mode, gid := volumeDirInitialPerms(r.opts.KukeonGroupGID)
+	if err := os.MkdirAll(path, mode); err != nil {
+		return false, fmt.Errorf("%w: create volume dir: %w", errdefs.ErrWriteVolume, err)
+	}
+	// MkdirAll masks the setgid bit and honors the umask, so chmod the full
+	// mode (setgid included) unconditionally to assert the contract.
+	if err := os.Chmod(path, mode); err != nil {
+		return false, fmt.Errorf("%w: chmod volume dir: %w", errdefs.ErrWriteVolume, err)
+	}
+	if gid > 0 {
+		if err := os.Chown(path, 0, gid); err != nil {
+			return false, fmt.Errorf("%w: chown volume dir to root:%d: %w", errdefs.ErrWriteVolume, gid, err)
+		}
+	}
+
+	action := "updated"
+	if created {
+		action = "created"
+	}
+	r.logger.InfoContext(r.ctx, "volume "+action,
+		"name", md.Name,
+		"realm", md.Realm,
+		"space", md.Space,
+		"stack", md.Stack,
+	)
+	return created, nil
+}
+
+// GetVolume reports whether a single named, scoped Volume exists on disk and
+// returns its metadata-only view (issue #1018). Like GetSecret the scope and
+// name come from the path, not from any stored document — a Volume carries no
+// body. Returns errdefs.ErrVolumeNotFound when the directory is absent, or when
+// a non-directory occupies the path (which is not a volume).
+func (r *Exec) GetVolume(volume intmodel.Volume) (intmodel.Volume, error) {
+	md := volume.Metadata
+	path := fs.VolumePath(r.opts.RunPath, md.Realm, md.Space, md.Stack, md.Name)
+
+	info, err := os.Stat(path)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return intmodel.Volume{}, errdefs.ErrVolumeNotFound
+		}
+		return intmodel.Volume{}, fmt.Errorf("%w: %w", errdefs.ErrGetVolume, err)
+	}
+	if !info.IsDir() {
+		return intmodel.Volume{}, errdefs.ErrVolumeNotFound
+	}
+
+	return intmodel.Volume{Metadata: md}, nil
+}
+
+// ListVolumes enumerates the metadata of every Volume bound to the scope
+// identified by the filter coordinates, plus every Volume bound to a deeper
+// scope nested within it (issue #1018). The filter is a prefix: an empty
+// realmName lists across all realms; a set realmName with an empty spaceName
+// lists realm-scoped volumes and everything under that realm; and so on. This
+// mirrors ListBlueprints's subtree-filter semantics, bounded at stack depth — a
+// Volume is never cell-scoped. Each entry under a volumes/ dir is itself a
+// directory (the volume), so the walk collects directories and the metadata is
+// the scope coordinates (from the path) plus the directory name.
+func (r *Exec) ListVolumes(realmName, spaceName, stackName string) ([]intmodel.Volume, error) {
+	realmDirs, err := r.resolveRealmDirs(realmName)
+	if err != nil {
+		return nil, fmt.Errorf("%w: %w", errdefs.ErrListVolumes, err)
+	}
+
+	var out []intmodel.Volume
+	for _, realmDir := range realmDirs {
+		realm := filepath.Base(realmDir)
+		if walkErr := r.collectVolumeSubtree(&out, realm, spaceName, stackName); walkErr != nil {
+			return nil, fmt.Errorf("%w: %w", errdefs.ErrListVolumes, walkErr)
+		}
+	}
+	return out, nil
+}
+
+// collectVolumeSubtree appends the metadata of every Volume bound to scope
+// (realm, space, stack) — where a trailing coordinate that is "" marks the
+// filter floor — and every Volume in scopes nested within it. The rule mirrors
+// collectBlueprintSubtree: collect a level's own volumes only when the
+// next-deeper filter coordinate is empty, and descend into a child only when it
+// matches a set filter coordinate or the filter is empty at that level. The
+// walk is bounded at stack depth, so cell directories are never descended.
+func (r *Exec) collectVolumeSubtree(out *[]intmodel.Volume, realm, space, stack string) error {
+	if space == "" {
+		if err := r.collectVolumesInScope(out, realm, "", ""); err != nil {
+			return err
+		}
+	}
+
+	spaces, err := r.childScopeNames(fs.RealmMetadataDir(r.opts.RunPath, realm), space)
+	if err != nil {
+		return err
+	}
+	for _, sp := range spaces {
+		if stack == "" {
+			if err = r.collectVolumesInScope(out, realm, sp, ""); err != nil {
+				return err
+			}
+		}
+
+		stacks, stErr := r.childScopeNames(fs.SpaceMetadataDir(r.opts.RunPath, realm, sp), stack)
+		if stErr != nil {
+			return stErr
+		}
+		for _, st := range stacks {
+			if err = r.collectVolumesInScope(out, realm, sp, st); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+// collectVolumesInScope appends the metadata of every Volume stored directly at
+// the given scope (realm, space, stack). Unlike the blueprint/secret collectors
+// — which skip directories because each resource is a file — a volume *is* a
+// directory, so non-directory entries (none are written by WriteVolume) are
+// skipped instead.
+func (r *Exec) collectVolumesInScope(out *[]intmodel.Volume, realm, space, stack string) error {
+	dir := fs.VolumesDir(r.opts.RunPath, realm, space, stack)
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return fmt.Errorf("failed to read volumes dir %q: %w", dir, err)
+	}
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+		*out = append(*out, intmodel.Volume{
+			Metadata: intmodel.VolumeMetadata{
+				Name:  entry.Name(),
+				Realm: realm,
+				Space: space,
+				Stack: stack,
+			},
+		})
+	}
+	return nil
+}
+
+// DeleteVolume removes the daemon-provisioned directory for a single named,
+// scoped Volume (issue #1018). Returns errdefs.ErrVolumeNotFound when the
+// directory is absent so the caller can report a clear "not found" instead of a
+// silent success. Uses RemoveAll (the volume is a directory that may hold
+// container-written contents), gated on a prior stat so a missing volume still
+// surfaces NotFound rather than RemoveAll's silent nil.
+func (r *Exec) DeleteVolume(volume intmodel.Volume) error {
+	md := volume.Metadata
+	path := fs.VolumePath(r.opts.RunPath, md.Realm, md.Space, md.Stack, md.Name)
+
+	info, err := os.Stat(path)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return errdefs.ErrVolumeNotFound
+		}
+		return fmt.Errorf("%w: stat volume: %w", errdefs.ErrDeleteVolume, err)
+	}
+	if !info.IsDir() {
+		return errdefs.ErrVolumeNotFound
+	}
+
+	if err := os.RemoveAll(path); err != nil {
+		return fmt.Errorf("%w: %w", errdefs.ErrDeleteVolume, err)
+	}
+
+	r.logger.InfoContext(r.ctx, "volume deleted",
+		"name", md.Name,
+		"realm", md.Realm,
+		"space", md.Space,
+		"stack", md.Stack,
+	)
+	return nil
+}

--- a/internal/controller/runner/volume_test.go
+++ b/internal/controller/runner/volume_test.go
@@ -1,0 +1,319 @@
+//go:build !integration
+
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+//nolint:testpackage // tests the unexported WriteVolume path against a temp RunPath
+package runner
+
+import (
+	"errors"
+	"os"
+	"sort"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/eminwux/kukeon/internal/errdefs"
+	intmodel "github.com/eminwux/kukeon/internal/modelhub"
+	"github.com/eminwux/kukeon/internal/util/fs"
+)
+
+// TestWriteVolume_CreatesContainerWritableDir pins the issue #1018 storage
+// contract: the volume lands at <RunPath>/data/<scope>/volumes/<name> as a
+// directory (not a file), the per-scope volumes/ container dir is 0o755
+// (world-traversable), the volume dir itself is group-writable (0o770 in the
+// no-kukeon-group fallback the test Exec uses), and the first write reports
+// created=true.
+func TestWriteVolume_CreatesContainerWritableDir(t *testing.T) {
+	runPath := t.TempDir()
+	r := newMetadataTestExec(t, runPath, time.Now())
+
+	vol := intmodel.Volume{
+		Metadata: intmodel.VolumeMetadata{Name: "data", Realm: "default"},
+	}
+
+	created, err := r.WriteVolume(vol)
+	if err != nil {
+		t.Fatalf("WriteVolume() error = %v", err)
+	}
+	if !created {
+		t.Errorf("created = false, want true on first write")
+	}
+
+	path := fs.VolumePath(runPath, "default", "", "", "data")
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat volume dir: %v", err)
+	}
+	if !info.IsDir() {
+		t.Errorf("volume path is not a directory")
+	}
+	if perm := info.Mode().Perm(); perm != 0o770 {
+		t.Errorf("volume dir mode = %o, want 770 (group-writable, no world access)", perm)
+	}
+
+	dirInfo, err := os.Stat(fs.VolumesDir(runPath, "default", "", ""))
+	if err != nil {
+		t.Fatalf("stat volumes dir: %v", err)
+	}
+	if perm := dirInfo.Mode().Perm(); perm != 0o755 {
+		t.Errorf("volumes/ container dir mode = %o, want 755 (world-traversable)", perm)
+	}
+}
+
+// TestWriteVolume_OverwriteReportsUpdated confirms a re-apply of an existing
+// volume is idempotent (the directory persists) and reports created=false.
+func TestWriteVolume_OverwriteReportsUpdated(t *testing.T) {
+	runPath := t.TempDir()
+	r := newMetadataTestExec(t, runPath, time.Now())
+
+	vol := intmodel.Volume{Metadata: intmodel.VolumeMetadata{Name: "data", Realm: "default"}}
+
+	if _, err := r.WriteVolume(vol); err != nil {
+		t.Fatalf("first WriteVolume() error = %v", err)
+	}
+	// Write a sentinel file inside the volume to prove the re-apply does not
+	// wipe container-written contents.
+	sentinel := fs.VolumePath(runPath, "default", "", "", "data") + "/keep"
+	if err := os.WriteFile(sentinel, []byte("x"), 0o644); err != nil {
+		t.Fatalf("write sentinel: %v", err)
+	}
+
+	created, err := r.WriteVolume(vol)
+	if err != nil {
+		t.Fatalf("second WriteVolume() error = %v", err)
+	}
+	if created {
+		t.Errorf("created = true on re-apply, want false")
+	}
+	if _, err := os.Stat(sentinel); err != nil {
+		t.Errorf("re-apply wiped container contents: %v", err)
+	}
+}
+
+// TestWriteVolume_RejectsNonDirectorySquatter confirms a stray file at the
+// volume path is refused rather than silently treated as a volume.
+func TestWriteVolume_RejectsNonDirectorySquatter(t *testing.T) {
+	runPath := t.TempDir()
+	r := newMetadataTestExec(t, runPath, time.Now())
+
+	dir := fs.VolumesDir(runPath, "default", "", "")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir volumes dir: %v", err)
+	}
+	if err := os.WriteFile(fs.VolumePath(runPath, "default", "", "", "data"), []byte("x"), 0o644); err != nil {
+		t.Fatalf("write squatter file: %v", err)
+	}
+
+	_, err := r.WriteVolume(intmodel.Volume{Metadata: intmodel.VolumeMetadata{Name: "data", Realm: "default"}})
+	if !errors.Is(err, errdefs.ErrWriteVolume) {
+		t.Errorf("WriteVolume() over a non-dir = %v, want ErrWriteVolume", err)
+	}
+}
+
+// TestGetVolume_RoundTrip confirms WriteVolume then GetVolume returns the same
+// scope+name metadata, and that an absent volume reports ErrVolumeNotFound.
+func TestGetVolume_RoundTrip(t *testing.T) {
+	runPath := t.TempDir()
+	r := newMetadataTestExec(t, runPath, time.Now())
+
+	md := intmodel.VolumeMetadata{Name: "data", Realm: "r1", Space: "s1", Stack: "st1"}
+	if _, err := r.WriteVolume(intmodel.Volume{Metadata: md}); err != nil {
+		t.Fatalf("WriteVolume() error = %v", err)
+	}
+
+	got, err := r.GetVolume(intmodel.Volume{Metadata: md})
+	if err != nil {
+		t.Fatalf("GetVolume() error = %v", err)
+	}
+	if got.Metadata != md {
+		t.Errorf("GetVolume() metadata = %+v, want %+v", got.Metadata, md)
+	}
+
+	_, err = r.GetVolume(intmodel.Volume{Metadata: intmodel.VolumeMetadata{Name: "missing", Realm: "r1"}})
+	if !errors.Is(err, errdefs.ErrVolumeNotFound) {
+		t.Errorf("GetVolume(missing) = %v, want ErrVolumeNotFound", err)
+	}
+}
+
+// TestListVolumes_SubtreeFilter confirms the prefix-filter semantics: a
+// realm-scoped listing surfaces volumes bound to the realm and every deeper
+// scope nested within it, matching the ListBlueprints contract.
+func TestListVolumes_SubtreeFilter(t *testing.T) {
+	runPath := t.TempDir()
+	r := newMetadataTestExec(t, runPath, time.Now())
+
+	mds := []intmodel.VolumeMetadata{
+		{Name: "realm-vol", Realm: "r1"},
+		{Name: "space-vol", Realm: "r1", Space: "s1"},
+		{Name: "stack-vol", Realm: "r1", Space: "s1", Stack: "st1"},
+		{Name: "other-realm", Realm: "r2"},
+	}
+	for _, md := range mds {
+		if _, err := r.WriteVolume(intmodel.Volume{Metadata: md}); err != nil {
+			t.Fatalf("WriteVolume(%q) error = %v", md.Name, err)
+		}
+	}
+
+	got, err := r.ListVolumes("r1", "", "")
+	if err != nil {
+		t.Fatalf("ListVolumes() error = %v", err)
+	}
+	names := make([]string, 0, len(got))
+	for _, v := range got {
+		names = append(names, v.Metadata.Name)
+	}
+	sort.Strings(names)
+	want := []string{"realm-vol", "space-vol", "stack-vol"}
+	if strings.Join(names, ",") != strings.Join(want, ",") {
+		t.Errorf("ListVolumes(r1) names = %v, want %v (r2's volume must not surface)", names, want)
+	}
+}
+
+// TestDeleteVolume_RemovesDirAndReportsNotFound confirms DeleteVolume removes
+// the directory (and any container-written contents) and reports
+// ErrVolumeNotFound for an absent volume.
+func TestDeleteVolume_RemovesDirAndReportsNotFound(t *testing.T) {
+	runPath := t.TempDir()
+	r := newMetadataTestExec(t, runPath, time.Now())
+
+	md := intmodel.VolumeMetadata{Name: "data", Realm: "default"}
+	if _, err := r.WriteVolume(intmodel.Volume{Metadata: md}); err != nil {
+		t.Fatalf("WriteVolume() error = %v", err)
+	}
+	path := fs.VolumePath(runPath, "default", "", "", "data")
+	if err := os.WriteFile(path+"/keep", []byte("x"), 0o644); err != nil {
+		t.Fatalf("write content: %v", err)
+	}
+
+	if err := r.DeleteVolume(intmodel.Volume{Metadata: md}); err != nil {
+		t.Fatalf("DeleteVolume() error = %v", err)
+	}
+	if _, err := os.Stat(path); !errors.Is(err, os.ErrNotExist) {
+		t.Errorf("volume dir still present after delete: stat err = %v", err)
+	}
+
+	if err := r.DeleteVolume(intmodel.Volume{Metadata: md}); !errors.Is(err, errdefs.ErrVolumeNotFound) {
+		t.Errorf("DeleteVolume(absent) = %v, want ErrVolumeNotFound", err)
+	}
+}
+
+// TestVolume_ReclaimedByScopeCascade pins the AC's implicit-reclaim invariant
+// (issue #1018): a volume's directory lives *inside* its owning scope's
+// metadata dir, so the same os.RemoveAll that `purge stack/space/realm
+// --cascade` already runs on the scope metadata dir
+// (internal/controller/runner/purge_stack.go:120, purge_space.go:112,
+// purge_realm.go:181) reclaims the volume with no new mechanism. The test
+// asserts containment structurally, then drives the exact RemoveAll the purge
+// paths use and confirms the volume is gone.
+func TestVolume_ReclaimedByScopeCascade(t *testing.T) {
+	cases := []struct {
+		name      string
+		md        intmodel.VolumeMetadata
+		scopeDir  func(runPath string) string
+		otherKept intmodel.VolumeMetadata // a volume outside the purged scope
+	}{
+		{
+			name: "stack",
+			md:   intmodel.VolumeMetadata{Name: "data", Realm: "r1", Space: "s1", Stack: "st1"},
+			scopeDir: func(runPath string) string {
+				return fs.StackMetadataDir(runPath, "r1", "s1", "st1")
+			},
+			otherKept: intmodel.VolumeMetadata{Name: "data", Realm: "r1", Space: "s1"},
+		},
+		{
+			name: "space",
+			md:   intmodel.VolumeMetadata{Name: "data", Realm: "r1", Space: "s1"},
+			scopeDir: func(runPath string) string {
+				return fs.SpaceMetadataDir(runPath, "r1", "s1")
+			},
+			otherKept: intmodel.VolumeMetadata{Name: "data", Realm: "r1"},
+		},
+		{
+			name: "realm",
+			md:   intmodel.VolumeMetadata{Name: "data", Realm: "r1"},
+			scopeDir: func(runPath string) string {
+				return fs.RealmMetadataDir(runPath, "r1")
+			},
+			otherKept: intmodel.VolumeMetadata{Name: "data", Realm: "r2"},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			runPath := t.TempDir()
+			r := newMetadataTestExec(t, runPath, time.Now())
+
+			if _, err := r.WriteVolume(intmodel.Volume{Metadata: tc.md}); err != nil {
+				t.Fatalf("WriteVolume(target) error = %v", err)
+			}
+			if _, err := r.WriteVolume(intmodel.Volume{Metadata: tc.otherKept}); err != nil {
+				t.Fatalf("WriteVolume(other) error = %v", err)
+			}
+
+			volPath := fs.VolumePath(runPath, tc.md.Realm, tc.md.Space, tc.md.Stack, tc.md.Name)
+			scopeDir := tc.scopeDir(runPath)
+			if !strings.HasPrefix(volPath, scopeDir+string(os.PathSeparator)) {
+				t.Fatalf("volume %q is not under its scope dir %q — cascade purge would not reclaim it", volPath, scopeDir)
+			}
+
+			// The exact reclaim the three purge paths perform.
+			if err := os.RemoveAll(scopeDir); err != nil {
+				t.Fatalf("RemoveAll(scopeDir) error = %v", err)
+			}
+
+			if _, err := os.Stat(volPath); !errors.Is(err, os.ErrNotExist) {
+				t.Errorf("volume survived scope cascade reclaim: stat err = %v", err)
+			}
+			// A volume outside the purged scope must be untouched.
+			otherPath := fs.VolumePath(runPath, tc.otherKept.Realm, tc.otherKept.Space, tc.otherKept.Stack, tc.otherKept.Name)
+			if _, err := os.Stat(otherPath); err != nil {
+				t.Errorf("volume outside purged scope was reclaimed: %v", err)
+			}
+		})
+	}
+}
+
+// TestVolumeDirInitialPerms pins the two-mode ownership choice (issue #1018):
+// when a kukeon group GID is configured the volume dir is setgid root:kukeon
+// (group-writable, files inside inherit the group — mirroring
+// attachableTTYDirInitialPerms); otherwise it is root:root 0o770 with no
+// setgid. The syscall-free pure function is asserted directly so the gid>0
+// branch is covered without a root-only chown.
+func TestVolumeDirInitialPerms(t *testing.T) {
+	mode, gid := volumeDirInitialPerms(4242)
+	if gid != 4242 {
+		t.Errorf("gid = %d, want 4242", gid)
+	}
+	if mode != volumeDirRootMode {
+		t.Errorf("mode = %v, want %v (setgid root:kukeon)", mode, volumeDirRootMode)
+	}
+	if mode&os.ModeSetgid == 0 {
+		t.Errorf("configured-gid mode missing setgid bit: %v", mode)
+	}
+
+	mode, gid = volumeDirInitialPerms(0)
+	if gid != 0 {
+		t.Errorf("fallback gid = %d, want 0", gid)
+	}
+	if mode != volumeDirFallbackMode {
+		t.Errorf("fallback mode = %v, want %v", mode, volumeDirFallbackMode)
+	}
+	if mode&os.ModeSetgid != 0 {
+		t.Errorf("fallback mode must not set setgid: %v", mode)
+	}
+}

--- a/internal/controller/runner/volume_test.go
+++ b/internal/controller/runner/volume_test.go
@@ -317,3 +317,31 @@ func TestVolumeDirInitialPerms(t *testing.T) {
 		t.Errorf("fallback mode must not set setgid: %v", mode)
 	}
 }
+
+// TestVolume_NotMistakenForChildScope confirms a scope's volumes/ subdir is in
+// the shared reservedScopeSubdirs set, so no childScopeNames consumer mistakes
+// it for a phantom child space/stack. A realm-scoped volume creates
+// default/volumes/; ListBlueprints walks the realm subtree via childScopeNames
+// and must not recurse into volumes/ as a phantom space (which would read the
+// daemon into the container-writable volume tree). Same invariant the configs/
+// omission tripped in #734 — exercised here for the volumes/ subdir added in
+// #1018.
+func TestVolume_NotMistakenForChildScope(t *testing.T) {
+	runPath := t.TempDir()
+	r := newMetadataTestExec(t, runPath, time.Now())
+
+	seedBlueprint(t, r, "realm-bp", "default", "", "")
+	// A realm-scoped volume creates default/volumes/; it must not surface as a
+	// child space when the blueprint walker enumerates the realm subtree.
+	if _, err := r.WriteVolume(intmodel.Volume{
+		Metadata: intmodel.VolumeMetadata{Name: "data", Realm: "default"},
+	}); err != nil {
+		t.Fatalf("seed WriteVolume error = %v", err)
+	}
+
+	got := listedKeys(t, r, "", "", "")
+	want := []string{"default///realm-bp"}
+	if !equalStrings(got, want) {
+		t.Errorf("ListBlueprints(all) = %v, want %v (volumes/ subdir must be ignored, not traversed as a phantom space)", got, want)
+	}
+}

--- a/internal/controller/volume.go
+++ b/internal/controller/volume.go
@@ -1,0 +1,141 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package controller
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/eminwux/kukeon/internal/errdefs"
+	intmodel "github.com/eminwux/kukeon/internal/modelhub"
+)
+
+// GetVolumeResult reports the metadata-only view of a single `kind: Volume`
+// (issue #1018). A Volume carries no body, so this is scope coordinates and
+// name only — the same metadata-only shape as GetSecretResult.
+type GetVolumeResult struct {
+	Volume         intmodel.Volume
+	MetadataExists bool
+}
+
+// GetVolume reports whether one named, scoped Volume exists. The scope
+// coordinates are validated for completeness (a deeper coordinate requires
+// every shallower one; a Volume may not be cell-scoped); realm and name are
+// mandatory. Returns MetadataExists=false (no error) when the volume is absent,
+// mirroring GetBlueprint's "report, don't error on not-found" shape.
+func (b *Exec) GetVolume(volume intmodel.Volume) (GetVolumeResult, error) {
+	var res GetVolumeResult
+
+	if err := validateVolumeLookup(volume.Metadata); err != nil {
+		return res, err
+	}
+
+	got, err := b.runner.GetVolume(volume)
+	if err != nil {
+		if errors.Is(err, errdefs.ErrVolumeNotFound) {
+			res.MetadataExists = false
+			return res, nil
+		}
+		return res, fmt.Errorf("%w: %w", errdefs.ErrGetVolume, err)
+	}
+
+	res.MetadataExists = true
+	res.Volume = got
+	return res, nil
+}
+
+// ListVolumes lists the metadata of every Volume bound to the filter scope or
+// any scope nested within it (issue #1018). An empty realm lists across all
+// realms; the filter coordinates must still be contiguous (no gap below a set
+// level), and — a Volume never being cell-scoped — there is no cell coordinate.
+func (b *Exec) ListVolumes(realmName, spaceName, stackName string) ([]intmodel.Volume, error) {
+	if err := validateVolumeScopeFilter(realmName, spaceName, stackName); err != nil {
+		return nil, err
+	}
+	return b.runner.ListVolumes(
+		strings.TrimSpace(realmName),
+		strings.TrimSpace(spaceName),
+		strings.TrimSpace(stackName),
+	)
+}
+
+// DeleteVolumeResult reports the outcome of removing a single Volume's
+// daemon-provisioned directory.
+type DeleteVolumeResult struct {
+	Volume  intmodel.Volume
+	Deleted bool
+}
+
+// DeleteVolume removes a single named, scoped Volume's daemon-provisioned
+// directory. Returns a "not found" error when the volume does not exist,
+// matching the DeleteBlueprint contract. There is no live-reference gate in
+// step 1: the container-side mount kind that would reference a Volume lands in
+// step 4 (#1016), where the delete gate against a live mount is exercised.
+func (b *Exec) DeleteVolume(volume intmodel.Volume) (DeleteVolumeResult, error) {
+	var res DeleteVolumeResult
+
+	if err := validateVolumeLookup(volume.Metadata); err != nil {
+		return res, err
+	}
+
+	if err := b.runner.DeleteVolume(volume); err != nil {
+		if errors.Is(err, errdefs.ErrVolumeNotFound) {
+			return res, fmt.Errorf("volume %q not found", volume.Metadata.Name)
+		}
+		return res, fmt.Errorf("%w: %w", errdefs.ErrDeleteVolume, err)
+	}
+
+	res.Deleted = true
+	res.Volume = volume
+	return res, nil
+}
+
+// validateVolumeLookup enforces the scope contract for a single-volume get or
+// delete: name and realm are mandatory and the scope coordinates must be
+// contiguous, with the Volume-specific rule that a cell coordinate is never
+// valid (a Volume is realm/space/stack-scoped only).
+func validateVolumeLookup(md intmodel.VolumeMetadata) error {
+	if strings.TrimSpace(md.Name) == "" {
+		return errdefs.ErrVolumeNameRequired
+	}
+	if strings.TrimSpace(md.Realm) == "" {
+		return errdefs.ErrVolumeRealmRequired
+	}
+	if strings.TrimSpace(md.Stack) != "" && strings.TrimSpace(md.Space) == "" {
+		return fmt.Errorf("%w (stack set without space)", errdefs.ErrVolumeScopeIncomplete)
+	}
+	return nil
+}
+
+// validateVolumeScopeFilter enforces the scope contract for a list filter:
+// realm is optional (an empty realm lists across all realms), but a set deeper
+// coordinate still requires every shallower one. A Volume is never cell-scoped,
+// so the filter bottoms out at stack.
+func validateVolumeScopeFilter(realm, space, stack string) error {
+	realm = strings.TrimSpace(realm)
+	space = strings.TrimSpace(space)
+	stack = strings.TrimSpace(stack)
+
+	if realm == "" && (space != "" || stack != "") {
+		return fmt.Errorf("%w (scope set without realm)", errdefs.ErrVolumeScopeIncomplete)
+	}
+	if stack != "" && space == "" {
+		return fmt.Errorf("%w (stack set without space)", errdefs.ErrVolumeScopeIncomplete)
+	}
+	return nil
+}

--- a/internal/controller/volume_test.go
+++ b/internal/controller/volume_test.go
@@ -1,0 +1,189 @@
+//go:build !integration
+
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package controller_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/eminwux/kukeon/internal/apply/parser"
+	"github.com/eminwux/kukeon/internal/errdefs"
+	intmodel "github.com/eminwux/kukeon/internal/modelhub"
+	v1beta1 "github.com/eminwux/kukeon/pkg/api/model/v1beta1"
+)
+
+// TestGetVolume_ReportsNotFoundWithoutError pins the GetBlueprint-shaped
+// contract: an absent volume yields MetadataExists=false and a nil error.
+func TestGetVolume_ReportsNotFoundWithoutError(t *testing.T) {
+	mockRunner := &fakeRunner{
+		GetVolumeFn: func(intmodel.Volume) (intmodel.Volume, error) {
+			return intmodel.Volume{}, errdefs.ErrVolumeNotFound
+		},
+	}
+	ctrl := setupTestController(t, mockRunner)
+
+	res, err := ctrl.GetVolume(intmodel.Volume{
+		Metadata: intmodel.VolumeMetadata{Name: "data", Realm: "default"},
+	})
+	if err != nil {
+		t.Fatalf("GetVolume() error = %v, want nil", err)
+	}
+	if res.MetadataExists {
+		t.Errorf("MetadataExists = true, want false for absent volume")
+	}
+}
+
+// TestGetVolume_ReturnsMetadata confirms a present volume surfaces its
+// metadata-only view.
+func TestGetVolume_ReturnsMetadata(t *testing.T) {
+	mockRunner := &fakeRunner{
+		GetVolumeFn: func(v intmodel.Volume) (intmodel.Volume, error) {
+			return intmodel.Volume{Metadata: v.Metadata}, nil
+		},
+	}
+	ctrl := setupTestController(t, mockRunner)
+
+	res, err := ctrl.GetVolume(intmodel.Volume{
+		Metadata: intmodel.VolumeMetadata{Name: "data", Realm: "default"},
+	})
+	if err != nil {
+		t.Fatalf("GetVolume() error = %v", err)
+	}
+	if !res.MetadataExists {
+		t.Fatalf("MetadataExists = false, want true")
+	}
+	if res.Volume.Metadata.Name != "data" {
+		t.Errorf("name = %q, want data", res.Volume.Metadata.Name)
+	}
+}
+
+// TestGetVolume_NameRequired confirms the lookup scope guard fires before the
+// runner is touched.
+func TestGetVolume_NameRequired(t *testing.T) {
+	ctrl := setupTestController(t, &fakeRunner{})
+	_, err := ctrl.GetVolume(intmodel.Volume{Metadata: intmodel.VolumeMetadata{Realm: "default"}})
+	if !errors.Is(err, errdefs.ErrVolumeNameRequired) {
+		t.Errorf("GetVolume(no name) = %v, want ErrVolumeNameRequired", err)
+	}
+}
+
+// TestDeleteVolume_NotFound confirms an absent volume surfaces a clear "not
+// found" error rather than a silent success.
+func TestDeleteVolume_NotFound(t *testing.T) {
+	mockRunner := &fakeRunner{
+		DeleteVolumeFn: func(intmodel.Volume) error { return errdefs.ErrVolumeNotFound },
+	}
+	ctrl := setupTestController(t, mockRunner)
+
+	res, err := ctrl.DeleteVolume(intmodel.Volume{
+		Metadata: intmodel.VolumeMetadata{Name: "data", Realm: "default"},
+	})
+	if err == nil {
+		t.Fatalf("DeleteVolume(absent) error = nil, want not-found")
+	}
+	if res.Deleted {
+		t.Errorf("Deleted = true for absent volume")
+	}
+}
+
+// TestDeleteVolume_Success confirms a present volume is removed and reported.
+func TestDeleteVolume_Success(t *testing.T) {
+	mockRunner := &fakeRunner{
+		DeleteVolumeFn: func(intmodel.Volume) error { return nil },
+	}
+	ctrl := setupTestController(t, mockRunner)
+
+	res, err := ctrl.DeleteVolume(intmodel.Volume{
+		Metadata: intmodel.VolumeMetadata{Name: "data", Realm: "default"},
+	})
+	if err != nil {
+		t.Fatalf("DeleteVolume() error = %v", err)
+	}
+	if !res.Deleted {
+		t.Errorf("Deleted = false, want true")
+	}
+}
+
+// TestListVolumes_FilterGuard confirms a gap in the scope filter (space set
+// without realm) is rejected before the runner is touched.
+func TestListVolumes_FilterGuard(t *testing.T) {
+	ctrl := setupTestController(t, &fakeRunner{})
+	_, err := ctrl.ListVolumes("", "agents", "")
+	if !errors.Is(err, errdefs.ErrVolumeScopeIncomplete) {
+		t.Errorf("ListVolumes(space without realm) = %v, want ErrVolumeScopeIncomplete", err)
+	}
+}
+
+// TestListVolumes_PassesThrough confirms a valid filter reaches the runner and
+// returns its result.
+func TestListVolumes_PassesThrough(t *testing.T) {
+	mockRunner := &fakeRunner{
+		ListVolumesFn: func(realm, _, _ string) ([]intmodel.Volume, error) {
+			return []intmodel.Volume{{Metadata: intmodel.VolumeMetadata{Name: "data", Realm: realm}}}, nil
+		},
+	}
+	ctrl := setupTestController(t, mockRunner)
+
+	got, err := ctrl.ListVolumes("default", "", "")
+	if err != nil {
+		t.Fatalf("ListVolumes() error = %v", err)
+	}
+	if len(got) != 1 || got[0].Metadata.Name != "data" {
+		t.Errorf("ListVolumes() = %+v, want one volume named data", got)
+	}
+}
+
+// TestApplyDocuments_VolumeRoutesToReconcile pins the AC end-to-end: a parsed
+// `kind: Volume` document routes through ApplyDocuments → ReconcileVolume →
+// WriteVolume and surfaces a "created" resource result.
+func TestApplyDocuments_VolumeRoutesToReconcile(t *testing.T) {
+	var wrote []intmodel.Volume
+	mock := &fakeRunner{
+		GetRealmFn: func(r intmodel.Realm) (intmodel.Realm, error) { return r, nil },
+		GetSpaceFn: func(s intmodel.Space) (intmodel.Space, error) { return s, nil },
+		GetStackFn: func(s intmodel.Stack) (intmodel.Stack, error) { return s, nil },
+		WriteVolumeFn: func(v intmodel.Volume) (bool, error) {
+			wrote = append(wrote, v)
+			return true, nil
+		},
+	}
+	exec := setupTestController(t, mock)
+
+	docs := []parser.Document{
+		{
+			Kind: v1beta1.KindVolume,
+			VolumeDoc: &v1beta1.VolumeDoc{
+				APIVersion: v1beta1.APIVersionV1Beta1,
+				Kind:       v1beta1.KindVolume,
+				Metadata:   v1beta1.VolumeMetadata{Name: "data", Realm: "default", Space: "agents"},
+			},
+		},
+	}
+
+	result, err := exec.ApplyDocuments(docs, "")
+	if err != nil {
+		t.Fatalf("ApplyDocuments() error = %v", err)
+	}
+	if len(wrote) != 1 || wrote[0].Metadata.Name != "data" {
+		t.Fatalf("WriteVolume calls = %+v, want one volume named data", wrote)
+	}
+	if len(result.Resources) != 1 || result.Resources[0].Action != "created" {
+		t.Errorf("apply result = %+v, want one created Volume", result.Resources)
+	}
+}

--- a/internal/errdefs/errdefs.go
+++ b/internal/errdefs/errdefs.go
@@ -491,6 +491,30 @@ var (
 		"blueprint secret slot with mode \"file\" requires an absolute mountPath",
 	)
 
+	// Volume kind (kind: Volume) storage-primitive errors (issue #1018, step 1
+	// of the volumes epic #1015).
+
+	ErrVolumeNameRequired  = errors.New("volume metadata.name is required")
+	ErrVolumeRealmRequired = errors.New("volume metadata.realm is required")
+	// ErrVolumeScopeIncomplete fires when a deeper scope coordinate is set
+	// without every shallower one. A Volume is scopable at realm/space/stack
+	// only, so a set cell coordinate is itself a violation.
+	ErrVolumeScopeIncomplete = errors.New(
+		"volume scope is incomplete: a deeper scope coordinate requires all shallower ones (and a Volume may not be cell-scoped)",
+	)
+	// ErrVolumeCoordUnsafe rejects a volume name or scope coordinate that would
+	// escape the volumes tree once fs.VolumePath filepath.Join's it into a host
+	// path — a "/" or "\" separator, a "." or ".." element, or a NUL byte
+	// (mirrors the Secret-coordinate guard from #673). A Volume provisions a
+	// real directory, so an unguarded name is a path-traversal risk.
+	ErrVolumeCoordUnsafe   = errors.New("volume name or scope coordinate is unsafe")
+	ErrVolumeScopeNotFound = errors.New("volume scope does not exist")
+	ErrWriteVolume         = errors.New("failed to write volume")
+	ErrVolumeNotFound      = errors.New("volume not found")
+	ErrGetVolume           = errors.New("failed to get volume")
+	ErrListVolumes         = errors.New("failed to list volumes")
+	ErrDeleteVolume        = errors.New("failed to delete volume")
+
 	// CellConfig kind (kind: CellConfig) errors (issue #624, phase 4b-i of #423).
 
 	ErrConfigNameRequired  = errors.New("config metadata.name is required")

--- a/internal/modelhub/volume.go
+++ b/internal/modelhub/volume.go
@@ -1,0 +1,40 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package modelhub
+
+// Volume is the internal carrier for a standalone, daemon-managed storage
+// volume (kind: Volume, issue #1018). Unlike CellBlueprint/CellConfig it
+// carries no Document: a Volume's spec is empty in step 1, and the resource
+// itself is the on-host directory the daemon provisions — not a serialized
+// document round-tripped back out. Like a Secret's metadata-only view, the
+// carrier holds only the scope coordinates and name, which the storage runner
+// resolves to (and derives from) the on-disk path. When `reclaimPolicy` lands
+// (step 3, #1237) a Spec field will join the carrier.
+type Volume struct {
+	Metadata VolumeMetadata
+}
+
+// VolumeMetadata identifies a Volume by name and the scope it binds to. A
+// Volume is scopable at realm, space, or stack only — never cell. The scope is
+// the deepest non-empty coordinate; a deeper coordinate requires every
+// shallower one. See external v1beta1.VolumeMetadata for the full contract.
+type VolumeMetadata struct {
+	Name  string
+	Realm string
+	Space string
+	Stack string
+}

--- a/internal/util/fs/metadata.go
+++ b/internal/util/fs/metadata.go
@@ -347,6 +347,44 @@ func ConfigPath(baseRunPath, realmName, spaceName, stackName, configName string)
 	)
 }
 
+// VolumeScopeDir returns the metadata directory of the scope a `kind: Volume`
+// is bound to (issue #1018). Like a CellBlueprint a Volume is scopable at
+// realm/space/stack only — never cell — so the deepest coordinate this resolves
+// is the stack dir. The caller is responsible for having validated coordinate
+// completeness.
+func VolumeScopeDir(baseRunPath, realmName, spaceName, stackName string) string {
+	switch {
+	case stackName != "":
+		return StackMetadataDir(baseRunPath, realmName, spaceName, stackName)
+	case spaceName != "":
+		return SpaceMetadataDir(baseRunPath, realmName, spaceName)
+	default:
+		return RealmMetadataDir(baseRunPath, realmName)
+	}
+}
+
+// VolumesDir returns the per-scope volumes directory — the root-owned,
+// world-traversable container directory under the scope's metadata tree that
+// owns daemon-managed volume directories (issue #1018). Nested inside the scope
+// dir so owning-scope cascade purge reclaims it.
+func VolumesDir(baseRunPath, realmName, spaceName, stackName string) string {
+	return filepath.Join(
+		VolumeScopeDir(baseRunPath, realmName, spaceName, stackName),
+		consts.KukeonVolumesSubdir,
+	)
+}
+
+// VolumePath returns the host-side path of a single daemon-managed volume:
+// <scope>/volumes/<name>. Unlike SecretPath/BlueprintPath — which resolve a
+// single file — this resolves the volume's own directory, the resource a
+// container mounts and writes into.
+func VolumePath(baseRunPath, realmName, spaceName, stackName, volumeName string) string {
+	return filepath.Join(
+		VolumesDir(baseRunPath, realmName, spaceName, stackName),
+		volumeName,
+	)
+}
+
 type metadataHeader struct {
 	APIVersion string `json:"apiVersion"`
 	Kind       string `json:"kind"`

--- a/pkg/api/model/v1beta1/consts.go
+++ b/pkg/api/model/v1beta1/consts.go
@@ -57,6 +57,16 @@ const (
 	// scope's metadata tree; the `kuke run -c` verb + identity state machine
 	// that runs it land in #625, and the get/delete verbs in #644.
 	KindCellConfig Kind = "CellConfig"
+	// KindVolume identifies a standalone, daemon-managed storage volume
+	// (issue #1018, step 1 of the volumes epic #1015). A Volume is decoupled
+	// from any cell: `kuke apply` creates a root-owned, container-writable
+	// directory under the scope's metadata tree, scopable at realm/space/stack
+	// only — never cell — so it outlives the cells that mount it. Reclaimed by
+	// owning-scope (stack/space/realm) cascade purge, not by cell deletion. The
+	// imperative create/get/delete verbs are step 2 (#1236), `reclaimPolicy:
+	// Retain` is step 3 (#1237), and the container-side mount kind that
+	// references a Volume is step 4 (#1016).
+	KindVolume Kind = "Volume"
 	// KindServerConfiguration identifies the kukeond daemon's configuration
 	// document loaded via `kukeond --configuration` (and consumed by
 	// `kuke init --server-configuration`). Not a server-side resource —

--- a/pkg/api/model/v1beta1/volume.go
+++ b/pkg/api/model/v1beta1/volume.go
@@ -1,0 +1,63 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package v1beta1
+
+// VolumeDoc is the top-level document for a standalone, daemon-managed storage
+// volume (kind: Volume, issue #1018, step 1 of the volumes epic #1015).
+// Reshaped to the Docker model: a Volume is decoupled from any cell and owns
+// its own lifecycle. Like the realm/space/stack/cell hierarchy it carries no
+// Status — its on-host presence is the directory the daemon creates under the
+// scope's metadata tree, container-writable so a mounting container can write
+// into it (the mount kind that references a Volume is step 4, #1016). This
+// step ships only the schema + storage primitive + `kuke apply`; the
+// imperative `kuke create/get/delete volume` verbs (#1236) and `reclaimPolicy:
+// Retain` + selective cascade (#1237) build on this foundation.
+type VolumeDoc struct {
+	APIVersion Version        `json:"apiVersion"     yaml:"apiVersion"`
+	Kind       Kind           `json:"kind"           yaml:"kind"`
+	Metadata   VolumeMetadata `json:"metadata"       yaml:"metadata"`
+	Spec       VolumeSpec     `json:"spec,omitempty" yaml:"spec,omitempty"`
+}
+
+// VolumeMetadata identifies a Volume by name and the scope it is bound to. Like
+// a CellBlueprint — and unlike a Secret — a Volume is scopable at realm, space,
+// or stack only, never cell: a volume must outlive the cells that mount it, so
+// binding it to a single cell would let the cell's deletion reclaim it (#1018).
+// The scope is the deepest non-empty coordinate; a deeper coordinate requires
+// every shallower one (a stack-scoped Volume must also name its space and
+// realm). Realm is always required. There is deliberately no Cell field — a
+// `cell:` coordinate is structurally unrepresentable, the same way
+// CellBlueprintMetadata rejects cell scope.
+type VolumeMetadata struct {
+	// Name is the volume's name, unique within its scope.
+	Name string `json:"name"            yaml:"name"`
+	// Realm is the always-required top-level scope coordinate.
+	Realm string `json:"realm"           yaml:"realm"`
+	// Space, when set, scopes the volume to a space within Realm.
+	Space string `json:"space,omitempty" yaml:"space,omitempty"`
+	// Stack, when set, scopes the volume to a stack within Space.
+	Stack string `json:"stack,omitempty" yaml:"stack,omitempty"`
+}
+
+// VolumeSpec carries the volume's declarative configuration. It is empty in
+// step 1 (#1018): the volume's identity is its scope plus its name, and the
+// resource is the directory the daemon provisions. The first spec field —
+// `reclaimPolicy: Retain` — lands in step 3 (#1237), where it reworks cascade
+// purge from the blunt scope-dir RemoveAll to enumerate-and-selectively-
+// preserve. The struct exists now so that addition is a field append rather
+// than a schema reshape.
+type VolumeSpec struct{}


### PR DESCRIPTION
## Summary

Implements **step 1 of the volumes epic** (#1015, re-sized from #1018): a standalone, daemon-managed `kind: Volume` resource — schema, daemon storage, and `kuke apply` support — decoupled from any cell. Mirrors the `CellBlueprint` subsystem shape for parser/scope/storage and the `Secret` precedent for path-segment safety. The imperative CLI verbs are step 2 (#1236); `reclaimPolicy: Retain` + selective cascade is step 3 (#1237); the container-side mount kind is step 4 (#1016).

Why the directory-backed model: a Volume's *resource* is the on-host directory a container mounts and writes into (`<scope>/volumes/<name>`), not a serialized document. So `WriteVolume` provisions a directory (idempotent `MkdirAll`) rather than writing a file, and `GetVolume`/`ListVolumes` are metadata-only (scope + name derived from the path), the same shape as `GetSecret`. The internal carrier therefore has no `Document` field.

## Acceptance criteria

- [x] `kind: Volume` schema in `pkg/api/model/v1beta1` (`volume.go`) + internal model (`internal/modelhub/volume.go`) + apischeme conversion (`internal/apischeme/volume.go`); `apiVersion: v1beta1`; scope validated realm/space/stack with **cell rejected** (mirrors `validateBlueprintScope` — `VolumeMetadata` structurally has no `Cell` field, so a `cell:` coordinate is dropped at unmarshal, the same way `CellBlueprintMetadata` rejects cell scope).
- [x] `KindVolume` parser registration (`internal/apply/parser/parser.go`: `Document.VolumeDoc` field, `ParseDocument` case, `ValidateDocument` kind list + `validateVolume`/`validateVolumeScope`); `kuke apply -f` creates/updates a Volume via `ReconcileVolume` (`internal/controller/apply/reconcile.go`, wired in `internal/controller/apply.go`).
- [x] Daemon storage CRUD in runner (`internal/controller/runner/volume.go`: `WriteVolume`/`GetVolume`/`ListVolumes`/`DeleteVolume` + `Runner` interface) + controller (`internal/controller/volume.go`: `GetVolume`/`ListVolumes`/`DeleteVolume` + lookup/filter guards), mirroring the Blueprint shape.
- [x] `fs.VolumePath`/`fs.VolumeScopeDir` (+ `fs.VolumesDir`, `KukeonVolumesSubdir` const) resolve `<scope>/volumes/<name>`; the dir is created idempotently. **Owner/mode choice (documented per the sibling-precedent rule):** the per-scope `volumes/` container dir is `0o755` root-owned (world-traversable, like `blueprints/`); each **volume dir** is `02770 root:kukeon` (setgid, group-writable, no world access) when the kukeon GID is configured, `0o770 root:root` otherwise — directly mirroring `attachableTTYDirInitialPerms`/`attachableTTYDirRootMode`. The setgid bit makes container-created files inherit the kukeon group. The mounting container's own uid is wired in at mount time in **step 4 (#1016)**, the same two-phase shape as `attachablePostCreateChown` — so step 1 satisfies "container-writable" for root/kukeon-group writers and defers the arbitrary-uid finalization to the mount step.
- [x] Scope purge (`purge stack/space/realm --cascade`) reclaims the scope's volumes — implicit via the existing scope-dir `os.RemoveAll`, covered by `TestVolume_ReclaimedByScopeCascade` (asserts containment under the scope dir, then drives the exact `RemoveAll` the three purge paths use) rather than any new mechanism.
- [x] Tests: scope validation incl. cell-rejected + unsafe-name (`internal/apply/parser/volume_test.go`), storage CRUD round-trip + mode/ownership (`internal/controller/runner/volume_test.go`), `apply` idempotency create→updated + missing-scope reject (`internal/controller/apply/reconcile_volume_test.go`), controller CRUD guards + end-to-end `ApplyDocuments` dispatch (`internal/controller/volume_test.go`), and implicit scope-cascade reclaim.

## Non-obvious calls (reviewer please confirm)

- **No `apply --prune` / team-label participation for Volume.** Unlike Blueprint/Config, the `KindVolume` apply dispatch deliberately does **not** stamp `kukeon.io/team` or feed the prune accumulator: a volume is decoupled from any cell and outlives the apply that created it, so `apply --prune` removing one would wipe persistent data. Reclaim is owning-scope cascade purge only. (Documented inline at the dispatch site.)
- **Path-segment safety beyond a literal "mirror validateBlueprintScope".** `validateVolumeScope` adds `validateVolumeSegment` (rejects `/`, `..`, NUL in name/coords) because a Volume provisions a real directory — a path-traversal name is a genuine escape risk. This mirrors the `Secret` coordinate guard (#673) rather than Blueprint, which lacks it. New sentinel `ErrVolumeCoordUnsafe`.
- **`VolumeSpec` is an empty struct.** No spec fields in step 1; it exists so step 3's `reclaimPolicy` is a field append, not a schema reshape.
- **Declarative `kuke delete -f` of a Volume** is unsupported (hits the existing `ErrUnknownKind` default in `delete_documents.go`) — consistent with Secret/Blueprint/Config siblings, which the delete-documents switch also doesn't handle. Volume removal is cascade-reclaim (this PR) or the step-2 imperative verb.

## Test plan

- [x] `make test-root` — full main-module suite, all green
- [x] `make test-kukebuild` — green (untouched by this change)
- [x] `GOWORK=off go vet ./... (minus e2e)` — clean
- [x] `gofmt -l` on all changed files — clean
- [ ] `make dev-init` end-to-end smoke — not run: this change adds a new resource kind to the apply/storage path and does not touch the build path, the daemon bootstrap, or anything under `/opt/kukeon` that the daemon-parity tail reads; the new code paths are covered by the unit + dispatch tests above. The reviewer may run it on a clean host if a live `kuke apply -f` of a Volume manifest is desired.

Closes #1018