### PR TITLE
fix: resolve device nodes against host root when kukeond is containerized

### DIFF
--- a/internal/ctr/container_utils.go
+++ b/internal/ctr/container_utils.go
@@ -167,8 +167,13 @@ func BuildRootContainerSpec(
 		specOpts = append(specOpts, oci.WithEnv(env))
 	}
 
+	// Mirror BuildContainerSpec's privileged path: oci.WithPrivileged grants no
+	// device access, so pair it with an allow-all device cgroup and a
+	// host-root-aware enumeration of the host's /dev (resolved against the host
+	// root when kukeond is containerized) to restore `docker run --privileged`
+	// device parity (issue #1261).
 	if rootSpec.Privileged {
-		specOpts = append(specOpts, oci.WithPrivileged)
+		specOpts = append(specOpts, oci.WithPrivileged, oci.WithAllDevicesAllowed, privilegedHostDevicesOpt())
 	}
 
 	// Host network: drop the network LinuxNamespace entry from the OCI spec so

--- a/internal/ctr/devices.go
+++ b/internal/ctr/devices.go
@@ -1,0 +1,211 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package ctr
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/containerd/containerd/v2/core/containers"
+	"github.com/containerd/containerd/v2/pkg/oci"
+	runtimespec "github.com/opencontainers/runtime-spec/specs-go"
+)
+
+// hostRootViaPID1 is the path through which a process that shares the host PID
+// namespace reaches the host's root filesystem: PID 1's root, exposed by
+// procfs as a magic symlink. kukeond runs inside the kuke-system kukeond cell
+// with hostPID: true (required by the CNI bridge path), so /proc/1/root is the
+// host root even though the cell's own mount namespace exposes only a minimal
+// /dev that contains none of the host's pass-through device nodes.
+const hostRootViaPID1 = "/proc/1/root"
+
+// deviceHostRoot returns the filesystem prefix under which the kukeond process
+// must resolve *host* device nodes when building a container spec. Device
+// resolution (the os.Stat behind oci.DeviceFromPath / oci.HostDevices) runs in
+// the kukeond process, not in the target container — so when kukeond is
+// containerized its own mount namespace, not the host's, is what gets stat'd.
+// The cell binds only /run/kukeon and /opt/kukeon; its /dev is the cell's
+// devtmpfs (default nodes only), so a host device path like /dev/kvm fails the
+// stat. Resolving against the host root reachable at /proc/1/root fixes that.
+//
+// Indirected through a var so tests can pin the prefix without a containerized
+// daemon.
+var deviceHostRoot = resolveDeviceHostRoot
+
+func resolveDeviceHostRoot() string {
+	if daemonInPrivateMountNS() {
+		return hostRootViaPID1
+	}
+	return "/"
+}
+
+// daemonInPrivateMountNS reports whether the calling process's root filesystem
+// differs from PID 1's — i.e. kukeond runs in its own mount namespace (the
+// containerized kukeond cell) rather than sharing the host's (un-containerized
+// dev loops, host-side kuke init). When the two roots are the same inode the
+// daemon's own /dev *is* the host's, so device resolution needs no prefix.
+//
+// A normal container that does not share the host PID namespace sees its own
+// init as PID 1, so /proc/1/root equals its own root and this correctly
+// reports false — only the kukeond cell's hostPID + private-mount-ns shape
+// (host PID 1 with a different root) reports true. If /proc/1/root cannot be
+// stat'd (no procfs, PID 1 not visible, insufficient privilege) the daemon
+// falls back to resolving against its own /, the historical behavior.
+func daemonInPrivateMountNS() bool {
+	self, err := os.Stat("/")
+	if err != nil {
+		return false
+	}
+	pid1, err := os.Stat(hostRootViaPID1)
+	if err != nil {
+		return false
+	}
+	return !os.SameFile(self, pid1)
+}
+
+// deviceFromPath resolves a single host device node into its OCI LinuxDevice.
+// Indirected for tests; defaults to containerd's oci.DeviceFromPath, which
+// Lstat's the node and reads its type/major/minor/mode.
+var deviceFromPath = oci.DeviceFromPath
+
+// hostLinuxDeviceOpt returns a SpecOpts that replicates the host device node at
+// containerPath into the container — appending a Linux.Devices entry (so the
+// node is visible at containerPath inside the container) and a matching
+// Linux.Resources.Devices allow rule (so open() is not denied by the default
+// deny-all device cgroup). It is the host-root-aware replacement for
+// oci.WithLinuxDevice, which stat's the path in the kukeond process's own mount
+// namespace and so fails for any host device absent from the containerized
+// daemon cell's minimal /dev. The node is stat'd via the host-root prefix but
+// exposed at the un-prefixed containerPath. A missing node fails container
+// create with an error naming the requested path. Issue #1261.
+func hostLinuxDeviceOpt(containerPath, access string) oci.SpecOpts {
+	return func(_ context.Context, _ oci.Client, _ *containers.Container, s *runtimespec.Spec) error {
+		hostPath := filepath.Join(deviceHostRoot(), strings.TrimPrefix(containerPath, "/"))
+		dev, err := deviceFromPath(hostPath)
+		if err != nil {
+			return fmt.Errorf("resolve device %q: %w", containerPath, err)
+		}
+		// Expose the node at the path the caller asked for, not the
+		// host-root-prefixed path it was stat'd through.
+		dev.Path = containerPath
+
+		if s.Linux == nil {
+			s.Linux = &runtimespec.Linux{}
+		}
+		if s.Linux.Resources == nil {
+			s.Linux.Resources = &runtimespec.LinuxResources{}
+		}
+		s.Linux.Devices = append(s.Linux.Devices, *dev)
+		s.Linux.Resources.Devices = append(s.Linux.Resources.Devices, runtimespec.LinuxDeviceCgroup{
+			Type:   dev.Type,
+			Allow:  true,
+			Major:  &dev.Major,
+			Minor:  &dev.Minor,
+			Access: access,
+		})
+		return nil
+	}
+}
+
+// privilegedHostDevicesOpt returns a SpecOpts that populates Linux.Devices with
+// every host device node, resolved against the host root so a containerized
+// kukeond replicates the *host's* /dev rather than the kukeond cell's minimal
+// devtmpfs. Paired with oci.WithAllDevicesAllowed at the privileged call sites,
+// it restores `docker run --privileged` / `ctr run --privileged` device parity
+// without the namespace blindness of oci.WithHostDevices, which enumerates the
+// calling process's own /dev (the daemon cell's, when containerized). When
+// kukeond is un-containerized its own /dev is the host's, so the well-tested
+// oci.WithHostDevices is reused directly. Issue #1261 (supersedes the
+// namespace-blind approach proposed for #1255).
+func privilegedHostDevicesOpt() oci.SpecOpts {
+	return func(ctx context.Context, client oci.Client, c *containers.Container, s *runtimespec.Spec) error {
+		root := deviceHostRoot()
+		if root == "/" {
+			return oci.WithHostDevices(ctx, client, c, s)
+		}
+		devRoot := filepath.Join(root, "dev")
+		devices, err := enumerateHostDevices(devRoot)
+		if err != nil {
+			return fmt.Errorf("enumerate host devices under %q: %w", devRoot, err)
+		}
+		if s.Linux == nil {
+			s.Linux = &runtimespec.Linux{}
+		}
+		s.Linux.Devices = append(s.Linux.Devices, devices...)
+		return nil
+	}
+}
+
+// enumerateHostDevices walks the device tree rooted at devRoot (e.g.
+// /proc/1/root/dev) and returns the contained nodes with their Path rewritten
+// to the in-container /dev/... path, stripping the host-root prefix. It is the
+// host-root-aware analogue of oci.HostDevices(), which is hard-wired to the
+// calling process's own /dev. Mirrors containerd's getDevices skip list:
+// pseudo-filesystem subdirs, the console, fifos, and non-device entries.
+func enumerateHostDevices(devRoot string) ([]runtimespec.LinuxDevice, error) {
+	var out []runtimespec.LinuxDevice
+	if err := walkHostDevices(devRoot, devRoot, &out); err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func walkHostDevices(devRoot, dir string, out *[]runtimespec.LinuxDevice) error {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return err
+	}
+	for _, e := range entries {
+		full := filepath.Join(dir, e.Name())
+		if e.IsDir() {
+			switch e.Name() {
+			// Pseudo-filesystems and bookkeeping dirs containerd's getDevices
+			// skips; recursing into them yields no real pass-through nodes.
+			case "pts", "shm", "fd", "mqueue", ".lxc", ".lxd-mounts", ".udev":
+				continue
+			}
+			if err := walkHostDevices(devRoot, full, out); err != nil {
+				return err
+			}
+			continue
+		}
+		if e.Name() == "console" {
+			continue
+		}
+		dev, err := deviceFromPath(full)
+		if err != nil {
+			if errors.Is(err, oci.ErrNotADevice) || os.IsNotExist(err) {
+				continue
+			}
+			return err
+		}
+		if dev.Type == "p" { // fifo — not a pass-through device
+			continue
+		}
+		rel, err := filepath.Rel(devRoot, full)
+		if err != nil {
+			return err
+		}
+		dev.Path = filepath.Join("/dev", rel)
+		*out = append(*out, *dev)
+	}
+	return nil
+}

