### PR TITLE
fix: bump sbsh to v0.13.1 so clean kuketty workload exits report Exited

### DIFF
--- a/cmd/kuketty/main.go
+++ b/cmd/kuketty/main.go
@@ -92,13 +92,24 @@ func (e *workloadExitError) Error() string {
 }
 
 // workloadExitCode reports whether err is sbsh's "workload child exited"
-// terminating cause and, if so, the child's exit code. sbsh v0.13.0 (the
+// terminating cause and, if so, the child's exit code. sbsh v0.13.1 (the
 // pinned release) has no machine-readable exit-code field on EvCmdExited — it
 // embeds the code in the terminating error: an *exec.ExitError on the non-init
 // cmd.Wait path, a "(code 0)" literal on a non-init clean exit, or a "code=N"
 // string on the PID-1 reaper path (internal/terminal/terminalrunner/
 // lifecycle.go). This recognizes all three carriers. ok=false means err is a
 // genuine kuketty-internal failure that should map to exitCodeInternal.
+//
+// Before sbsh v0.13.1 a clean PID-1 exit could surface here as the benign
+// PTY-master read EIO ("read /dev/ptmx: input/output error") instead of the
+// "code=N" carrier: the EIO is the immediate kernel side-effect of the child
+// closing its tty and it reliably preempted the reaper's EvCmdExited inside
+// sbsh's runLoop, so Serve returned the EIO as its cause and kuketty flipped a
+// clean exit to exitCodeInternal (issue #1282). sbsh v0.13.1's server.Serve now
+// waits briefly for the authoritative EvCmdExited before returning a PTY-read
+// EvError (eminwux/sbsh#439), so the benign race no longer reaches here — a
+// raw PTY-read EIO that *does* surface now means a genuine error with the child
+// still alive, and ok=false / exitCodeInternal is the correct mapping for it.
 func workloadExitCode(err error) (code int, ok bool) {
 	if err == nil {
 		return 0, true

--- a/cmd/kuketty/main_test.go
+++ b/cmd/kuketty/main_test.go
@@ -283,12 +283,18 @@ func TestIsCleanShutdown(t *testing.T) {
 	}
 }
 
-// TestWorkloadExitCode covers the carriers sbsh v0.13.0 embeds the workload
+// TestWorkloadExitCode covers the carriers sbsh v0.13.1 embeds the workload
 // child's exit code in (issue #1273): the *exec.ExitError on the non-init
 // cmd.Wait path, the "(code 0)" literal on a non-init clean exit, the
 // init-mode "code=N" string from the PID-1 reaper, and the abnormal
 // no-recoverable-code teardown paths. A genuine kuketty-internal failure must
 // report ok=false so it maps to exitCodeInternal.
+//
+// The "pty-EIO race resolves to code=N" case pins the issue #1282 contract:
+// sbsh v0.13.1 prefers the authoritative EvCmdExited over the benign PTY-master
+// read EIO (eminwux/sbsh#439), so a clean PID-1 exit surfaces as "code=0" here
+// rather than the EIO error — and a raw PTY-read EIO that still surfaces means
+// a genuine error (child alive), which must map to exitCodeInternal (ok=false).
 func TestWorkloadExitCode(t *testing.T) {
 	tests := []struct {
 		name     string
@@ -336,6 +342,24 @@ func TestWorkloadExitCode(t *testing.T) {
 		{
 			name:     "internal failure is not a workload exit",
 			err:      errors.New("server.New: bind failed"),
+			wantCode: 0,
+			wantOK:   false,
+		},
+		{
+			// #1282: under sbsh v0.13.1 a clean PID-1 exit racing the
+			// PTY-master EIO surfaces as the authoritative "code=N" carrier
+			// (sbsh#439), not the EIO — so it decodes to a clean exit.
+			name:     "pty-EIO race resolves to init-mode code=N",
+			err:      fmt.Errorf("server.Serve: %w", errors.New("shell process exited: code=0")),
+			wantCode: 0,
+			wantOK:   true,
+		},
+		{
+			// A raw PTY-read EIO that still surfaces means a genuine error with
+			// the child alive (sbsh v0.13.1 only returns it after waiting in
+			// vain for EvCmdExited), so it is a kuketty-internal failure.
+			name:     "raw pty-read EIO is an internal failure",
+			err:      fmt.Errorf("terminalManagerReader pty read error: could not read pipe->pipe: %w", errors.New("read /dev/ptmx: input/output error")),
 			wantCode: 0,
 			wantOK:   false,
 		},

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/containerd/typeurl/v2 v2.2.3
 	github.com/containernetworking/cni v1.3.0
 	github.com/creack/pty v1.1.24
-	github.com/eminwux/sbsh v0.13.0
+	github.com/eminwux/sbsh v0.13.1
 	github.com/opencontainers/go-digest v1.0.0
 	github.com/opencontainers/image-spec v1.1.1
 	github.com/opencontainers/runtime-spec v1.2.1

--- a/go.sum
+++ b/go.sum
@@ -58,8 +58,8 @@ github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/distribution/reference v0.6.0 h1:0IXCQ5g4/QMHHkarYzh5l+u8T3t73zM5QvfrDyIgxBk=
 github.com/distribution/reference v0.6.0/go.mod h1:BbU0aIcezP1/5jX/8MP0YiH4SdvB5Y4f/wlDRiLyi3E=
-github.com/eminwux/sbsh v0.13.0 h1:f+HA3D8xvaAQH/HbAaC78kpY+AJUvdsx2SDSqY1Rlnk=
-github.com/eminwux/sbsh v0.13.0/go.mod h1:epv5XQTI+D68bTa+LTgJ9WsckiA/96bZOjHrsgC3UWU=
+github.com/eminwux/sbsh v0.13.1 h1:ks91juMccERW6aeo/huXsu6BMUk+YiR9A2RIjcgBxbU=
+github.com/eminwux/sbsh v0.13.1/go.mod h1:epv5XQTI+D68bTa+LTgJ9WsckiA/96bZOjHrsgC3UWU=
 github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.4/go.mod h1:6rpuAdCZL397s3pYoYcLgu1mIlRU8Am5FuJP05cCM98=


### PR DESCRIPTION
## Summary

- Bumps `github.com/eminwux/sbsh` v0.13.0 → **v0.13.1**, which consumes the upstream fix for the kuketty exit-code race in #1282.
- #1282 proposed an **interim kuketty-side mitigation** (teach `workloadExitCode` to treat a PTY-master read EIO as a benign exit 0), but explicitly noted the complete fix is upstream in sbsh (eminwux/sbsh#438), with the tradeoff that the interim path would report a non-zero workload exit as 0 when the EIO wins the race. **The user reports sbsh v0.13.1 has now landed with that upstream fix**, so this PR consumes the proper fix rather than the lossy interim workaround.

### Why the dependency bump is the correct fix (premise update)

The issue's premise — that only the interim kuketty mitigation is available — has been superseded by v0.13.1 shipping. I inspected the actual `v0.13.0..v0.13.1` diff: the fix is **"prefer EvCmdExited over benign PTY-read EvError in Serve cause" (eminwux/sbsh#439)**. `server.Serve`'s `runLoop` now waits up to 250ms (`ptyExitGrace`) for the authoritative `EvCmdExited` after a benign `ErrPipeRead` EIO and returns *its* cause (`shell process exited: code=N`) instead of the EIO. The diff touches only `pkg/terminal/server/server.go`'s internal terminating-cause selection + an internal test — **no change to the `server.New` / `server.Serve` / listener facade kuketty depends on.**

Consequences for kuketty:
- The clean PID-1 exit now surfaces as the `code=N` carrier, which kuketty's **existing** `workloadExitCode` already decodes (`cmd/kuketty/main.go:120-125`) → clean exits land `Exited`.
- The interim mitigation is **not** applied — it would now be *wrong*: v0.13.1 only surfaces a raw PTY-read EIO when the child is still alive (a genuine error), so masking it as exit 0 would hide real failures. A surfaced raw EIO correctly maps to `exitCodeInternal` (`ok=false`).

### Changes
- `go.mod` / `go.sum`: sbsh v0.13.0 → v0.13.1.
- `cmd/kuketty/main.go`: doc-comment only — explain why the bump resolves #1282 and what a surfaced raw EIO now means. No logic change (the existing carriers already cover the post-fix cause).
- `cmd/kuketty/main_test.go`: two regression cases pinning the #1282 contract — the EIO race resolving to the `code=0` carrier (clean exit), and a raw PTY-read EIO mapping to `exitCodeInternal`.

## Test plan
- [x] `go build ./cmd/kuketty/` — passes against v0.13.1 (confirms the sbsh facade API is unchanged).
- [x] `go vet ./cmd/kuketty/`
- [x] `go test ./cmd/kuketty/ -run WorkloadExitCode` — all carriers + new #1282 cases pass.
- [x] `make test` (full CI target: `test-root` + `test-kukebuild`) — exit 0, zero failures.
- [ ] `make dev-init` (`KUKEON_PROFILE=dev`) attach smoke — **not run: blocked by an environmental disk constraint, not by this change.** The image-build phase failed with `no space left on device`; the host's containerd state lives on a 4.0G tmpfs (`/var/lib/containerd`) that is 97% full from pre-existing shared-host workloads (a running kukeond + a `hello-fixedtest` cell). No safe documented build-cache prune exists, and pruning containerd leases manually would risk those live workloads. Build compatibility with v0.13.1 is already proven by `go build` + `make test` passing, and the v0.13.1 diff is internal-only to sbsh's terminating-cause selection (the attach handshake / socket facade is byte-for-byte unchanged), so the attach pipeline carries minimal runtime risk from this bump.
- [ ] Live `agents-dev-0` confirmation that a clean workload exit lands `Exited`/restartable — this is the issue's named live-host verification (the dev-init smoke covers only the attach handshake, not exit-code derivation per the issue). It runs on `agents-dev-0`, a separate host this dev session cannot reach.

Closes #1282