### PR TITLE
feat: installer detects daemon version skew and points at kuke daemon recreate

### DIFF
--- a/docs/site/install.sh
+++ b/docs/site/install.sh
@@ -21,6 +21,10 @@
 #   KUKE_SKIP_CHECKSUM=1   skip .sha256 verification (NOT recommended)
 #   KUKE_SKIP_KUKEBUILD=1  skip downloading/installing kukebuild (disables
 #                          `kuke build`; for release tags predating its asset)
+#   KUKE_SKIP_DAEMON_UPGRADE=1
+#                          on a live host, skip the daemon version check and
+#                          keep an intentionally pinned older daemon (preserves
+#                          the historical silent-skip behavior)
 
 set -euo pipefail
 
@@ -30,6 +34,12 @@ KUKE_VERSION="${KUKE_VERSION:-}"
 KUKE_SKIP_INIT="${KUKE_SKIP_INIT:-}"
 KUKE_SKIP_CHECKSUM="${KUKE_SKIP_CHECKSUM:-}"
 KUKE_SKIP_KUKEBUILD="${KUKE_SKIP_KUKEBUILD:-}"
+KUKE_SKIP_DAEMON_UPGRADE="${KUKE_SKIP_DAEMON_UPGRADE:-}"
+
+# Set by handle_running_daemon when a live host's daemon is older than the
+# binaries just installed; main exits non-zero on this so the installer never
+# prints an unqualified success banner over a client/daemon version skew.
+KUKE_DAEMON_SKEW=""
 
 MODE="install"
 
