### PR TITLE
deps: bump sbsh to v0.13.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/containerd/typeurl/v2 v2.2.3
 	github.com/containernetworking/cni v1.3.0
 	github.com/creack/pty v1.1.24
-	github.com/eminwux/sbsh v0.12.3
+	github.com/eminwux/sbsh v0.13.0
 	github.com/opencontainers/go-digest v1.0.0
 	github.com/opencontainers/image-spec v1.1.1
 	github.com/opencontainers/runtime-spec v1.2.1

--- a/go.sum
+++ b/go.sum
@@ -58,8 +58,8 @@ github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/distribution/reference v0.6.0 h1:0IXCQ5g4/QMHHkarYzh5l+u8T3t73zM5QvfrDyIgxBk=
 github.com/distribution/reference v0.6.0/go.mod h1:BbU0aIcezP1/5jX/8MP0YiH4SdvB5Y4f/wlDRiLyi3E=
-github.com/eminwux/sbsh v0.12.3 h1:0OBO2CFjTmRNJfKh5aegcCER7w93fBT/AO634A72x/4=
-github.com/eminwux/sbsh v0.12.3/go.mod h1:epv5XQTI+D68bTa+LTgJ9WsckiA/96bZOjHrsgC3UWU=
+github.com/eminwux/sbsh v0.13.0 h1:f+HA3D8xvaAQH/HbAaC78kpY+AJUvdsx2SDSqY1Rlnk=
+github.com/eminwux/sbsh v0.13.0/go.mod h1:epv5XQTI+D68bTa+LTgJ9WsckiA/96bZOjHrsgC3UWU=
 github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.4/go.mod h1:6rpuAdCZL397s3pYoYcLgu1mIlRU8Am5FuJP05cCM98=


### PR DESCRIPTION
## Summary
- Bumps `github.com/eminwux/sbsh` from v0.12.3 to v0.13.0 (the current `@latest`, tagged 2026-06-12).
- v0.13.0's changes are CLI/installer-focused (stop clearing terminal on attach/detach by default; `--clear-screen` → symmetric `--clear-on-attach`/`--clear-on-detach`; one-line installer; discovery doc fix). kukeon consumes the `pkg/attach` library, not the sbsh CLI, so none of the renamed flags are referenced in-tree (`git grep` for `clear-screen`/`clear-on-attach`/`clear-on-detach`/`ClearScreen` is empty).
- Diff is exactly the version bump: `go.mod` one line, `go.sum` the two sbsh hash lines. `go mod tidy` introduced no other changes.

## Test plan
- [x] `GOWORK=off go build ./...` — clean
- [x] `make test` (test-root + test-kukebuild) — 107 packages `ok`, zero FAIL
- [x] `git grep` confirms no references to the renamed sbsh `--clear-screen` CLI flags (kukeon uses `pkg/attach`, library API unchanged — build is the proof)

This is a dependency bump (no behavior change in kukeon), routed through the standard review flow.