### PR TITLE
fix: dev-init builds kukeond image with git-derived version to match client

### DIFF
--- a/scripts/dev-init.sh
+++ b/scripts/dev-init.sh
@@ -29,6 +29,17 @@ cd "${REPO_ROOT}"
 # unchanged — only the local dev-loop ref moves.
 KUKEOND_VERSION="v0.0.0-dev"
 KUKEOND_IMAGE_REF="kukeon.internal/kukeond:${KUKEOND_VERSION}"
+# Daemon build-arg version. Kept DISTINCT from the image-tag sentinel above:
+# `KUKEOND_VERSION` is a *ref label* (the tag `kuke init --kukeond-image`
+# resolves), whereas this value is compiled into the daemon binary's
+# `cmd/config.Version` (Dockerfile's `make release-build KUKEON_VERSION=…`)
+# and surfaces on `kuke version`'s `Daemon:` line. The client `kuke` binary
+# `make kuke` builds earlier derives its `config.Version` from the SAME
+# `git describe` the Makefile uses (Makefile § "Version sourcing"), so the
+# build-arg must match it — otherwise every dev bootstrap manufactures a
+# false client/daemon version skew (client `vX.Y.Z` vs daemon `v0.0.0-dev`)
+# that `kuke version` / `kuke status` flag as a mismatch (#1263 detection).
+KUKEOND_BUILD_VERSION="${KUKEON_VERSION:-$(git describe --tags --always --dirty --match 'v*')}"
 # The on-disk metadata layout lives under /opt/kukeon/data/ — see
 # internal/consts.KukeonMetadataSubdir. Siblings of the data root (e.g.
 # /opt/kukeon/bin/kuketty staged by `kuke init`) intentionally fall outside
@@ -411,7 +422,7 @@ step "Build ${KUKEOND_IMAGE_REF} into the kuke-system realm"
 # tag is fully qualified (`kukeon.internal/kukeond:<version>`), so kukebuild's
 # normalizeImageName preserves it verbatim — no docker.io/library/ rewrite —
 # matching the exact ref `kuke init --kukeond-image` resolves below.
-sudo --preserve-env="${PRESERVE_ENV_WORKLOAD}" ./kuke build --build-arg VERSION="${KUKEOND_VERSION}" \
+sudo --preserve-env="${PRESERVE_ENV_WORKLOAD}" ./kuke build --build-arg VERSION="${KUKEOND_BUILD_VERSION}" \
     -t "${KUKEOND_IMAGE_REF}" \
     --realm kuke-system .
 


### PR DESCRIPTION
## Summary

- `make dev-init` manufactured a false client/daemon version skew on every dev bootstrap. `kuke version` reported e.g. `Client: v0.7.1` / `Daemon: v0.0.0-dev` and a `Warning: version mismatch (...)`; `kuke status`' daemon-parity walk flags the same.
- Root cause: `scripts/dev-init.sh` overloaded one constant, `KUKEOND_VERSION="v0.0.0-dev"`, for two unrelated jobs — the image **tag ref** *and* the daemon `--build-arg VERSION`. The build-arg flows into the Dockerfile's `make release-build KUKEON_VERSION=${VERSION}` (`Dockerfile:17`) and is compiled into the daemon binary's `cmd/config.Version`, which surfaces on the `Daemon:` line. Meanwhile the **client** `kuke` binary (`make kuke`, run earlier in the same script) derives `config.Version` from `git describe` (`Makefile` § Version sourcing). The two never matched, so the strict string compare in `cmd/kuke/version/version.go:77` always tripped.
- Fix: split the two concerns. The image **tag** stays the `v0.0.0-dev` sentinel (the ref `kuke init --kukeond-image` resolves, referenced throughout the docs); the **build-arg** now uses a new `KUKEOND_BUILD_VERSION` derived from the *same* `git describe` invocation (and the same `KUKEON_VERSION` env override) the Makefile feeds `make kuke`. Client and daemon now report identical versions and the warning disappears.

## Why this variant

Two ways to silence the warning: (a) make the daemon report the honest git-derived version (this PR), or (b) pin *both* sides to a `v0.0.0-dev` sentinel. Chose (a) — it keeps the daemon's reported version truthful and aligns with the canonical Makefile pattern (`KUKEON_IMAGE_TAG ?= $(KUKEON_VERSION)`, build-arg `VERSION=$(KUKEON_VERSION)`); (b) would additionally falsify the client's version on the local loop. Lower-blast-radius and more honest.

## Scope / gate-vs-flip note

This is a dev-loop tooling script (`scripts/dev-init.sh`), not a public CLI default — no operator-facing flip. The image *tag* sentinel is preserved verbatim, so every `kukeon.internal/kukeond:v0.0.0-dev` reference in the docs and the `kuke init --kukeond-image` call still resolves unchanged. Independent of #1263 (real-installer skew *detection*), which does not touch dev-init.

## Test plan

- [x] `make test` (test-root + test-kukebuild) — passes (exit 0)
- [x] `bash -n scripts/dev-init.sh` — syntax OK (shellcheck not installed on host / not a CI gate; `scripts/**` is outside `test.yaml`'s path filter)
- [x] Verified derivation parity: build-arg resolves to the same `git describe` value `make kuke` bakes into the client, and honors a `KUKEON_VERSION` env override identically
- [ ] Full `make dev-init` end-to-end (rebuild + `kuke init` + `kuke version` parity) — not run: requires a standalone containerd + root bootstrap not safely available on this host. Recommend the reviewer confirm `kuke version` shows matching client/daemon lines on a dev host.