@@ -67,6 +77,9 @@ Env overrides:
   KUKE_SKIP_INIT=1       Skip the post-install \`kuke init\` step.
   KUKE_SKIP_CHECKSUM=1   Skip .sha256 verification (NOT recommended).
   KUKE_SKIP_KUKEBUILD=1  Skip kukebuild (disables \`kuke build\`).
+  KUKE_SKIP_DAEMON_UPGRADE=1
+                         On a live host, skip the daemon version check and keep
+                         an intentionally pinned older daemon.
 EOF
 }
 
@@ -381,14 +394,54 @@ do_install() {
     # Idempotency: if the daemon socket exists, init already ran. Skip
     # rather than re-running, because `kuke init` on a healthy host is a
     # no-op only if the prior bootstrap left consistent state — and we
-    # cannot reliably detect that from a shell script.
+    # cannot reliably detect that from a shell script. But a live daemon
+    # older than the binaries we just installed must NOT be declared a
+    # success — handle_running_daemon compares versions and surfaces the
+    # skew + recreate command instead of an unqualified skip (issue #1260).
     if [ -S /run/kukeon/kukeond.sock ]; then
-        ok "kukeond already running at /run/kukeon/kukeond.sock — skipping \`kuke init\`"
+        handle_running_daemon
     else
         $SUDO kuke init
     fi
 
     install_systemd_unit
+}
+
+# --- Running-daemon version gate ---------------------------------------------
+# A binary upgrade on a live host leaves the old kukeond running. The previous
+# liveness-only skip (socket present → skip) declared that a success even when
+# the daemon predated the new binaries, ending in a client/daemon version skew
+# the installer just called done (issue #1260). This compares the live daemon's
+# version against the just-installed client and, on a mismatch, surfaces the
+# exact `kuke daemon recreate` command rather than a silent skip.
+#
+# `kuke version --strict` prints the Client/Daemon lines and exits non-zero
+# only on a real version mismatch; an unreachable daemon (socket present but
+# dead) prints a warning and exits 0, so it falls through to the historical
+# skip rather than a spurious recreate prompt. The installer does not auto-cycle
+# the daemon — a recreate tears down and re-provisions the kuke-system kukeond
+# cell, too aggressive to do unprompted from a piped curl|bash — so it prints
+# the copy-pasteable command and lets main exit non-zero on the skew.
+handle_running_daemon() {
+    if [ -n "$KUKE_SKIP_DAEMON_UPGRADE" ]; then
+        ok "kukeond already running at /run/kukeon/kukeond.sock — skipping \`kuke init\` (KUKE_SKIP_DAEMON_UPGRADE=1)"
+        return 0
+    fi
+
+    local version_out
+    if version_out="$($SUDO kuke version --strict 2>&1)"; then
+        ok "kukeond already running at /run/kukeon/kukeond.sock (version-matched) — skipping \`kuke init\`"
+        return 0
+    fi
+
+    KUKE_DAEMON_SKEW=1
+    fail "kukeond is older than the binaries just installed (client ${KUKE_VERSION}) — leaving a client/daemon version skew."
+    printf '%s\n' "$version_out" | sed 's/^/    /' >&2
+    printf '\n    Upgrade the daemon to match. Workload cells are untouched — recreate\n' >&2
+    printf '    only cycles the kuke-system kukeond cell:\n\n' >&2
+    printf '      %ssudo kuke daemon recreate --kukeond-image ghcr.io/%s:%s%s\n\n' "$C_BOLD" "$KUKE_REPO" "$KUKE_VERSION" "$C_RESET" >&2
+    printf '    To keep an intentionally pinned older daemon, re-run with KUKE_SKIP_DAEMON_UPGRADE=1.\n' >&2
+    return 0
 }
 
 # --- systemd unit ------------------------------------------------------------
@@ -485,4 +538,15 @@ if [ "$MODE" = "check" ]; then
 fi
 
 do_install
+
+# A live host with a daemon older than the just-installed binaries is left in a
+# version skew (handle_running_daemon already printed the recreate command).
+# Exit non-zero with a qualified message instead of the rosy "installed and
+# initialized" banner — the installer must never claim an unqualified success
+# over a skew it just declared (issue #1260).
+if [ -n "$KUKE_DAEMON_SKEW" ]; then
+    fail "binaries installed, but the running daemon is older — run the recreate command above to finish the upgrade."
+    exit 1
+fi
+
 print_next_steps

--- a/docs/site/install/install-linux.md
+++ b/docs/site/install/install-linux.md
@@ -15,7 +15,7 @@ The installer:
 1. Detects your platform (`linux/amd64` or `linux/arm64`) and refuses anything else.
 2. Verifies cgroups v2 is mounted and `/run/containerd/containerd.sock` is responsive. On any miss it prints a distro-aware hint and exits non-zero without touching the system.
 3. Downloads the latest release binary from GitHub, verifies its `.sha256` checksum, installs it to `/usr/local/bin/kuke`, and hard-links `kukeond` next to it.
-4. Runs `sudo kuke init` to bring up the daemon. Skipped on a host that already has a healthy `kukeond` listening on `/run/kukeon/kukeond.sock`.
+4. Runs `sudo kuke init` to bring up the daemon. On a host that already has a `kukeond` listening on `/run/kukeon/kukeond.sock`, init is skipped — but the installer first compares the running daemon's version against the binaries it just installed. A version-matched daemon is skipped silently as before; an **older** daemon prints the exact `kuke daemon recreate` command to finish the upgrade and exits non-zero rather than declaring an unqualified success over a client/daemon skew (see [Upgrade](#upgrade)). Set `KUKE_SKIP_DAEMON_UPGRADE=1` to keep an intentionally pinned older daemon.
 5. Installs `/etc/systemd/system/kukeond.service` and runs `systemctl enable --now kukeond.service` so the daemon comes back automatically after a host or containerd restart. Skipped with a notice on systemd-less hosts — bring kukeond up manually with `sudo kuke daemon start` after each reboot in that case.
 
 Pass `--check` to run the prereq checks only without touching the system:
@@ -33,6 +33,7 @@ Environment overrides the installer honors:
 | `KUKE_INSTALL_PREFIX`  | Install dir (default: `/usr/local/bin`).                         |
 | `KUKE_SKIP_INIT=1`     | Skip the post-install `kuke init` step.                          |
 | `KUKE_SKIP_CHECKSUM=1` | Skip `.sha256` verification (not recommended).                   |
+| `KUKE_SKIP_DAEMON_UPGRADE=1` | On a live host, skip the running-daemon version check and keep an intentionally pinned older daemon (preserves the historical silent-skip on an already-running socket). |
 
 ## Manual install (fallback)
 
@@ -101,6 +102,29 @@ If your host has no systemd (some minimal container images, dev sandboxes), the 
 ```bash
 sudo kuke daemon start
 ```
+
+## Upgrade
+
+The canonical upgrade procedure is **re-run the installer, then recreate the daemon** so the running `kukeond` matches the new binaries:
+
+```bash
+curl -fsSL https://kukeon.io/install.sh | bash
+```
+
+Re-running the one-liner installs the latest `kuke` / `kukeond` / `kukebuild` / `kukepause` binaries. Because `kuke init` already ran on this host, the installer skips it — but it now checks the **running** daemon's version against the binaries it just installed:
+
+- **Version-matched daemon** — skipped silently, no daemon churn.
+- **Older daemon** — the installer does **not** auto-cycle it (a recreate tears down and re-provisions the daemon cell, too aggressive to do unprompted from a piped `curl | bash`). Instead it prints the exact command and exits non-zero:
+
+  ```bash
+  sudo kuke daemon recreate --kukeond-image ghcr.io/eminwux/kukeon:<installed-version>
+  ```
+
+  Run it to finish the upgrade. `kuke daemon recreate` cycles **only** the `kuke-system` kukeond cell — your workload cells in the `default` realm are untouched. Confirm the result with `kuke version` (the `Client:` and `Daemon:` lines should match).
+
+To keep an intentionally pinned older daemon while still upgrading the CLI binaries, set `KUKE_SKIP_DAEMON_UPGRADE=1` — the installer then preserves the historical silent-skip on an already-running socket.
+
+> Pin a specific target version with `KUKE_VERSION=vX.Y.Z` (see the [environment overrides](#one-line-install-recommended) table). The `--kukeond-image` tag the installer prints always matches the binaries it installed.
 
 ## Uninstall
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -21,6 +21,10 @@
 #   KUKE_SKIP_CHECKSUM=1   skip .sha256 verification (NOT recommended)
 #   KUKE_SKIP_KUKEBUILD=1  skip downloading/installing kukebuild (disables
 #                          `kuke build`; for release tags predating its asset)
+#   KUKE_SKIP_DAEMON_UPGRADE=1
+#                          on a live host, skip the daemon version check and
+#                          keep an intentionally pinned older daemon (preserves
+#                          the historical silent-skip behavior)
 
 set -euo pipefail
 
@@ -30,6 +34,12 @@ KUKE_VERSION="${KUKE_VERSION:-}"
 KUKE_SKIP_INIT="${KUKE_SKIP_INIT:-}"
 KUKE_SKIP_CHECKSUM="${KUKE_SKIP_CHECKSUM:-}"
 KUKE_SKIP_KUKEBUILD="${KUKE_SKIP_KUKEBUILD:-}"
+KUKE_SKIP_DAEMON_UPGRADE="${KUKE_SKIP_DAEMON_UPGRADE:-}"
+
+# Set by handle_running_daemon when a live host's daemon is older than the
+# binaries just installed; main exits non-zero on this so the installer never
+# prints an unqualified success banner over a client/daemon version skew.
+KUKE_DAEMON_SKEW=""
 
 MODE="install"
 
@@ -67,6 +77,9 @@ Env overrides:
   KUKE_SKIP_INIT=1       Skip the post-install \`kuke init\` step.
   KUKE_SKIP_CHECKSUM=1   Skip .sha256 verification (NOT recommended).
   KUKE_SKIP_KUKEBUILD=1  Skip kukebuild (disables \`kuke build\`).
+  KUKE_SKIP_DAEMON_UPGRADE=1
+                         On a live host, skip the daemon version check and keep
+                         an intentionally pinned older daemon.
 EOF
 }
 
@@ -381,14 +394,54 @@ do_install() {
     # Idempotency: if the daemon socket exists, init already ran. Skip
     # rather than re-running, because `kuke init` on a healthy host is a
     # no-op only if the prior bootstrap left consistent state — and we
-    # cannot reliably detect that from a shell script.
+    # cannot reliably detect that from a shell script. But a live daemon
+    # older than the binaries we just installed must NOT be declared a
+    # success — handle_running_daemon compares versions and surfaces the
+    # skew + recreate command instead of an unqualified skip (issue #1260).
     if [ -S /run/kukeon/kukeond.sock ]; then
-        ok "kukeond already running at /run/kukeon/kukeond.sock — skipping \`kuke init\`"
+        handle_running_daemon
     else
         $SUDO kuke init
     fi
 
     install_systemd_unit
+}
+
+# --- Running-daemon version gate ---------------------------------------------
+# A binary upgrade on a live host leaves the old kukeond running. The previous
+# liveness-only skip (socket present → skip) declared that a success even when
+# the daemon predated the new binaries, ending in a client/daemon version skew
+# the installer just called done (issue #1260). This compares the live daemon's
+# version against the just-installed client and, on a mismatch, surfaces the
+# exact `kuke daemon recreate` command rather than a silent skip.
+#
+# `kuke version --strict` prints the Client/Daemon lines and exits non-zero
+# only on a real version mismatch; an unreachable daemon (socket present but
+# dead) prints a warning and exits 0, so it falls through to the historical
+# skip rather than a spurious recreate prompt. The installer does not auto-cycle
+# the daemon — a recreate tears down and re-provisions the kuke-system kukeond
+# cell, too aggressive to do unprompted from a piped curl|bash — so it prints
+# the copy-pasteable command and lets main exit non-zero on the skew.
+handle_running_daemon() {
+    if [ -n "$KUKE_SKIP_DAEMON_UPGRADE" ]; then
+        ok "kukeond already running at /run/kukeon/kukeond.sock — skipping \`kuke init\` (KUKE_SKIP_DAEMON_UPGRADE=1)"
+        return 0
+    fi
+
+    local version_out
+    if version_out="$($SUDO kuke version --strict 2>&1)"; then
+        ok "kukeond already running at /run/kukeon/kukeond.sock (version-matched) — skipping \`kuke init\`"
+        return 0
+    fi
+
+    KUKE_DAEMON_SKEW=1
+    fail "kukeond is older than the binaries just installed (client ${KUKE_VERSION}) — leaving a client/daemon version skew."
+    printf '%s\n' "$version_out" | sed 's/^/    /' >&2
+    printf '\n    Upgrade the daemon to match. Workload cells are untouched — recreate\n' >&2
+    printf '    only cycles the kuke-system kukeond cell:\n\n' >&2
+    printf '      %ssudo kuke daemon recreate --kukeond-image ghcr.io/%s:%s%s\n\n' "$C_BOLD" "$KUKE_REPO" "$KUKE_VERSION" "$C_RESET" >&2
+    printf '    To keep an intentionally pinned older daemon, re-run with KUKE_SKIP_DAEMON_UPGRADE=1.\n' >&2
+    return 0
 }
 
 # --- systemd unit ------------------------------------------------------------
@@ -485,4 +538,15 @@ if [ "$MODE" = "check" ]; then
 fi
 
 do_install
+
+# A live host with a daemon older than the just-installed binaries is left in a
+# version skew (handle_running_daemon already printed the recreate command).
+# Exit non-zero with a qualified message instead of the rosy "installed and
+# initialized" banner — the installer must never claim an unqualified success
+# over a skew it just declared (issue #1260).
+if [ -n "$KUKE_DAEMON_SKEW" ]; then
+    fail "binaries installed, but the running daemon is older — run the recreate command above to finish the upgrade."
+    exit 1
+fi
+
 print_next_steps


### PR DESCRIPTION
## Summary

- The installer's post-install init skip at `scripts/install.sh` was liveness-only: socket present → `✓ … skipping`, never comparing versions. A binary upgrade on a live host (`curl install.sh | bash`) thus left the old `kukeond` running and declared it a success, ending in a client/daemon version skew the installer just called done (issue #1260).
- On a live socket the installer now compares the running daemon's version against the just-installed client via `kuke version --strict` (which already prints the `Client:`/`Daemon:` lines and exits non-zero only on a real mismatch):
  - **version-matched** → skipped silently, exactly as today (no daemon churn).
  - **older daemon** → prints the exact `sudo kuke daemon recreate --kukeond-image <repo>:<installed-version>` command and exits non-zero, instead of an unqualified success. It does **not** auto-cycle the daemon — a recreate tears down and re-provisions the kuke-system kukeond cell, too aggressive to do unprompted from a piped `curl | bash`.
  - **present-but-dead socket** (`kuke version` reports daemon unreachable, exit 0) → falls through to the historical skip rather than a spurious recreate prompt.
- `KUKE_SKIP_DAEMON_UPGRADE=1` escape hatch preserves the historical silent-skip for operators intentionally pinning an older daemon.
- Documented the env var in the install-docs override table and added a canonical **Upgrade** section (re-run installer → recreate daemon) to `docs/site/install/install-linux.md`.

## Design notes for the reviewer

- **Gate-vs-flip / blast radius (per dev CLAUDE.md):** the issue offered auto-recreate *or* loud-instruction-and-exit. I chose the lower-blast-radius **warn-and-exit-non-zero** default — auto-cycling a running daemon from a piped installer is a surprising, non-reversible side effect; the printed command lets the operator recreate when ready. The escape hatch (`KUKE_SKIP_DAEMON_UPGRADE=1`) restores the prior behavior. Happy to flip to auto-recreate if you'd rather.
- **Image-ref derivation:** the recreate command uses `ghcr.io/${KUKE_REPO}:${KUKE_VERSION}`, mirroring the documented default `KukeondImageRepo = ghcr.io/eminwux/kukeon` (`cmd/config/version.go:30`) ← `KUKE_REPO = eminwux/kukeon`. This keeps forks correct (a fork's `KUKE_REPO` maps to its own `ghcr.io/<owner>/<repo>` namespace) without parsing the daemon's stored image ref in shell.
- **`scripts/install.sh` ↔ `docs/site/install.sh` sync:** the two are kept byte-identical (the latter is the mkdocs-published copy). Re-rendered with `make install.sh` so the `installer.yaml` sync job passes.

## Test plan

- [x] `bash -n scripts/install.sh` + `bash -n docs/site/install.sh` — syntax clean.
- [x] `make install.sh` then `diff scripts/install.sh docs/site/install.sh` — identical (installer.yaml sync job will pass).
- [x] Isolated harness exercising `handle_running_daemon` with a fake `kuke` across all four branches: **match** → silent skip, no skew; **mismatch** → loud fail + correct `recreate --kukeond-image ghcr.io/eminwux/kukeon:v0.7.0` + `KUKE_DAEMON_SKEW=1`; **unreachable** → historical skip; **`KUKE_SKIP_DAEMON_UPGRADE=1`** → silent skip.
- [x] `bash scripts/install.sh --check` — unaffected; still exits non-zero with the containerd hint (my change is inside the live-socket branch, after the `--check`/`KUKE_SKIP_INIT` returns).
- [x] `make test` — exit 0 (no Go change; `test.yaml` is path-filtered away from this shell/docs PR, ran as insurance).

### AC coverage
- [x] Live host, version-matched daemon → skip, no daemon churn.
- [x] Live host, older daemon → never prints unqualified success; exits with the exact recreate command (auto-recreate not chosen — see design notes).
- [x] Escape hatch documented alongside the existing `KUKE_SKIP_*` knobs.
- [x] Upgrade flow (installer + `kuke daemon recreate`) documented as the canonical upgrade procedure.

Closes #1260