--- a/internal/ctr/devices_internal_test.go
+++ b/internal/ctr/devices_internal_test.go
@@ -1,0 +1,128 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package ctr
+
+import (
+	"context"
+	"os"
+	"strings"
+	"testing"
+
+	runtimespec "github.com/opencontainers/runtime-spec/specs-go"
+)
+
+// pinDeviceResolution overrides the host-root prefix and the node resolver for
+// the duration of a test, restoring both on cleanup. It lets the host-root
+// rewrite be exercised deterministically without a containerized daemon or the
+// root privilege a real mknod would need — the gap the issue notes unit tests
+// "structurally cannot catch" is only the live containerized stat, not this
+// path-rewrite logic.
+func pinDeviceResolution(t *testing.T, root string, resolve func(string) (*runtimespec.LinuxDevice, error)) {
+	t.Helper()
+	origRoot, origResolve := deviceHostRoot, deviceFromPath
+	t.Cleanup(func() { deviceHostRoot, deviceFromPath = origRoot, origResolve })
+	deviceHostRoot = func() string { return root }
+	deviceFromPath = resolve
+}
+
+// TestHostLinuxDeviceOpt_ResolvesViaHostRoot asserts that when kukeond is
+// containerized (deviceHostRoot == /proc/1/root) a devices[] entry is stat'd
+// through the host-root prefix yet exposed in the container at its original,
+// un-prefixed path, with a matching device-cgroup allow rule. Issue #1261.
+func TestHostLinuxDeviceOpt_ResolvesViaHostRoot(t *testing.T) {
+	mode := os.FileMode(0o660)
+	var statted string
+	pinDeviceResolution(t, hostRootViaPID1, func(path string) (*runtimespec.LinuxDevice, error) {
+		statted = path
+		if path != "/proc/1/root/dev/kvm" {
+			return nil, os.ErrNotExist
+		}
+		return &runtimespec.LinuxDevice{Type: "c", Path: path, Major: 10, Minor: 232, FileMode: &mode}, nil
+	})
+
+	spec := &runtimespec.Spec{Linux: &runtimespec.Linux{}}
+	if err := hostLinuxDeviceOpt("/dev/kvm", deviceAccessRWM)(context.Background(), nil, nil, spec); err != nil {
+		t.Fatalf("hostLinuxDeviceOpt returned error: %v", err)
+	}
+
+	if statted != "/proc/1/root/dev/kvm" {
+		t.Errorf("node stat'd at %q, want host-root-prefixed /proc/1/root/dev/kvm", statted)
+	}
+	if len(spec.Linux.Devices) != 1 || spec.Linux.Devices[0].Path != "/dev/kvm" {
+		t.Fatalf("Linux.Devices = %+v, want a single entry exposed at /dev/kvm", spec.Linux.Devices)
+	}
+	if spec.Linux.Resources == nil || len(spec.Linux.Resources.Devices) != 1 {
+		t.Fatalf("expected one device-cgroup allow rule, got %+v", spec.Linux.Resources)
+	}
+	r := spec.Linux.Resources.Devices[0]
+	if !r.Allow || r.Type != "c" || r.Major == nil || *r.Major != 10 || r.Minor == nil || *r.Minor != 232 || r.Access != "rwm" {
+		t.Errorf("device-cgroup rule = %+v, want allow c 10:232 rwm", r)
+	}
+}
+
+// TestHostLinuxDeviceOpt_MissingNodeNamesPath asserts that a node missing on
+// the host fails container create with an error that names the requested device
+// path — the "clear error for a missing node" the issue calls out as unmet by
+// the path-less ENOENT the old in-daemon stat produced. Issue #1261.
+func TestHostLinuxDeviceOpt_MissingNodeNamesPath(t *testing.T) {
+	pinDeviceResolution(t, hostRootViaPID1, func(string) (*runtimespec.LinuxDevice, error) {
+		return nil, os.ErrNotExist
+	})
+
+	err := hostLinuxDeviceOpt("/dev/kvm", deviceAccessRWM)(context.Background(), nil, nil, &runtimespec.Spec{Linux: &runtimespec.Linux{}})
+	if err == nil {
+		t.Fatal("expected a create-time error for a missing host node, got nil")
+	}
+	if !strings.Contains(err.Error(), "/dev/kvm") {
+		t.Errorf("error %q does not name the device path /dev/kvm", err)
+	}
+}
+
+// TestEnumerateHostDevices_RewritesContainerPath exercises the privileged-path
+// walker against the test host's real /dev (standing in for a host-root /dev),
+// asserting every returned node is rooted at /dev with the prefix stripped.
+// Skips when the test host's /dev has no device nodes. Issue #1261.
+func TestEnumerateHostDevices_RewritesContainerPath(t *testing.T) {
+	devices, err := enumerateHostDevices("/dev")
+	if err != nil {
+		t.Fatalf("enumerateHostDevices(/dev): %v", err)
+	}
+	if len(devices) == 0 {
+		t.Skip("no device nodes under /dev on the test host")
+	}
+	for _, d := range devices {
+		if !strings.HasPrefix(d.Path, "/dev/") {
+			t.Errorf("device exposed at %q, want a /dev/... container path", d.Path)
+		}
+		if d.Type == "p" {
+			t.Errorf("fifo %q should have been skipped", d.Path)
+		}
+	}
+}
+
+// TestResolveDeviceHostRoot_UnContainerized asserts that on a host where the
+// process shares PID 1's root (the unit-test environment), resolution targets
+// "/" — preserving the historical in-daemon stat behavior so a privileged or
+// devices[] spec built off the host behaves exactly as before. Issue #1261.
+func TestResolveDeviceHostRoot_UnContainerized(t *testing.T) {
+	if daemonInPrivateMountNS() {
+		t.Skip("test host is in a private mount namespace relative to PID 1")
+	}
+	if got := resolveDeviceHostRoot(); got != "/" {
+		t.Errorf("resolveDeviceHostRoot() = %q, want \"/\" when un-containerized", got)
+	}
+}

