### PR TITLE
fix: install kukepause in install.sh so kuke init can bootstrap

### DIFF
--- a/.github/workflows/installer.yaml
+++ b/.github/workflows/installer.yaml
@@ -95,24 +95,21 @@ jobs:
       - name: Run installer --check
         run: bash scripts/install.sh --check
 
-  # End-to-end smoke: download a real release binary, install it to
+  # End-to-end smoke: download real release binaries, install them to
   # /usr/local/bin, and skip the kuke-init step (which would need root,
   # cgroup writes, and a healthy containerd). Pinned to a known-good tag so
-  # the test doesn't drift with future releases. Checksum verification is
-  # skipped because pre-issue-#62 releases shipped without .sha256 assets;
-  # once a release lands with .sha256 published, drop the skip.
-  # KUKE_SKIP_KUKEBUILD is set for the same reason: v0.4.0 predates the
-  # kukebuild release asset (issue #1227), so the installer would 404 fetching
-  # it. Once the pinned tag ships kukebuild-linux-*, bump KUKE_VERSION and drop
-  # this skip to exercise the kukebuild install path here.
+  # the test doesn't drift with future releases. v0.6.1 ships kuke, kukebuild,
+  # and kukepause assets plus their .sha256 sums, so this job exercises the
+  # full multi-binary download + checksum-verify + install path (no
+  # KUKE_SKIP_CHECKSUM, no KUKE_SKIP_KUKEBUILD). kukepause is fetched
+  # unconditionally because `kuke init` cannot bootstrap without it (issue
+  # #1241).
   install-skip-init:
     name: full install (KUKE_SKIP_INIT=1) against a real release
     runs-on: ubuntu-latest
     env:
-      KUKE_VERSION: v0.4.0
+      KUKE_VERSION: v0.6.1
       KUKE_SKIP_INIT: "1"
-      KUKE_SKIP_CHECKSUM: "1"
-      KUKE_SKIP_KUKEBUILD: "1"
     steps:
       - uses: actions/checkout@v4
       - name: Run installer (download + install, skip init)
@@ -121,4 +118,6 @@ jobs:
         run: |
           test -x /usr/local/bin/kuke
           test -x /usr/local/bin/kukeond
+          test -x /usr/local/bin/kukebuild
+          test -x /usr/local/bin/kukepause
           /usr/local/bin/kuke version

