### PR TITLE
fix: silence cobra usage/error dump on kuke version --strict mismatch

### DIFF
--- a/cmd/kuke/version/version.go
+++ b/cmd/kuke/version/version.go
@@ -38,8 +38,10 @@ type MockDaemonClientKey struct{}
 
 func NewVersionCmd() *cobra.Command {
 	versionCmd := &cobra.Command{
-		Use:   "version",
-		Short: "Print the version number",
+		Use:           "version",
+		Short:         "Print the version number",
+		SilenceUsage:  true,
+		SilenceErrors: true,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			clientVersion := config.Version
 			_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Client: %s\n", clientVersion)

--- a/cmd/kuke/version/version_test.go
+++ b/cmd/kuke/version/version_test.go
@@ -223,3 +223,40 @@ func TestVersionCmdRun_MismatchStderr(t *testing.T) {
 		t.Errorf("stderr should contain daemon version; got: %q", errBuf.String())
 	}
 }
+
+// TestVersionCmdRun_StrictMismatchNoUsage verifies that the --strict error path
+// emits neither cobra's usage/help block nor its duplicate "Error:" line, leaving
+// only the command's own "Warning: version mismatch" on stderr. Regression guard
+// for the installer skew handler (scripts/install.sh handle_running_daemon), which
+// captures `kuke version --strict 2>&1` and re-prints it verbatim.
+func TestVersionCmdRun_StrictMismatchNoUsage(t *testing.T) {
+	cmd := version.NewVersionCmd()
+	outBuf := &bytes.Buffer{}
+	errBuf := &bytes.Buffer{}
+	cmd.SetOut(outBuf)
+	cmd.SetErr(errBuf)
+	ctx := context.WithValue(context.Background(), version.MockDaemonClientKey{}, &fakeDaemonClient{
+		pingVersionFn: func(_ context.Context) (string, error) {
+			return "dummy", nil
+		},
+	})
+	cmd.SetContext(ctx)
+	cmd.SetArgs([]string{"--strict"})
+
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected error on --strict mismatch, got nil")
+	}
+
+	// The command's own warning must still be present.
+	if !strings.Contains(errBuf.String(), "Warning: version mismatch") {
+		t.Errorf("expected version mismatch warning on stderr; got: %q", errBuf.String())
+	}
+	// No cobra usage/help dump (SilenceUsage) and no duplicate "Error:" line
+	// (SilenceErrors).
+	for _, unwanted := range []string{"Usage:", "Global Flags:", "help for version", "Error:"} {
+		if strings.Contains(errBuf.String(), unwanted) {
+			t.Errorf("stderr should not contain %q on --strict error path; got: %q", unwanted, errBuf.String())
+		}
+	}
+}


### PR DESCRIPTION
## Summary

- `cmd/kuke/version/version.go`'s `NewVersionCmd` literal set neither `SilenceUsage` nor `SilenceErrors`, so a real version mismatch under `kuke version --strict` (an expected, by-design non-zero exit) dumped the full cobra usage/help block **and** a duplicate `Error: version mismatch…` line to stderr — on top of the intentional `Warning: version mismatch…` the command prints itself.
- The installer's skew handler (`scripts/install.sh` `handle_running_daemon`, added in #1263) captures `kuke version --strict 2>&1` and re-prints it verbatim inside the recreate notice, so the clean 3-line skew hint was buried under the usage dump.
- `version` was the odd command out — every other leaf command (`apply`, `build`, `create/*`, `daemon/*`, …) already sets `SilenceUsage: true`. Fixing it at the command (not by filtering captured output in `install.sh`) also benefits any other caller of `kuke version --strict`.

Added `SilenceUsage: true` (drops the usage dump) and `SilenceErrors: true` (drops cobra's duplicate `Error:` line; `cmd/main.go`'s `execRoot` only maps the error to exit code 1 and never prints it, so nothing else re-emits it). The command's own `Warning: version mismatch…` remains.

Extended `version_test.go` with `TestVersionCmdRun_StrictMismatchNoUsage`, asserting the `--strict` error path emits the warning but none of `Usage:` / `Global Flags:` / `help for version` / `Error:`.

## Test plan
- [x] `make test-root` — full main-module suite, all green (exit 0)
- [x] `make test-kukebuild` — green (untouched by this change)
- [x] `go test ./cmd/kuke/version/...` — new + existing version tests pass
- [x] `go vet ./cmd/kuke/version/...` — clean
- [x] `gofmt -l` on changed files — clean

Closes #1264