### PR TITLE
fix: re-stage kuketty binary on content mismatch

### DIFF
--- a/internal/controller/runner/attachable.go
+++ b/internal/controller/runner/attachable.go
@@ -17,6 +17,8 @@
 package runner
 
 import (
+	"bytes"
+	"crypto/sha256"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -335,11 +337,14 @@ func kukettyMetadataLabels(spec intmodel.ContainerSpec) map[string]string {
 // daemon binary — see Dockerfile); for --no-daemon mode the function falls
 // back to a sibling of the running binary and then $PATH.
 //
-// The stage is idempotent: once the destination exists with non-zero size
-// and the executable bit, subsequent calls return its path without
-// re-copying. This is the hot path for every attachable container start,
-// so doing the lstat early avoids re-reading and re-writing a multi-MiB
-// binary per container.
+// The stage is idempotent on content: a subsequent call returns the
+// destination path without re-copying only when the staged copy is usable
+// (non-zero size, executable bit) AND byte-identical to the source. A
+// rebuilt kukeond image ships a newer kuketty, so a content mismatch re-
+// stages — the existence-only gate this replaced left an existing host
+// pinned to its first staged copy forever (#1277). The size short-circuit in
+// sameFileContent keeps the common up-to-date path off the multi-MiB hash on
+// every attachable container start.
 //
 // Atomicity is handled with a tmp-file rename so two concurrent provisions
 // never see a partial binary at the destination. The rename is on the same
@@ -348,25 +353,106 @@ func stageKukettyBinary(runPath string) (string, error) {
 	dstDir := filepath.Join(runPath, kukettyBinaryStagedSubdir)
 	dst := filepath.Join(dstDir, "kuketty")
 
-	if ok, err := stagedBinaryUsable(dst); err != nil {
-		return "", err
-	} else if ok {
-		return dst, nil
-	}
-
 	src, err := resolveKukettyBinary()
 	if err != nil {
+		// The source can no longer be resolved (dev / --no-daemon path where
+		// the source binary moved out from under us). Fall back to a usable
+		// staged copy if one exists rather than failing — this preserves the
+		// prior existence-only reuse for that path. Only when nothing usable
+		// is staged do we surface the resolve error.
+		if ok, uErr := stagedBinaryUsable(dst); uErr == nil && ok {
+			return dst, nil
+		}
 		return "", err
 	}
 
-	if err = os.MkdirAll(dstDir, 0o755); err != nil {
-		return "", fmt.Errorf("mkdir %q: %w", dstDir, err)
-	}
-
-	if err = copyBinaryAtomic(src, dst, "kuketty"); err != nil {
+	if _, err := ensureStagedBinary(src, dst, "kuketty"); err != nil {
 		return "", err
 	}
 	return dst, nil
+}
+
+// ensureStagedBinary makes dst a byte-identical, executable copy of src,
+// copying via copyBinaryAtomic only when dst is missing, defective (zero-byte
+// or non-exec, per stagedBinaryUsable), or holds content that differs from
+// src. It returns true when a copy was performed.
+//
+// The content check is the #1277 fix: the prior existence-only gate pinned an
+// existing host to its first-ever staged copy forever, so a rebuilt kukeond
+// image's newer kuketty never reached newly-created cells on `kuke daemon
+// recreate` until an operator manually rm'd the staged file. Comparing source
+// against dest re-stages on mismatch without needing a `kuketty version`
+// subcommand, version wiring, or an exec — the daemon already holds both
+// files. The zero-byte / non-exec defensive rejections in stagedBinaryUsable
+// are preserved: a defective dest is treated as unusable and re-staged.
+func ensureStagedBinary(src, dst, label string) (bool, error) {
+	usable, err := stagedBinaryUsable(dst)
+	if err != nil {
+		return false, err
+	}
+	if usable {
+		same, err := sameFileContent(src, dst)
+		if err != nil {
+			return false, err
+		}
+		if same {
+			return false, nil
+		}
+	}
+
+	dstDir := filepath.Dir(dst)
+	if err := os.MkdirAll(dstDir, 0o755); err != nil {
+		return false, fmt.Errorf("mkdir %q: %w", dstDir, err)
+	}
+	if err := copyBinaryAtomic(src, dst, label); err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
+// sameFileContent reports whether the files at a and b hold byte-identical
+// content. It short-circuits on a size mismatch — the cheap discriminator —
+// before hashing, so the common "already up to date" path hashes only when
+// sizes coincide, and a rebuild that changed the binary's size is caught by
+// the stat alone.
+func sameFileContent(a, b string) (bool, error) {
+	ai, err := os.Stat(a)
+	if err != nil {
+		return false, fmt.Errorf("stat %q: %w", a, err)
+	}
+	bi, err := os.Stat(b)
+	if err != nil {
+		return false, fmt.Errorf("stat %q: %w", b, err)
+	}
+	if ai.Size() != bi.Size() {
+		return false, nil
+	}
+
+	ah, err := sha256File(a)
+	if err != nil {
+		return false, err
+	}
+	bh, err := sha256File(b)
+	if err != nil {
+		return false, err
+	}
+	return bytes.Equal(ah, bh), nil
+}
+
+// sha256File returns the SHA-256 digest of the file at path, streaming the
+// read so a multi-MiB binary never lands fully in memory.
+func sha256File(path string) ([]byte, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, fmt.Errorf("open %q: %w", path, err)
+	}
+	defer func() { _ = f.Close() }()
+
+	h := sha256.New()
+	if _, err := io.Copy(h, f); err != nil {
+		return nil, fmt.Errorf("hash %q: %w", path, err)
+	}
+	return h.Sum(nil), nil
 }
 
 // stagedBinaryUsable reports whether the destination already holds an

--- a/internal/controller/runner/attachable_test.go
+++ b/internal/controller/runner/attachable_test.go
@@ -317,6 +317,145 @@ func TestStageKukettyBinary_ReusesExisting(t *testing.T) {
 	}
 }
 
+// TestEnsureStagedBinary_RestagesOnMismatch locks the #1277 content-aware
+// cache invalidation: ensureStagedBinary re-copies whenever the staged dest
+// is missing, defective (zero-byte / non-exec, per stagedBinaryUsable), or
+// holds content that differs from the source, and reuses it without a copy
+// only when the dest is usable AND byte-identical to the source. The
+// existence-only predecessor pinned an existing host to its first staged copy
+// forever, so a rebuilt kukeond image's newer kuketty never reached newly
+// created cells without a manual rm of the staged file.
+func TestEnsureStagedBinary_RestagesOnMismatch(t *testing.T) {
+	const srcContent = "\x7fELF new-kuketty"
+
+	cases := []struct {
+		name string
+		// seed prepares the dest before the call. A nil seed leaves the dest
+		// missing; the staged dir is created first either way so seeds that
+		// write a file have a parent.
+		seed       func(t *testing.T, dst string)
+		wantCopied bool
+	}{
+		{
+			name:       "missing dest re-stages",
+			seed:       nil,
+			wantCopied: true,
+		},
+		{
+			name: "zero-byte dest re-stages",
+			seed: func(t *testing.T, dst string) {
+				if err := os.WriteFile(dst, nil, 0o755); err != nil {
+					t.Fatalf("seed zero-byte: %v", err)
+				}
+			},
+			wantCopied: true,
+		},
+		{
+			name: "non-exec dest re-stages",
+			seed: func(t *testing.T, dst string) {
+				if err := os.WriteFile(dst, []byte(srcContent), 0o644); err != nil {
+					t.Fatalf("seed non-exec: %v", err)
+				}
+			},
+			wantCopied: true,
+		},
+		{
+			name: "stale-content dest re-stages",
+			seed: func(t *testing.T, dst string) {
+				if err := os.WriteFile(dst, []byte("\x7fELF old-stale-kuketty"), 0o755); err != nil {
+					t.Fatalf("seed stale: %v", err)
+				}
+			},
+			wantCopied: true,
+		},
+		{
+			name: "identical dest reuses without copy",
+			seed: func(t *testing.T, dst string) {
+				if err := os.WriteFile(dst, []byte(srcContent), 0o755); err != nil {
+					t.Fatalf("seed identical: %v", err)
+				}
+			},
+			wantCopied: false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			src := filepath.Join(dir, "src-kuketty")
+			if err := os.WriteFile(src, []byte(srcContent), 0o755); err != nil {
+				t.Fatalf("write src: %v", err)
+			}
+			dstDir := filepath.Join(dir, kukettyBinaryStagedSubdir)
+			if err := os.MkdirAll(dstDir, 0o755); err != nil {
+				t.Fatalf("mkdir dstDir: %v", err)
+			}
+			dst := filepath.Join(dstDir, "kuketty")
+			if tc.seed != nil {
+				tc.seed(t, dst)
+			}
+
+			copied, err := ensureStagedBinary(src, dst, "kuketty")
+			if err != nil {
+				t.Fatalf("ensureStagedBinary: %v", err)
+			}
+			if copied != tc.wantCopied {
+				t.Fatalf("copied = %v, want %v", copied, tc.wantCopied)
+			}
+
+			// Regardless of branch, the dest must end byte-identical to src
+			// and stay executable.
+			got, err := os.ReadFile(dst)
+			if err != nil {
+				t.Fatalf("read dst: %v", err)
+			}
+			if string(got) != srcContent {
+				t.Fatalf("dst content = %q, want %q", got, srcContent)
+			}
+			info, err := os.Stat(dst)
+			if err != nil {
+				t.Fatalf("stat dst: %v", err)
+			}
+			if info.Mode()&0o111 == 0 {
+				t.Fatalf("dst mode = %v, want executable", info.Mode())
+			}
+		})
+	}
+}
+
+// TestSameFileContent locks the size-short-circuit + hash discriminator:
+// equal content reports true, content of a different size reports false
+// without hashing, and same-size-but-different content reports false via the
+// hash.
+func TestSameFileContent(t *testing.T) {
+	dir := t.TempDir()
+	write := func(name, content string) string {
+		p := filepath.Join(dir, name)
+		if err := os.WriteFile(p, []byte(content), 0o644); err != nil {
+			t.Fatalf("write %s: %v", name, err)
+		}
+		return p
+	}
+
+	a := write("a", "\x7fELF identical-bytes")
+	b := write("b", "\x7fELF identical-bytes")
+	cDiffSize := write("c", "short")
+	dSameSize := write("d", "\x7fELF differing-bytez") // same length as a, differing content
+
+	if same, err := sameFileContent(a, b); err != nil || !same {
+		t.Fatalf("sameFileContent(identical) = (%v, %v), want (true, nil)", same, err)
+	}
+	if same, err := sameFileContent(a, cDiffSize); err != nil || same {
+		t.Fatalf("sameFileContent(different size) = (%v, %v), want (false, nil)", same, err)
+	}
+	if len("\x7fELF identical-bytes") != len("\x7fELF differing-bytez") {
+		t.Fatalf("test setup: same-size fixtures differ in length")
+	}
+	if same, err := sameFileContent(a, dSameSize); err != nil || same {
+		t.Fatalf("sameFileContent(same size, differing content) = (%v, %v), want (false, nil)", same, err)
+	}
+}
+
 // TestEnsureAttachableSocketSymlink_RefusesOverflow locks the provision-
 // time fail-fast added in #521 AC #2: when the resolved symlink path would
 // exceed consts.KukeonMaxSocketPath bytes, ensureAttachableSocketSymlink


### PR DESCRIPTION
## Summary
- `stageKukettyBinary`'s cache gate (`stagedBinaryUsable`) only checked existence + non-zero size + exec bit, so once `<RunPath>/bin/kuketty` existed the daemon reused it forever — a rebuilt kukeond image's newer kuketty never reached newly-created cells on `kuke daemon recreate` until an operator manually `rm`'d the staged copy (#1277, the propagation gap behind #1275 resurfacing).
- Added a content comparison: `stageKukettyBinary` now resolves the source first and delegates to `ensureStagedBinary`, which reuses the staged copy only when it is usable **and** byte-identical to the source. On any mismatch it re-stages via the existing `copyBinaryAtomic` tmp+rename path.
- Comparison is a cheap size short-circuit (`sameFileContent`) before a streamed SHA-256, so the common up-to-date path stays off the multi-MiB hash on every attachable container start. No `kuketty version` subcommand, version wiring, or exec — the daemon already holds both files.
- The zero-byte / non-exec defensive rejections in `stagedBinaryUsable` are preserved (left untouched, since it is also used by `resolveKukettyBinary` to vet source candidates). A source-unresolvable fallback keeps the prior reuse behavior for the `--no-daemon`/dev path where the source binary has moved.

## Implementation notes
- `stagedBinaryUsable` is intentionally **not** changed — it is shared with `resolveKukettyBinary` (vetting source candidate paths), so the content check lives in the caller (`ensureStagedBinary`) per the AC's "keep the existing defensive rejections" requirement.
- Source resolution now runs before the cache check (previously after). In the daemon path the source is always `/bin/kuketty` and resolves; for the dev/`--no-daemon` path where it may not, a usable staged copy is reused rather than failing — preserving the prior existence-only reuse for that path.

## Test plan
- [x] `make test` (full project CI target) — exit 0
- [x] `GOWORK=off go build ./internal/controller/runner/` and `go vet` — clean
- [x] `go test ./internal/controller/runner/ -run 'TestStageKukettyBinary|TestEnsureStagedBinary|TestSameFileContent' -v` — all pass (new + existing reuse test)
- [x] `make dev-init` smoke (containerd started on host) — exit 0; both realms `Ready` in the daemon-parity tail (daemon + `--no-daemon` shapes match), `kukeond is ready`, and the `kuke attach` smoke against the kuketty-wrapped cell (the staging + socket pipeline this change touches) passed with clean detach and parent plumbing intact. Ran on the default profile (nested mode without `KUKEON_PROFILE=dev`); the two-realm parity contract held.

## Acceptance criteria
- [x] `stageKukettyBinary` re-stages when the staged dest differs from the source by content/hash, not only when absent.
- [x] A rebuilt kukeond image propagates to newly-created cells after `kuke daemon recreate` with no manual `rm` (content mismatch drives the re-stage; verified by unit tests + the dev-init staging path).
- [x] Existing zero-byte / non-executable defensive re-stage paths in `stagedBinaryUsable` are preserved.
- [x] Unit tests cover: stale-content dest → re-staged; identical dest → reused (no copy); missing/zero-byte/non-exec dest → re-staged (`TestEnsureStagedBinary_RestagesOnMismatch`, plus `TestSameFileContent` for the size/hash discriminator).

Closes #1277