--- a/docs/site/install.sh
+++ b/docs/site/install.sh
@@ -55,7 +55,7 @@ usage() {
     cat <<EOF
 Usage: install.sh [--check] [--help]
 
-Installs kukeon (kuke + kukeond + kukebuild) on a Linux host.
+Installs kukeon (kuke + kukeond + kukebuild + kukepause) on a Linux host.
 
   --check    Run prerequisite checks only; do not touch the system.
   --help     Show this help.
@@ -308,7 +308,7 @@ fetch_verified() {
 }
 
 do_install() {
-    local arch kuke_path kukebuild_path
+    local arch kuke_path kukebuild_path kukepause_path
     arch="$(detect_platform)"
 
     step "Resolving release version"
@@ -321,17 +321,25 @@ do_install() {
     trap cleanup_tmpdir EXIT
     kuke_path="${INSTALL_TMPDIR}/kuke"
     kukebuild_path="${INSTALL_TMPDIR}/kukebuild"
+    kukepause_path="${INSTALL_TMPDIR}/kukepause"
 
     # kuke is the CLI + daemon (argv[0]-dispatched to kukeond); kukebuild is the
-    # docker-free image builder `kuke build` execs. Ship both so a fresh
-    # installer host can build images without a source checkout (issue #1227) —
-    # without kukebuild, `kuke build` fails with errdefs.ErrKukebuildNotFound.
+    # docker-free image builder `kuke build` execs; kukepause is the static PID 1
+    # `kuke init` stages to /opt/kukeon/bin/kukepause and bind-mounts into every
+    # cell's root container. Ship all three so a fresh installer host can build
+    # images and bootstrap the runtime without a source checkout (issues #1227,
+    # #1241) — without kukebuild, `kuke build` fails with
+    # errdefs.ErrKukebuildNotFound; without kukepause, `kuke init` aborts at its
+    # "stage kukepause" step.
     #
-    # Both assets are downloaded + verified into the tmpdir before anything is
+    # All assets are downloaded + verified into the tmpdir before anything is
     # placed on the system, so a fetch/verify failure leaves the host untouched.
     # KUKE_SKIP_KUKEBUILD skips kukebuild entirely — release tags predating its
     # asset (#1227) have no kukebuild-linux-* to fetch, so an old KUKE_VERSION
     # pin sets it to install kuke alone rather than 404 on the missing asset.
+    # kukepause has no skip flag: it is mandatory for `kuke init`, so a release
+    # pin too old to ship kukepause-linux-* fails loudly here rather than
+    # installing a runtime that cannot bootstrap.
     fetch_verified "kuke-linux-${arch}" "$kuke_path"
     chmod +x "$kuke_path"
     if [ -n "$KUKE_SKIP_KUKEBUILD" ]; then
@@ -340,6 +348,8 @@ do_install() {
         fetch_verified "kukebuild-linux-${arch}" "$kukebuild_path"
         chmod +x "$kukebuild_path"
     fi
+    fetch_verified "kukepause-linux-${arch}" "$kukepause_path"
+    chmod +x "$kukepause_path"
 
     step "Installing to ${KUKE_INSTALL_PREFIX}"
     $SUDO install -m 0755 "$kuke_path" "${KUKE_INSTALL_PREFIX}/kuke"
@@ -347,14 +357,18 @@ do_install() {
     # basename and we want `kukeond` resolved as a real path, not as
     # `kuke -> kukeond` indirection that some shells resolve.
     $SUDO ln -f "${KUKE_INSTALL_PREFIX}/kuke" "${KUKE_INSTALL_PREFIX}/kukeond"
+    # kukepause is a distinct static binary (not an argv[0] alias of kuke) that
+    # `kuke init` resolves on $PATH / alongside kuke to stage as every cell's
+    # PID 1 — install it as a real file so init finds it (issue #1241).
+    $SUDO install -m 0755 "$kukepause_path" "${KUKE_INSTALL_PREFIX}/kukepause"
     if [ -n "$KUKE_SKIP_KUKEBUILD" ]; then
-        ok "installed kuke + kukeond at ${KUKE_INSTALL_PREFIX}"
+        ok "installed kuke + kukeond + kukepause at ${KUKE_INSTALL_PREFIX}"
     else
         # kukebuild is a distinct binary (its own Go module embedding BuildKit),
         # not an argv[0] alias of kuke — install it as a real file so `kuke
         # build` resolves it on PATH.
         $SUDO install -m 0755 "$kukebuild_path" "${KUKE_INSTALL_PREFIX}/kukebuild"
-        ok "installed kuke + kukeond + kukebuild at ${KUKE_INSTALL_PREFIX}"
+        ok "installed kuke + kukeond + kukebuild + kukepause at ${KUKE_INSTALL_PREFIX}"
     fi
 
     if [ -n "$KUKE_SKIP_INIT" ]; then

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -55,7 +55,7 @@ usage() {
     cat <<EOF
 Usage: install.sh [--check] [--help]
 
-Installs kukeon (kuke + kukeond + kukebuild) on a Linux host.
+Installs kukeon (kuke + kukeond + kukebuild + kukepause) on a Linux host.
 
   --check    Run prerequisite checks only; do not touch the system.
   --help     Show this help.
@@ -308,7 +308,7 @@ fetch_verified() {
 }
 
 do_install() {
-    local arch kuke_path kukebuild_path
+    local arch kuke_path kukebuild_path kukepause_path
     arch="$(detect_platform)"
 
     step "Resolving release version"
@@ -321,17 +321,25 @@ do_install() {
     trap cleanup_tmpdir EXIT
     kuke_path="${INSTALL_TMPDIR}/kuke"
     kukebuild_path="${INSTALL_TMPDIR}/kukebuild"
+    kukepause_path="${INSTALL_TMPDIR}/kukepause"
 
     # kuke is the CLI + daemon (argv[0]-dispatched to kukeond); kukebuild is the
-    # docker-free image builder `kuke build` execs. Ship both so a fresh
-    # installer host can build images without a source checkout (issue #1227) —
-    # without kukebuild, `kuke build` fails with errdefs.ErrKukebuildNotFound.
+    # docker-free image builder `kuke build` execs; kukepause is the static PID 1
+    # `kuke init` stages to /opt/kukeon/bin/kukepause and bind-mounts into every
+    # cell's root container. Ship all three so a fresh installer host can build
+    # images and bootstrap the runtime without a source checkout (issues #1227,
+    # #1241) — without kukebuild, `kuke build` fails with
+    # errdefs.ErrKukebuildNotFound; without kukepause, `kuke init` aborts at its
+    # "stage kukepause" step.
     #
-    # Both assets are downloaded + verified into the tmpdir before anything is
+    # All assets are downloaded + verified into the tmpdir before anything is
     # placed on the system, so a fetch/verify failure leaves the host untouched.
     # KUKE_SKIP_KUKEBUILD skips kukebuild entirely — release tags predating its
     # asset (#1227) have no kukebuild-linux-* to fetch, so an old KUKE_VERSION
     # pin sets it to install kuke alone rather than 404 on the missing asset.
+    # kukepause has no skip flag: it is mandatory for `kuke init`, so a release
+    # pin too old to ship kukepause-linux-* fails loudly here rather than
+    # installing a runtime that cannot bootstrap.
     fetch_verified "kuke-linux-${arch}" "$kuke_path"
     chmod +x "$kuke_path"
     if [ -n "$KUKE_SKIP_KUKEBUILD" ]; then
@@ -340,6 +348,8 @@ do_install() {
         fetch_verified "kukebuild-linux-${arch}" "$kukebuild_path"
         chmod +x "$kukebuild_path"
     fi
+    fetch_verified "kukepause-linux-${arch}" "$kukepause_path"
+    chmod +x "$kukepause_path"
 
     step "Installing to ${KUKE_INSTALL_PREFIX}"
     $SUDO install -m 0755 "$kuke_path" "${KUKE_INSTALL_PREFIX}/kuke"
@@ -347,14 +357,18 @@ do_install() {
     # basename and we want `kukeond` resolved as a real path, not as
     # `kuke -> kukeond` indirection that some shells resolve.
     $SUDO ln -f "${KUKE_INSTALL_PREFIX}/kuke" "${KUKE_INSTALL_PREFIX}/kukeond"
+    # kukepause is a distinct static binary (not an argv[0] alias of kuke) that
+    # `kuke init` resolves on $PATH / alongside kuke to stage as every cell's
+    # PID 1 — install it as a real file so init finds it (issue #1241).
+    $SUDO install -m 0755 "$kukepause_path" "${KUKE_INSTALL_PREFIX}/kukepause"
     if [ -n "$KUKE_SKIP_KUKEBUILD" ]; then
-        ok "installed kuke + kukeond at ${KUKE_INSTALL_PREFIX}"
+        ok "installed kuke + kukeond + kukepause at ${KUKE_INSTALL_PREFIX}"
     else
         # kukebuild is a distinct binary (its own Go module embedding BuildKit),
         # not an argv[0] alias of kuke — install it as a real file so `kuke
         # build` resolves it on PATH.
         $SUDO install -m 0755 "$kukebuild_path" "${KUKE_INSTALL_PREFIX}/kukebuild"
-        ok "installed kuke + kukeond + kukebuild at ${KUKE_INSTALL_PREFIX}"
+        ok "installed kuke + kukeond + kukebuild + kukepause at ${KUKE_INSTALL_PREFIX}"
     fi
 
     if [ -n "$KUKE_SKIP_INIT" ]; then


### PR DESCRIPTION
## Summary

- `scripts/install.sh` (and its published mirror `docs/site/install.sh`) downloaded and installed `kuke` and `kukebuild` but never fetched `kukepause`, so `curl -fsSL https://kukeon.io/install.sh | bash` left a host where `kuke init` aborts at `stage kukepause: kukepause not found on $PATH or alongside kuke`. The release workflow already publishes the `kukepause-linux-{amd64,arm64}` asset + `.sha256`; the installer simply never fetched it. Reported and root-caused in #1241.
- Adds an **unconditional** `fetch_verified "kukepause-linux-${arch}"` + `install -m 0755 … /kukepause` step, mirroring the kukebuild handling. `kuke init` resolves kukepause via `$PATH`/alongside-`kuke` (`cmd/kuke/init/init.go:421-441`) and stages it as every cell's static PID 1, so the binary must land in the install prefix.

## Design notes

- **No skip flag for kukepause (gate-vs-flip).** Unlike `kukebuild` (gated by `KUKE_SKIP_KUKEBUILD` so old pins predating its asset don't 404), kukepause is **mandatory** — `kuke init` cannot bootstrap without it. So a release pin too old to ship `kukepause-linux-*` should fail loudly at fetch rather than silently install a runtime that can't init. Documented inline in the script comment.
- **CI tag bump (required, not scope creep).** The `install-skip-init` job in `.github/workflows/installer.yaml` pinned `KUKE_VERSION: v0.4.0` with `KUKE_SKIP_KUKEBUILD=1`. Because the kukepause fetch is unconditional, v0.4.0 (which predates the kukepause asset) would now 404 and fail the job. The job's own comment anticipated this ("bump KUKE_VERSION … to exercise the kukebuild install path"). Bumped to `v0.6.1` — which ships kuke + kukebuild + kukepause + all `.sha256` sums — and dropped the now-stale `KUKE_SKIP_CHECKSUM` / `KUKE_SKIP_KUKEBUILD` skips so the job exercises the full multi-binary download + checksum-verify path, plus added `test -x` assertions for the kukebuild and kukepause artifacts.

## Test plan

- [x] `bash -n scripts/install.sh` and `bash -n docs/site/install.sh` — syntax clean
- [x] `make install.sh` — docs mirror re-renders with no drift (`diff -q` of the two files is identical, the `installer.yaml` `sync` job's invariant)
- [x] `git grep` — no remaining references to the old `installed kuke + kukeond + kukebuild` success string
- [ ] `.github/workflows/installer.yaml` `install-skip-init` job against the real v0.6.1 release — exercised by CI on this PR (downloads real release assets; not run locally as it requires fetching GitHub release binaries)
- [ ] `make test` — not run: this PR touches only shell scripts and a CI workflow, no Go code; the Go test target covers none of the changed files

Closes #1241