### PR TITLE
docs: consolidated private-registry credentials guide

### DIFF
--- a/docs/site/guides/private-registry.md
+++ b/docs/site/guides/private-registry.md
@@ -79,7 +79,7 @@ spec:
 | `password`      | yes      | Registry password or token                                                                          |
 | `serverAddress` | no       | Registry server (e.g. `docker.io`, `ghcr.io`). If omitted, applies to the registry in the image reference. |
 
-See [Manifests → Realm](../manifests/realm.md#specregistrycredentials) for the
+See [Manifests → Realm](../manifests/realm.md#specregistrycredentials-array-optional) for the
 full field reference.
 
 ## Pushing images: build-time credentials

--- a/docs/site/guides/private-registry.md
+++ b/docs/site/guides/private-registry.md
@@ -1,0 +1,99 @@
+# Private registry credentials
+
+When a realm pulls an image from a registry that requires authentication, the
+pull fails with `403 Forbidden` (containerd surfaces it as `pull access denied,
+repository does not exist or may require authorization`) unless that realm
+carries a credential for the registry. This guide covers how to attach those
+credentials — imperatively for quick setup, or declaratively as part of a Realm
+manifest.
+
+## Credentials are realm-scoped
+
+Registry credentials live on the **realm**, not the host. Each realm carries its
+own `spec.registryCredentials` list, so two realms can use the same image
+reference with different credentials — different teams can pull from different
+private registries without sharing a login. See
+[Concepts → Realm](../concepts/realm.md) for the full realm model.
+
+A credential is keyed by its registry host (`serverAddress`). A realm can hold
+credentials for multiple registries at once; each entry applies to the registry
+it names.
+
+## Imperative: `kuke create registry-credential`
+
+The quickest way to attach a credential to an **existing** realm:
+
+```bash
+# Pipe a token in from stdin (keeps it out of shell history)
+echo "$GHCR_TOKEN" | sudo kuke create registry-credential default \
+    --server ghcr.io --username my-user --password-stdin
+
+# Or read the token from a file
+sudo kuke create registry-credential default \
+    --server ghcr.io --username my-user --from-file ./ghcr-token.txt
+```
+
+The command reads the realm, upserts an entry onto its
+`spec.registryCredentials` keyed by `--server`, and re-applies the realm. The
+reconciler converges the change as a *compatible* update — no realm recreate and
+no cell disruption — so cells in the realm can immediately pull images that
+previously returned `403 Forbidden`.
+
+A few behaviors worth knowing:
+
+- **The token never enters argv.** Supply it via `--password-stdin` (read from
+  stdin, docker-login style) or `--from-file` (read from a file). Exactly one of
+  the two is required.
+- **Re-running upserts.** Re-running with the same `--server` updates that entry
+  in place (username + token) rather than appending a duplicate; a different
+  `--server` appends a new entry. Existing entries for other servers are
+  preserved.
+- **`--server` defaults to the image's host.** Leave `--server` empty and the
+  credential matches the registry extracted from the image reference at pull
+  time; set it explicitly (e.g. `ghcr.io`) to scope the credential to one host.
+
+See [kuke create → registry-credential](../cli/kuke-create.md#kuke-create-registry-credential)
+for the full flag table.
+
+## Declarative: `spec.registryCredentials`
+
+For anything you want to commit, diff, or apply repeatedly, put the credentials
+in a Realm manifest and use [`kuke apply`](../cli/kuke-apply.md). Manifests are
+the unit of version control; imperative commands are not.
+
+```yaml
+apiVersion: v1beta1
+kind: Realm
+metadata:
+  name: myrealm
+spec:
+  registryCredentials:
+    - username: eminwux
+      password: ${{ GHCR_TOKEN }}
+      serverAddress: ghcr.io
+```
+
+| Field           | Required | Description                                                                                         |
+| --------------- | -------- | --------------------------------------------------------------------------------------------------- |
+| `username`      | yes      | Registry username                                                                                   |
+| `password`      | yes      | Registry password or token                                                                          |
+| `serverAddress` | no       | Registry server (e.g. `docker.io`, `ghcr.io`). If omitted, applies to the registry in the image reference. |
+
+See [Manifests → Realm](../manifests/realm.md#specregistrycredentials) for the
+full field reference.
+
+## Pushing images: build-time credentials
+
+The credentials above authenticate image **pulls** for cells in a realm. Pushing
+an image you built with [`kuke build --push`](../cli/kuke-build.md) is a separate
+path with its own credential resolution: `$DOCKER_CONFIG/config.json` (when
+`DOCKER_CONFIG` is set), then `~/.docker/config.json`, then the
+`KUKEON_REGISTRY_AUTH` env var (base64 `user:pass`). The push tag must be a
+fully qualified `REGISTRY/REPO:TAG`.
+
+## Related
+
+- [kuke create](../cli/kuke-create.md) — imperative resource creation
+- [Manifests → Realm](../manifests/realm.md) — declarative Realm schema
+- [kuke build](../cli/kuke-build.md) — build and push images
+- [Troubleshooting → pull access denied](troubleshooting.md#pull-access-denied--403-on-a-private-image)

--- a/docs/site/guides/troubleshooting.md
+++ b/docs/site/guides/troubleshooting.md
@@ -227,6 +227,32 @@ sudo rmdir /sys/fs/cgroup/kukeon/<realm>/<space>/<stack>/<cell> 2>/dev/null || t
 sudo ip link delete kuke-<realm>-<space> 2>/dev/null || true
 ```
 
+## `pull access denied` / `403` on a private image
+
+**Symptom.** A cell fails to start and the containerd resolver reports:
+
+```
+pull access denied, repository does not exist or may require authorization
+```
+
+(or a bare `403 Forbidden`) when pulling an image from a private registry.
+
+**What it means.** The realm has no credential for that registry. Registry
+credentials are scoped to the realm, so even if another realm can pull the same
+image, the realm running this cell needs its own entry.
+
+**Fix.** Attach a credential to the realm:
+
+```bash
+echo "$REGISTRY_TOKEN" | sudo kuke create registry-credential <realm> \
+    --server <host> --username <user> --password-stdin
+```
+
+The reconciler converges the change without recreating the realm or disrupting
+cells, so the pull succeeds on the next attempt. See
+[Private registry credentials](private-registry.md) for the imperative and
+declarative setups in full.
+
 ## Verbose logging
 
 Add `--verbose` (or `-v`) to any `kuke` command to get structured slog output on stderr. Pair with `--log-level debug` for the most detail:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -89,6 +89,7 @@ nav:
       - guides/apply-manifests.md
       - guides/run-claude-code.md
       - guides/local-dev.md
+      - guides/private-registry.md
       - guides/autocomplete.md
       - guides/troubleshooting.md
   - CLI Reference:


### PR DESCRIPTION
## Summary
Best-effort documentation update applied from issue #1258.
Mode: best-effort — the issue body identified files and sections but did not provide paste-ready Before/After wording, so wording was authored to match the issue's Proposal and Acceptance criteria.

## Files changed
- `docs/site/guides/private-registry.md` (new) — Overview / imperative / declarative / build-push sections
- `docs/site/guides/troubleshooting.md` — new `pull access denied` / `403` section
- `mkdocs.yml` — added the new guide to the Guides nav

## Editorial choices
- Sourced every command, flag, and behavior verbatim-in-substance from the named reference pages (`kuke-create.md`, `manifests/realm.md`, `concepts/realm.md`, `kuke-build.md`); nothing invented.
- Placed the new guide after `local-dev.md` in the nav and the troubleshooting entry immediately before "Verbose logging" — both editorial placement choices, consistent with the existing operational grouping.
- Used mkdocs-material heading-slug anchors for the cross-links (e.g. `troubleshooting.md#pull-access-denied--403-on-a-private-image`).

## Acceptance criteria check
- [x] New `docs/site/guides/private-registry.md` covering overview, imperative, declarative, and build/push sections, matching the existing guides' prose style — done
- [x] Commands/flags/behaviors drawn from the named source pages, nothing invented — done
- [x] `troubleshooting.md` gains a `pull access denied` / `403` section cross-linking the new guide — done
- [x] New guide cross-links `kuke-create.md`, `manifests/realm.md`, and `kuke-build.md` — done
- [x] New page added to `mkdocs.yml` nav — done

Closes #1258