--- a/internal/ctr/spec.go
+++ b/internal/ctr/spec.go
@@ -380,9 +380,16 @@ func BuildContainerSpec(
 		specOpts = append(specOpts, oci.WithEnv(env))
 	}
 
-	// Set privileged mode if specified
+	// Set privileged mode if specified. oci.WithPrivileged handles
+	// capabilities, masked/readonly paths, writable sysfs/cgroupfs and
+	// seccomp/apparmor unconfinement but no device exposure, so a privileged
+	// cell could not open() any host node. Pair it with an allow-all device
+	// cgroup and a host-root-aware enumeration of the host's /dev to restore
+	// `docker run --privileged` device parity; privilegedHostDevicesOpt
+	// resolves against the host root so a containerized kukeond replicates the
+	// host's nodes, not the daemon cell's minimal devtmpfs (issue #1261).
 	if containerSpec.Privileged {
-		specOpts = append(specOpts, oci.WithPrivileged)
+		specOpts = append(specOpts, oci.WithPrivileged, oci.WithAllDevicesAllowed, privilegedHostDevicesOpt())
 	}
 
 	// Host network: drop the network LinuxNamespace entry from the OCI spec so
@@ -436,8 +443,10 @@ func BuildContainerSpec(
 	// container (Linux.Devices) and adds a matching device-cgroup allow rule
 	// (Linux.Resources.Devices), the same pair Docker's --device emits. The
 	// least-privilege alternative to Privileged. The host node is stat'd at
-	// this point (create time) via oci.WithLinuxDevice → DeviceFromPath, which
-	// returns a clear error for a missing node so container create fails fast.
+	// this point (create time), resolved against the host root when kukeond is
+	// containerized so a host path like /dev/kvm is found in the host's /dev
+	// rather than the daemon cell's minimal devtmpfs (issue #1261), and a
+	// missing node returns a clear path-named error so create fails fast.
 	specOpts = append(specOpts, deviceSpecOpts(containerSpec.Devices)...)
 
 	// Linux.CgroupsPath: place the container task inside the cell's cgroup
@@ -747,12 +756,13 @@ func tmpfsVolumeMount(v intmodel.VolumeMount) (runtimespec.Mount, bool) {
 const deviceAccessRWM = "rwm"
 
 // deviceSpecOpts builds one OCI spec option per short-form devices[] entry.
-// Each entry is a host device path (e.g. "/dev/kvm"); oci.WithLinuxDevice
-// stat's the node at create time and appends both a Linux.Devices entry (so
-// the node is visible in the container at the same path) and a matching
+// Each entry is a host device path (e.g. "/dev/kvm"); hostLinuxDeviceOpt stat's
+// the node at create time — against the host root when kukeond is containerized
+// (issue #1261) — and appends both a Linux.Devices entry (so the node is
+// visible in the container at the same path) and a matching
 // Linux.Resources.Devices allow rule (so open() is not denied by the default
 // deny-all device cgroup). A missing host node surfaces as a create-time error
-// from DeviceFromPath. Empty/blank entries are skipped. Issue #1252.
+// naming the path. Empty/blank entries are skipped. Issue #1252.
 func deviceSpecOpts(devices []string) []oci.SpecOpts {
 	if len(devices) == 0 {
 		return nil
@@ -763,7 +773,7 @@ func deviceSpecOpts(devices []string) []oci.SpecOpts {
 		if path == "" {
 			continue
 		}
-		opts = append(opts, oci.WithLinuxDevice(path, deviceAccessRWM))
+		opts = append(opts, hostLinuxDeviceOpt(path, deviceAccessRWM))
 	}
 	return opts
 }

--- a/internal/ctr/spec_privileged_devices_test.go
+++ b/internal/ctr/spec_privileged_devices_test.go
@@ -1,0 +1,116 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package ctr_test
+
+import (
+	"context"
+	"testing"
+
+	ctr "github.com/eminwux/kukeon/internal/ctr"
+	intmodel "github.com/eminwux/kukeon/internal/modelhub"
+	runtimespec "github.com/opencontainers/runtime-spec/specs-go"
+)
+
+// hasAllowAllDeviceRule reports whether resources carries the wildcard
+// allow-all device-cgroup rule oci.WithAllDevicesAllowed emits (Allow, no
+// type/major/minor, rwm access).
+func hasAllowAllDeviceRule(resources *runtimespec.LinuxResources) bool {
+	if resources == nil {
+		return false
+	}
+	for _, r := range resources.Devices {
+		if r.Allow && r.Type == "" && r.Major == nil && r.Minor == nil && r.Access == "rwm" {
+			return true
+		}
+	}
+	return false
+}
+
+// TestBuildContainerSpec_PrivilegedHostDevices asserts that a privileged
+// container gets the allow-all device cgroup rule and host device nodes
+// replicated into Linux.Devices, restoring `docker run --privileged` device
+// parity. The enumeration runs against the un-containerized test host's /dev
+// (the host-root containerized path is e2e-only). Issue #1261.
+func TestBuildContainerSpec_PrivilegedHostDevices(t *testing.T) {
+	spec := applyBuiltSpec(t, intmodel.ContainerSpec{
+		ID:         "c1",
+		Image:      "registry.eminwux.com/busybox:latest",
+		CellName:   "cell",
+		SpaceName:  "space",
+		RealmName:  "realm",
+		StackName:  "stack",
+		Privileged: true,
+	})
+
+	if spec.Linux == nil {
+		t.Fatalf("Linux section is nil")
+	}
+	if !hasAllowAllDeviceRule(spec.Linux.Resources) {
+		t.Errorf("privileged spec missing allow-all device cgroup rule: %+v", spec.Linux.Resources)
+	}
+	if len(spec.Linux.Devices) == 0 {
+		t.Errorf("privileged spec replicated no host devices into Linux.Devices")
+	}
+}
+
+// TestBuildRootContainerSpec_PrivilegedHostDevices asserts the root-container
+// path gets the same allow-all rule + host-device replication. Issue #1261.
+func TestBuildRootContainerSpec_PrivilegedHostDevices(t *testing.T) {
+	built := ctr.BuildRootContainerSpec(intmodel.ContainerSpec{
+		ID:         "root",
+		Root:       true,
+		Image:      "registry.eminwux.com/busybox:latest",
+		CellName:   "cell",
+		SpaceName:  "space",
+		RealmName:  "realm",
+		StackName:  "stack",
+		Privileged: true,
+	}, nil)
+
+	spec := &runtimespec.Spec{Process: &runtimespec.Process{}, Linux: &runtimespec.Linux{}}
+	for _, opt := range built.SpecOpts {
+		if err := opt(context.Background(), nil, nil, spec); err != nil {
+			t.Fatalf("SpecOpts returned error: %v", err)
+		}
+	}
+
+	if !hasAllowAllDeviceRule(spec.Linux.Resources) {
+		t.Errorf("privileged root spec missing allow-all device cgroup rule: %+v", spec.Linux.Resources)
+	}
+	if len(spec.Linux.Devices) == 0 {
+		t.Errorf("privileged root spec replicated no host devices into Linux.Devices")
+	}
+}
+
+// TestBuildContainerSpec_NonPrivilegedNoAllowAll asserts a non-privileged
+// container without devices[] gets neither the allow-all rule nor host-device
+// replication, so the privileged change does not leak into ordinary cells.
+// Issue #1261.
+func TestBuildContainerSpec_NonPrivilegedNoAllowAll(t *testing.T) {
+	spec := applyBuiltSpec(t, intmodel.ContainerSpec{
+		ID:        "c1",
+		Image:     "registry.eminwux.com/busybox:latest",
+		CellName:  "cell",
+		SpaceName: "space",
+		RealmName: "realm",
+		StackName: "stack",
+	})
+
+	if spec.Linux != nil && hasAllowAllDeviceRule(spec.Linux.Resources) {
+		t.Errorf("non-privileged spec unexpectedly carries allow-all device rule: %+v", spec.Linux.Resources)
+	}
+}


### PR DESCRIPTION
## Summary
- `deviceSpecOpts` resolved `devices[]` host nodes with `oci.WithLinuxDevice` → `DeviceFromPath` → `os.Stat`, which runs **in the kukeond process**. When kukeond is containerized (the `kuke init` default), the daemon cell's mount namespace exposes only its own minimal `/dev`, so a host path like `/dev/kvm` fails the stat and container create dies with a path-less `no such file or directory`. The kukeond cell runs `hostPID: true`, so the host root — and the host's `/dev` — is reachable at `/proc/1/root`; device resolution now targets that prefix when the daemon is in a private mount namespace, and `/` (unchanged behavior) otherwise.
- The node is stat'd through the host-root prefix but exposed in the container at the **un-prefixed** path, and a missing node now fails create with an error that **names the device** (`resolve device "/dev/kvm": ...`) — closing the unmet "clear error for a missing node" item the issue calls out.
- `privileged: true` now pairs `oci.WithPrivileged` (which grants *no* device access on its own) with `oci.WithAllDevicesAllowed` + a host-root-aware enumeration of the host's `/dev`, restoring `docker run --privileged` / `ctr run --privileged` device parity at both privileged call sites (`BuildContainerSpec`, `BuildRootContainerSpec`). Un-containerized this reuses the well-tested `oci.WithHostDevices`; containerized it walks `/proc/1/root/dev` and rewrites container paths back to `/dev/...`.

## Reinterpreted scope (premise note for the reviewer)
The issue's suggested fix says "enumerate `<hostRoot>/dev` instead of `oci.WithHostDevices`" for the privileged path, implying #1255's fix (PR #1256) had landed. **#1256 was closed unmerged** (LGTM'd, then closed by the owner — superseded by this issue's correct-namespace approach). So on `origin/main` the privileged path is bare `oci.WithPrivileged` with *zero* host devices. This PR therefore **adds** host-root-aware device exposure rather than replacing `WithHostDevices`. The intent — privileged containers see the host's devices, resolved correctly even when the daemon is containerized — is unchanged; the diff just also carries the device-exposure #1256 would have added, done host-root-aware. Flagging so the reviewer can push back if absorbing #1255/#1256's behavior here oversteps.

## Test plan
- [x] `GOWORK=off go build ./internal/ctr/...` + `go vet ./internal/ctr/...` — clean
- [x] `make test` (full CI suite, `GOWORK=off` per Makefile) — exit 0
- [x] New unit tests: `TestHostLinuxDeviceOpt_ResolvesViaHostRoot` (stat goes through `/proc/1/root`, node exposed at `/dev/kvm`, cgroup allow rule emitted), `TestHostLinuxDeviceOpt_MissingNodeNamesPath` (error names the path), `TestEnumerateHostDevices_RewritesContainerPath` (privileged walker rewrites to `/dev/...`, skips fifos), `TestResolveDeviceHostRoot_UnContainerized`, and privileged-parity tests for both spec builders + a non-privileged negative.
- [x] Detection sanity-checked at runtime in a real cell: with PID 1 sharing the cell's root mount, `daemonInPrivateMountNS()` returns false → resolves against `/` (historical behavior preserved). Only the `hostPID` kukeond cell, whose PID 1 is the *host* init with a different root, flips to `/proc/1/root`.
- [ ] Live containerized device-passthrough (build the spec through a `hostPID` kukeond cell that is itself containerized, confirm `/dev/kvm` resolves) — **not run**: this is the e2e-shaped test the issue notes "unit tests on the generated OCI spec structurally cannot catch", and the dev host has no standalone containerd socket / full `kuke init` stack to bring up the nested daemon safely. The host-root *resolution* logic is exercised deterministically by the unit tests above via an injected resolver; the un-containerized privileged-parity path is identical to PR #1256, which was `make e2e`-green. Recommend the reviewer (or a follow-up e2e job) verify the live containerized stat on a clean host.

Closes #1261