### PR TITLE
fix: reconcile re-reads cell from disk after lock to avoid resurrecting deleted cell

### DIFF
--- a/internal/controller/reconcile.go
+++ b/internal/controller/reconcile.go
@@ -109,7 +109,15 @@ func (b *Exec) ReconcileCells() (ReconcileResult, error) {
 					// them) and cells without the kukeon.io/config label.
 					// A persisted write counts toward CellsUpdated so the
 					// reconcile summary reflects the metadata flip.
-					if outcome.Deleted {
+					//
+					// Vanished cells (#1251) short-circuit the same way: the
+					// metadata is already gone, so re-deriving OutOfSync and
+					// persisting it would rewrite the just-deleted
+					// metadata.json — the very resurrection the post-lock
+					// recheck exists to prevent. Unlike Deleted, a Vanished
+					// outcome is left out of CellsDeleted (the reconciler
+					// observed an external delete, it did not perform one).
+					if outcome.Deleted || outcome.Vanished {
 						continue
 					}
 					syncUpdated, syncErr := reconcileCellOutOfSync(b.runner, reconciled)

--- a/internal/controller/runner/cell_lock_test.go
+++ b/internal/controller/runner/cell_lock_test.go
@@ -177,12 +177,17 @@ func TestCellLifecycleLock_StartCellWaitsForReconcile(t *testing.T) {
 	fake := &deleteCellFakeClient{existsContainerFn: gateExistsContainer(entered, release)}
 	r := newDeleteCellTestExec(t, fake)
 	seedDeleteCellRealm(t, r, realm)
-	// The cell metadata is deliberately NOT seeded: ReconcileCell reaches the
-	// gated ExistsContainer off the in-memory cell arg (it needs only the
-	// realm), while StartCell fails fast at its early GetCell (a filesystem
-	// read, not gated) the moment it acquires the lock. That makes "StartCell
-	// returned" a clean signal that it got past lock acquisition — without the
-	// lock it would return near-instantly rather than waiting on ReconcileCell.
+	// The cell metadata IS seeded but the space metadata is deliberately not:
+	// since #1251 ReconcileCell re-reads the cell from disk after acquiring the
+	// per-cell lock (GetCell) and short-circuits when it is gone, so it must
+	// find the cell metadata to proceed to the gated ExistsContainer off the
+	// in-memory cell arg. StartCell still fails fast the moment it acquires the
+	// lock — now one step later, at ResolveSpaceCNIConfigPath's GetSpace (a
+	// filesystem read, not gated), since the space is unseeded. That keeps
+	// "StartCell returned" a clean signal that it got past lock acquisition —
+	// without the lock it would return near-instantly rather than waiting on
+	// ReconcileCell.
+	seedDeleteCellCell(t, r, realm, space, stack, cellName)
 
 	cell := oneContainerCell(realm, space, stack, cellName)
 

--- a/internal/controller/runner/reconcile_heal_test.go
+++ b/internal/controller/runner/reconcile_heal_test.go
@@ -249,3 +249,177 @@ func seedNeverReadyCell(t *testing.T, r *Exec, realm, space, stack, cellName str
 		t.Fatalf("write cell metadata: %v", err)
 	}
 }
+
+// TestReconcileCell_DoesNotResurrectDeletedCell is the headline #1251 guard:
+// the delete-while-reconcile-blocked-on-lock race. ReconcileCells snapshots
+// the cell list once per tick and iterates with the in-memory value captured
+// at list time (ReadyObserved=true). A `kuke delete cell` that completes
+// while this tick is blocked on the per-cell lock leaves the reconciler
+// holding a pre-delete snapshot whose cgroup is now absent — pre-fix the
+// #855 heal branch fired (`!cgroupExists && ReadyObserved`) and
+// ensureCellCgroup recreated the cgroup AND rewrote the just-deleted
+// metadata.json, silently resurrecting the cell. The post-lock GetCell
+// recheck must short-circuit on ErrCellNotFound: no NewCgroup, no metadata
+// rewrite, and a Vanished outcome (not Deleted — the reconciler observed an
+// external delete, it did not perform one).
+func TestReconcileCell_DoesNotResurrectDeletedCell(t *testing.T) {
+	realm, space, stack, cellName := "default", "kukeon", "kukeon", "github-runner"
+	rootID := "root"
+	workloadID := "workload"
+	rootContainerdID := space + "_" + stack + "_" + cellName + "_" + rootID
+	workloadContainerdID := space + "_" + stack + "_" + cellName + "_" + workloadID
+
+	fake := &deleteCellFakeClient{
+		// Cgroup absent: DeleteCell removed it as part of the teardown
+		// the reconcile tick was blocked behind. This is the same probe
+		// result the post-reboot heal keys off — the bug is that the
+		// heal can't tell "metadata survives" from "metadata just deleted".
+		loadCgroupFn: func(string, string) (*cgroup2.Manager, error) {
+			return nil, errors.New("cgroup path does not exist")
+		},
+		// Any NewCgroup / subtree-controller call is the resurrection
+		// regression — fail loudly so the recheck reads as a behavior
+		// change in the test surface, not a silent log-only divergence.
+		newCgroupFn: func(ctr.CgroupSpec) (*cgroup2.Manager, error) {
+			t.Errorf("NewCgroup called on a deleted cell — the post-lock recheck must short-circuit before the #855 heal (#1251)")
+			return nil, errors.New("must not be called")
+		},
+		enableCellSubtreeFn: func(string, string, []string) ([]string, error) {
+			t.Errorf("EnableCellSubtreeControllers called on a deleted cell — same recheck gate as NewCgroup (#1251)")
+			return nil, errors.New("must not be called")
+		},
+	}
+	r := newDeleteCellTestExec(t, fake)
+	seedDeleteCellRealm(t, r, realm)
+	// Seed the cell, then remove its metadata to model the just-completed
+	// DeleteCell: the snapshot below is the pre-delete value, the on-disk
+	// metadata is gone.
+	seedPostRebootCell(t, r, realm, space, stack, cellName, rootID, workloadID, rootContainerdID, workloadContainerdID)
+	metadataPath := fs.CellMetadataPath(r.opts.RunPath, realm, space, stack, cellName)
+	if err := os.Remove(metadataPath); err != nil {
+		t.Fatalf("remove cell metadata (simulate completed DeleteCell): %v", err)
+	}
+
+	// The stale pre-delete snapshot the reconcile tick still holds:
+	// ReadyObserved=true is what drives the heal branch pre-fix.
+	cell := intmodel.Cell{
+		Metadata: intmodel.CellMetadata{Name: cellName},
+		Spec: intmodel.CellSpec{
+			ID:        cellName,
+			RealmName: realm,
+			SpaceName: space,
+			StackName: stack,
+			Containers: []intmodel.ContainerSpec{
+				{ID: rootID, ContainerdID: rootContainerdID, Root: true},
+				{ID: workloadID, ContainerdID: workloadContainerdID, Root: false},
+			},
+		},
+		Status: intmodel.CellStatus{
+			State:         intmodel.CellStateReady,
+			ReadyObserved: true,
+		},
+	}
+
+	_, outcome, err := r.ReconcileCell(cell)
+	if err != nil {
+		t.Fatalf("ReconcileCell: unexpected error: %v", err)
+	}
+	if !outcome.Vanished {
+		t.Errorf("ReconcileOutcome.Vanished = false, want true (the cell's metadata is gone — the reconciler must report it vanished, not heal it)")
+	}
+	if outcome.Deleted {
+		t.Errorf("ReconcileOutcome.Deleted = true, want false (the reconciler observed an external delete, it did not perform one — Deleted is reserved for the AutoDelete path)")
+	}
+	if outcome.Updated {
+		t.Errorf("ReconcileOutcome.Updated = true, want false (a vanished cell is a pure no-op — no status write)")
+	}
+	// The resurrection signature: metadata.json must stay gone. Pre-fix
+	// ensureCellCgroup's UpdateCellMetadata rewrote it.
+	if _, statErr := os.Stat(metadataPath); !os.IsNotExist(statErr) {
+		t.Errorf("cell metadata.json exists after reconcile (stat err = %v), want still-absent — the reconciler resurrected the deleted cell (#1251)", statErr)
+	}
+}
+
+// TestReconcileCell_HealVsDeletedMetadata pins the AC #4 distinction the
+// post-lock recheck draws: a missing cgroup on a Ready cell heals only when
+// the metadata survives (genuine post-reboot, #855), and is left alone when
+// the metadata is gone (just-deleted, #1251). Both share the identical
+// absent-cgroup + ReadyObserved=true snapshot — the on-disk metadata is the
+// only discriminator, which is exactly why the pre-fix heal branch
+// (keyed only on cgroup-absent + ReadyObserved) could not tell them apart.
+func TestReconcileCell_HealVsDeletedMetadata(t *testing.T) {
+	realm, space, stack := "default", "kukeon", "kukeon"
+	rootID, workloadID := "root", "workload"
+
+	makeCell := func(cellName string) intmodel.Cell {
+		return intmodel.Cell{
+			Metadata: intmodel.CellMetadata{Name: cellName},
+			Spec: intmodel.CellSpec{
+				ID:        cellName,
+				RealmName: realm,
+				SpaceName: space,
+				StackName: stack,
+				Containers: []intmodel.ContainerSpec{
+					{ID: rootID, ContainerdID: space + "_" + stack + "_" + cellName + "_" + rootID, Root: true},
+					{ID: workloadID, ContainerdID: space + "_" + stack + "_" + cellName + "_" + workloadID, Root: false},
+				},
+			},
+			Status: intmodel.CellStatus{State: intmodel.CellStateReady, ReadyObserved: true},
+		}
+	}
+
+	t.Run("metadata survives -> heals", func(t *testing.T) {
+		cellName := "survivor"
+		var newCgroupCalls int32
+		fake := &deleteCellFakeClient{
+			loadCgroupFn: func(string, string) (*cgroup2.Manager, error) {
+				return nil, errors.New("cgroup path does not exist")
+			},
+			newCgroupFn: func(ctr.CgroupSpec) (*cgroup2.Manager, error) {
+				atomic.AddInt32(&newCgroupCalls, 1)
+				return &cgroup2.Manager{}, nil
+			},
+			enableCellSubtreeFn: func(string, string, []string) ([]string, error) { return nil, nil },
+			existsContainerFn:   func(_, _ string) (bool, error) { return true, nil },
+			taskStatusFn: func(_, _ string) (containerd.Status, error) {
+				return containerd.Status{}, fmt.Errorf("%w: %w", errdefs.ErrTaskNotFound, errors.New("task: not found"))
+			},
+		}
+		r := newDeleteCellTestExec(t, fake)
+		seedDeleteCellRealm(t, r, realm)
+		seedPostRebootCell(t, r, realm, space, stack, cellName, rootID, workloadID,
+			space+"_"+stack+"_"+cellName+"_"+rootID, space+"_"+stack+"_"+cellName+"_"+workloadID)
+
+		if _, _, err := r.ReconcileCell(makeCell(cellName)); err != nil {
+			t.Fatalf("ReconcileCell: unexpected error: %v", err)
+		}
+		if got := atomic.LoadInt32(&newCgroupCalls); got != 1 {
+			t.Errorf("NewCgroup call count = %d, want 1 (metadata survives, so the #855 heal must still fire)", got)
+		}
+	})
+
+	t.Run("metadata deleted -> no heal", func(t *testing.T) {
+		cellName := "deleted"
+		fake := &deleteCellFakeClient{
+			loadCgroupFn: func(string, string) (*cgroup2.Manager, error) {
+				return nil, errors.New("cgroup path does not exist")
+			},
+			newCgroupFn: func(ctr.CgroupSpec) (*cgroup2.Manager, error) {
+				t.Errorf("NewCgroup called on a cell whose metadata is gone — the recheck must skip the heal (#1251)")
+				return nil, errors.New("must not be called")
+			},
+			enableCellSubtreeFn: func(string, string, []string) ([]string, error) { return nil, nil },
+		}
+		r := newDeleteCellTestExec(t, fake)
+		seedDeleteCellRealm(t, r, realm)
+		// Intentionally do NOT seed the cell metadata — GetCell returns
+		// ErrCellNotFound, the deleted-metadata arm of the distinction.
+		_, outcome, err := r.ReconcileCell(makeCell(cellName))
+		if err != nil {
+			t.Fatalf("ReconcileCell: unexpected error: %v", err)
+		}
+		if !outcome.Vanished {
+			t.Errorf("ReconcileOutcome.Vanished = false, want true (metadata is gone)")
+		}
+	})
+}

--- a/internal/controller/runner/refresh.go
+++ b/internal/controller/runner/refresh.go
@@ -651,6 +651,30 @@ func (r *Exec) refreshContainerStatus(cell intmodel.Cell, containerSpec *intmode
 func (r *Exec) ReconcileCell(cell intmodel.Cell) (intmodel.Cell, ReconcileOutcome, error) {
 	defer r.lockCell(cell)()
 
+	// Post-lock existence recheck (#1251). ReconcileCells snapshots the
+	// cell list once per tick and iterates with the in-memory value
+	// captured at list time. A `kuke delete cell` that completed while this
+	// tick was blocked on the per-cell lock leaves us holding a pre-delete
+	// snapshot whose ReadyObserved latch is still true — the cgroup-heal
+	// branch below (#855) would then "heal" the missing cgroup and rewrite
+	// the just-deleted metadata.json, silently resurrecting the cell. The
+	// lock the #714 work added serializes the mutations but never re-read
+	// disk after acquiring it; re-read now and short-circuit when the
+	// metadata is gone. The post-reboot heal (#855) is unaffected: on a
+	// genuine reboot the metadata survives, so GetCell succeeds here.
+	if _, err := r.GetCell(cell); err != nil {
+		if errors.Is(err, errdefs.ErrCellNotFound) {
+			r.logger.DebugContext(r.ctx, "reconcile: cell metadata gone, skipping",
+				"cell", cell.Metadata.Name,
+				"realm", cell.Spec.RealmName,
+				"space", cell.Spec.SpaceName,
+				"stack", cell.Spec.StackName)
+			return cell, ReconcileOutcome{Vanished: true}, nil
+		}
+		r.logger.DebugContext(r.ctx, "reconcile: failed to re-read cell after lock",
+			"cell", cell.Metadata.Name, "error", err)
+	}
+
 	originalStatus := cell.Status
 
 	// CellStateFailed is terminal (issue #407): once a cell has been marked

--- a/internal/controller/runner/runner.go
+++ b/internal/controller/runner/runner.go
@@ -42,6 +42,16 @@ type ReconcileOutcome struct {
 	// part of honoring Spec.AutoDelete. When true the input cell no
 	// longer exists in metadata.
 	Deleted bool
+	// Vanished is true if the reconciler found the cell's metadata already
+	// gone after acquiring the per-cell lock — an operator `kuke delete
+	// cell` (or a stack/space teardown) completed while this tick was
+	// blocked on the lock holding a pre-delete snapshot (#1251). Unlike
+	// Deleted, the reconciler did not perform the removal, so it must not
+	// count toward the auto-delete metric; the flag exists purely to make
+	// the loop short-circuit the cell as a no-op (no status write, no
+	// OutOfSync re-derivation) instead of healing it back into existence
+	// from the stale snapshot.
+	Vanished bool
 }
 
 type Runner interface {


### PR DESCRIPTION
## Summary

- Closes a TOCTOU between `DeleteCell` and the reconcile loop's **stale per-tick cell snapshot** (the interaction of the `#714` per-cell lock and the `#855` post-reboot cgroup-heal branch). `ReconcileCells` snapshots the cell list once per tick and iterates with the in-memory `cell` captured at list time (`ReadyObserved=true`). A `kuke delete cell` that completes while that tick is blocked on the per-cell lock leaves `ReconcileCell` holding a pre-delete snapshot; the `!cgroupExists && ReadyObserved` heal branch then re-creates the cgroup **and** `ensureCellCgroup`'s `UpdateCellMetadata` rewrites the just-deleted `metadata.json` — silently resurrecting the cell in `Stopped` state.
- **Fix:** `ReconcileCell` now re-reads the cell from disk (`GetCell`) immediately after acquiring the per-cell lock and short-circuits on `ErrCellNotFound` with a new no-op `ReconcileOutcome{Vanished: true}` — placed *before* the sticky-`Failed` guard and the heal/derivation logic so neither path can rewrite the gone metadata. The lock makes the recheck reliable: the delete has fully completed before the reconcile observes absence.
- A new `Vanished` outcome field (distinct from `Deleted`) keeps the reconcile loop from re-deriving/persisting OutOfSync on the gone cell (a second metadata-rewrite resurrection vector for Config-lineage cells) **without** inflating the `CellsDeleted` auto-delete metric — the reconciler observed an external delete, it did not perform one.
- The `#855` post-reboot heal is unaffected: on a genuine reboot the `metadata.json` survives, so `GetCell` succeeds and the heal proceeds exactly as before. The on-disk metadata is the only discriminator between "reboot wiped the cgroup" and "delete removed the cell" — which is precisely why the pre-fix heal branch (keyed only on cgroup-absent + `ReadyObserved`) could not tell them apart.

### AC #2 (secret-delete unblock)

Verified transitively, not by a separate test: the secret guard's `secretReferences` (`internal/controller/secret.go:160`) reads `b.runner.ListCells(...)`. With the resurrection closed, the deleted cell's `metadata.json` is never rewritten, so `ListCells` no longer returns it and its `secretRef` no longer blocks `kuke delete secret`. The new regression test asserts the metadata stays absent after the racing tick, which is the root enabler of this AC.

## Test plan

- [x] `make test` (full CI target: `test-root` + `test-kukebuild`) — exit 0, zero failures
- [x] `go vet ./internal/controller/...` — clean
- [x] New `TestReconcileCell_DoesNotResurrectDeletedCell` — reproduces the delete-while-reconcile-blocked-on-lock race; asserts `Vanished` outcome, no `NewCgroup`/subtree call, and `metadata.json` stays absent. Verified it **fails** without the fix (NewCgroup called + metadata.json rewritten) and passes with it.
- [x] New `TestReconcileCell_HealVsDeletedMetadata` — pins the AC #4 distinction: metadata-survives → heals (`#855`); metadata-deleted → no heal (`#1251`).
- [x] Existing `TestReconcileCell_HealsWipedCgroupWhenReadyObserved` / `TestReconcileCell_DoesNotHealHalfCreateCell` still pass (post-reboot heal + half-CreateCell gate intact).

## Acceptance criteria

- [x] `kuke delete cell` followed by `kuke get ce` no longer shows the cell across reconcile ticks — the recheck leaves the metadata gone, and subsequent ticks no longer list the cell at all.
- [x] After deleting a cell that referenced a secret, `kuke delete secret` succeeds — see AC #2 note above (transitive via the no-rewrite invariant; `secretReferences` → `ListCells`).
- [x] `ReconcileCell` re-reads the cell from disk after acquiring the per-cell lock and returns a no-op outcome (no heal, no `metadata.json` rewrite, no cgroup recreate) when the cell's metadata is gone.
- [x] The `#855` post-reboot heal still heals a Ready cell whose cgroup is absent but whose `metadata.json` survives — regression covering reboot-survives-metadata vs. deleted-metadata.
- [x] Unit/regression test reproducing the delete-while-reconcile-blocked-on-lock race.

## Notes

- Updated `TestCellLifecycleLock_StartCellWaitsForReconcile` (`cell_lock_test.go`): its premise was "cell metadata deliberately NOT seeded so `ReconcileCell` reaches the gated `ExistsContainer` off the in-memory arg." The new recheck makes `ReconcileCell` require on-disk metadata, so the test now seeds the cell (but still not the space) — `ReconcileCell` reaches its gate, and `StartCell` still fails fast the moment it acquires the lock, now one step later at `ResolveSpaceCNIConfigPath`'s `GetSpace` (unseeded space) instead of its early `GetCell`. The lock-serialization contract it guards is unchanged.
- The separate `metadata file does not exist .../secrets/metadata.json` noise line called out in the issue is out of scope here (the issue flags it as a pre-existing follow-up).

Closes #1251