### PR TITLE
fix: kuketty surfaces workload exit code so clean attachable exits report Exited

### DIFF
--- a/cmd/kuketty/main.go
+++ b/cmd/kuketty/main.go
@@ -39,8 +39,12 @@ import (
 	"log/slog"
 	"net"
 	"os"
+	"os/exec"
 	"os/signal"
+	"regexp"
 	"runtime"
+	"strconv"
+	"strings"
 	"sync"
 	"syscall"
 
@@ -63,19 +67,84 @@ const defaultConfigPath = "/.kukeon/kuketty/metadata.json"
 const exitCodeUsage = 64
 
 // exitCodeInternal is returned when kuketty itself fails (config parse,
-// socket listen, server bring-up). 70 is BSD EX_SOFTWARE. The workload's
-// own exit code is not surfaced through kuketty — the sbsh server reports
-// terminal-exit via its event loop and the attached client sees the
-// workload's status through the RPC, not the wrapper's exit code.
+// socket listen, server bring-up). 70 is BSD EX_SOFTWARE. It is reserved for
+// genuine wrapper failures: the *workload's* own exit is surfaced separately
+// through kuketty's exit code (see workloadExitCode / workloadExitError and
+// issue #1273), so the daemon's task-exit-code → container/cell-state
+// derivation (#1267/#1269) reflects the workload's fate rather than mapping
+// every clean workload exit to this internal-error code.
 const exitCodeInternal = 70
+
+// codeRe extracts the workload child's numeric exit code from sbsh's PID-1
+// (init-mode) EvCmdExited cause, which embeds it as "code=N"
+// (sbsh internal/terminal/terminalrunner/lifecycle.go).
+var codeRe = regexp.MustCompile(`code=(-?\d+)`)
+
+// workloadExitError carries the workload child's non-zero exit code up to
+// main() so it can propagate it as kuketty's own exit code. It is distinct
+// from a kuketty-internal failure (exitCodeInternal): a non-zero workload
+// exit is the workload's fate, not a wrapper bug, and must reach the daemon
+// verbatim so the container/cell lands in Error with the workload's status.
+type workloadExitError struct{ code int }
+
+func (e *workloadExitError) Error() string {
+	return fmt.Sprintf("workload exited with status %d", e.code)
+}
+
+// workloadExitCode reports whether err is sbsh's "workload child exited"
+// terminating cause and, if so, the child's exit code. sbsh v0.13.0 (the
+// pinned release) has no machine-readable exit-code field on EvCmdExited — it
+// embeds the code in the terminating error: an *exec.ExitError on the non-init
+// cmd.Wait path, a "(code 0)" literal on a non-init clean exit, or a "code=N"
+// string on the PID-1 reaper path (internal/terminal/terminalrunner/
+// lifecycle.go). This recognizes all three carriers. ok=false means err is a
+// genuine kuketty-internal failure that should map to exitCodeInternal.
+func workloadExitCode(err error) (code int, ok bool) {
+	if err == nil {
+		return 0, true
+	}
+	// Non-init cmd.Wait path: the *exec.ExitError carries the real code (and
+	// signal info on signaled deaths), wrapped by sbsh with %w.
+	var exitErr *exec.ExitError
+	if errors.As(err, &exitErr) {
+		return exitErr.ExitCode(), true
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, "shell process exited") {
+		return 0, false
+	}
+	// Non-init clean exit: errors.New("shell process exited (code 0)").
+	if strings.Contains(msg, "(code 0)") {
+		return 0, true
+	}
+	// PID-1 init mode: fmt.Errorf("shell process exited: code=%d", code).
+	if m := codeRe.FindStringSubmatch(msg); m != nil {
+		if c, perr := strconv.Atoi(m[1]); perr == nil {
+			return c, true
+		}
+	}
+	// "shell process exited" with no recoverable code — an abnormal reaper or
+	// shutdown-race path (sbsh #398: reaper channel closed, or the tracked-exit
+	// wait was cancelled by Close). These arise during teardown, not a workload
+	// crash, so treat them as a clean termination rather than flipping a
+	// stopped cell to Error.
+	return 0, true
+}
 
 func main() {
 	if err := run(os.Args[1:]); err != nil {
 		var usageErr *usageError
+		var wlErr *workloadExitError
 		switch {
 		case errors.As(err, &usageErr):
 			fmt.Fprintf(os.Stderr, "kuketty: %v\n", err)
 			os.Exit(exitCodeUsage)
+		case errors.As(err, &wlErr):
+			// The workload itself exited non-zero. Propagate its code so the
+			// daemon records the container/cell as Error with the workload's
+			// real status (#1273) — this is the workload's fate, not a kuketty
+			// failure, so it gets no "kuketty:" diagnostic.
+			os.Exit(wlErr.code)
 		default:
 			fmt.Fprintf(os.Stderr, "kuketty: %v\n", err)
 			os.Exit(exitCodeInternal)
@@ -172,10 +241,26 @@ func run(args []string) error {
 	if err != nil {
 		return fmt.Errorf("server.New: %w", err)
 	}
-	if serveErr := srv.Serve(ctx, listener); serveErr != nil && !isCleanShutdown(serveErr) {
-		return fmt.Errorf("server.Serve: %w", serveErr)
+	// The workload's exit is surfaced through kuketty's own exit code so the
+	// daemon's task-exit-code → container/cell-state derivation (#1267/#1269)
+	// reflects the workload's fate, not the wrapper's (issue #1273). sbsh
+	// reports terminal exit as the Serve terminating cause:
+	//   - a clean operator-initiated shutdown (ctx cancel / Stop) → exit 0;
+	//   - a workload that exited carries the child's code: 0 → Exited (return
+	//     nil), non-zero → Error (return *workloadExitError so main() exits
+	//     with that code);
+	//   - anything else is a genuine kuketty-internal failure → exitCodeInternal.
+	serveErr := srv.Serve(ctx, listener)
+	if isCleanShutdown(serveErr) {
+		return nil
 	}
-	return nil
+	if code, ok := workloadExitCode(serveErr); ok {
+		if code == 0 {
+			return nil
+		}
+		return &workloadExitError{code: code}
+	}
+	return fmt.Errorf("server.Serve: %w", serveErr)
 }
 
 // parseArgs accepts a single optional `--config <path>` override. Any other

--- a/cmd/kuketty/main_test.go
+++ b/cmd/kuketty/main_test.go
@@ -20,7 +20,9 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"syscall"
 	"testing"
@@ -278,6 +280,96 @@ func TestIsCleanShutdown(t *testing.T) {
 	}
 	if isCleanShutdown(errors.New("something went wrong")) {
 		t.Errorf("opaque err: reported clean")
+	}
+}
+
+// TestWorkloadExitCode covers the carriers sbsh v0.13.0 embeds the workload
+// child's exit code in (issue #1273): the *exec.ExitError on the non-init
+// cmd.Wait path, the "(code 0)" literal on a non-init clean exit, the
+// init-mode "code=N" string from the PID-1 reaper, and the abnormal
+// no-recoverable-code teardown paths. A genuine kuketty-internal failure must
+// report ok=false so it maps to exitCodeInternal.
+func TestWorkloadExitCode(t *testing.T) {
+	tests := []struct {
+		name     string
+		err      error
+		wantCode int
+		wantOK   bool
+	}{
+		{name: "nil is clean", err: nil, wantCode: 0, wantOK: true},
+		{
+			name:     "non-init clean exit literal",
+			err:      errors.New("shell process exited (code 0)"),
+			wantCode: 0,
+			wantOK:   true,
+		},
+		{
+			name:     "init-mode clean exit",
+			err:      errors.New("shell process exited: code=0"),
+			wantCode: 0,
+			wantOK:   true,
+		},
+		{
+			name:     "init-mode non-zero exit",
+			err:      errors.New("shell process exited: code=7"),
+			wantCode: 7,
+			wantOK:   true,
+		},
+		{
+			name:     "init-mode wraps via fmt.Errorf",
+			err:      fmt.Errorf("server.Serve: %w", errors.New("shell process exited: code=137")),
+			wantCode: 137,
+			wantOK:   true,
+		},
+		{
+			name:     "no recoverable code is treated clean",
+			err:      errors.New("shell process exited"),
+			wantCode: 0,
+			wantOK:   true,
+		},
+		{
+			name:     "close-cancelled tracked-exit wait is treated clean",
+			err:      errors.New("shell process exited (close cancelled tracked-exit wait)"),
+			wantCode: 0,
+			wantOK:   true,
+		},
+		{
+			name:     "internal failure is not a workload exit",
+			err:      errors.New("server.New: bind failed"),
+			wantCode: 0,
+			wantOK:   false,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			code, ok := workloadExitCode(tc.err)
+			if ok != tc.wantOK {
+				t.Fatalf("ok = %v, want %v", ok, tc.wantOK)
+			}
+			if code != tc.wantCode {
+				t.Errorf("code = %d, want %d", code, tc.wantCode)
+			}
+		})
+	}
+}
+
+// TestWorkloadExitCode_ExecExitError pins the non-init cmd.Wait carrier: sbsh
+// wraps the *exec.ExitError from cmd.Wait with %w, so errors.As must recover
+// the child's real exit code (here a non-zero status).
+func TestWorkloadExitCode_ExecExitError(t *testing.T) {
+	cmd := exec.Command("sh", "-c", "exit 3")
+	runErr := cmd.Run()
+	var exitErr *exec.ExitError
+	if !errors.As(runErr, &exitErr) {
+		t.Fatalf("expected *exec.ExitError, got %v", runErr)
+	}
+	wrapped := fmt.Errorf("shell process exited: %w", exitErr)
+	code, ok := workloadExitCode(wrapped)
+	if !ok {
+		t.Fatalf("ok = false, want true")
+	}
+	if code != 3 {
+		t.Errorf("code = %d, want 3", code)
 	}
 }
 


### PR DESCRIPTION
## Summary

- An attachable (kuketty-wrapped) cell whose workload exited **cleanly (exit 0)** landed in `Error` (exit 70) instead of `Exited`, defeating the #1267/#1269 clean-exit-vs-crash split for the primary interactive cell type (#1273).
- Root cause: kuketty's PID 1 is the *wrapper*, not the workload. sbsh's `EvCmdExited` always carries a non-nil terminating cause — even on a clean exit (`"shell process exited (code 0)"` / `"shell process exited: code=0"`). kuketty's `isCleanShutdown` only treated `nil`/`context.Canceled` as clean, so every workload exit fell through to `exitCodeInternal` (70). containerd then recorded `ExitStatus=70` → `ContainerStateError` → `CellStateError`.
- Fix: kuketty now recognizes sbsh's "shell process exited" terminating cause as a workload termination (not a wrapper failure) and **propagates the workload's real exit code as its own** — `0 → Exited`, non-zero → `Error` with the workload's status. Genuine kuketty-internal failures still map to `exitCodeInternal` (70).

## Implementation notes

- **No structured exit field in the pinned dependency.** sbsh v0.13.0 (latest available — `go list -m -versions` confirms no newer tag) has no machine-readable exit-code field on `EvCmdExited`; the code is embedded in the terminating error, exactly as the issue's "Suggested fix" anticipated ("today it is embedded in the error string"). `workloadExitCode` therefore recognizes all three carriers sbsh emits (`sbsh@v0.13.0/internal/terminal/terminalrunner/lifecycle.go:160-192`):
  - non-init `cmd.Wait` path → wrapped `*exec.ExitError` (recovered via `errors.As`);
  - non-init clean exit → `"shell process exited (code 0)"` literal;
  - PID-1 reaper (init mode — the path in a real container, since kuketty is PID 1) → `"shell process exited: code=N"`.
- **No sbsh change required.** The issue noted a structured field "if needed"; since the code is recoverable from the existing v0.13.0 error carriers, no dependency bump or upstream coordination is needed. If sbsh later exposes a structured field, the string parsing can be dropped.
- **Abnormal no-code teardown paths treated clean.** The bare `"shell process exited"` (reaper channel closed) and `"shell process exited (close cancelled tracked-exit wait)"` (sbsh #398) cases carry no recoverable code; they arise during teardown/shutdown races, not a workload crash, so they map to exit 0 rather than spuriously flipping a stopped cell to `Error`. Documented inline.
- **Operator-stop path unchanged.** `kuke stop` cancels kuketty's ctx → sbsh's `runLoop` returns `context.Canceled` → `isCleanShutdown` → exit 0, as before.
- Updated the now-stale `exitCodeInternal` doc comment (the issue flagged `cmd/kuketty/main.go:65-70`'s "workload exit is not surfaced through kuketty" claim as contradicting the actual fall-through behavior).

## Test plan

- [x] `make test` (`make test-root` + `make test-kukebuild`) — full suite green, 107 packages ok, exit 0
- [x] `go test ./cmd/kuketty/ -run 'TestWorkloadExitCode|TestIsCleanShutdown' -v` — new table test covers all three carriers + init/non-init/abnormal/internal-failure cases; `TestWorkloadExitCode_ExecExitError` pins the real `*exec.ExitError` carrier
- [x] `GOWORK=off go vet ./... (minus e2e)` — clean
- [x] `gofmt -l` on changed files — clean
- [ ] `make dev-init` end-to-end smoke — not run: this change touches only the in-container `kuketty` binary's exit-code mapping (`cmd/kuketty/main.go`), not the build path, daemon bootstrap, or anything under `/opt/kukeon` the daemon-parity tail reads. The runtime behavior (containerd records kuketty's exit code → cell state) is a live-daemon observation; the deterministic code path is covered by the unit tests above, and the original bug was itself diagnosed by code trace (daemon not live on the dev host). A reviewer with a live daemon can confirm a clean `exit` in an attached cell now reports `Exited`.

Closes #1273