### PR TITLE
feat: add create/get/delete volume CLI verbs (step 2)

### DIFF
--- a/cmd/config/autocomplete.go
+++ b/cmd/config/autocomplete.go
@@ -645,6 +645,67 @@ func CompleteBlueprintNames(cmd *cobra.Command, args []string, toComplete string
 	return names, cobra.ShellCompDirectiveNoFileComp
 }
 
+// CompleteVolumeNames provides shell completion for volume name args by listing
+// every Volume visible in the active scope filter (issue #1236). A Volume is
+// never cell-scoped, so the filter bottoms out at stack. Errors swallow to an
+// empty list so a down daemon never surfaces a noisy completion.
+//
+// /CompleteConfigNames by the same convention every get/<kind> completer follows.
+//
+//nolint:dupl // per-kind completer; structurally mirrors CompleteBlueprintNames
+func CompleteVolumeNames(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	if len(args) >= 1 && toComplete == "" {
+		if cmd.ValidArgsFunction != nil {
+			testArgs := make([]string, len(args), len(args)+1)
+			copy(testArgs, args)
+			testArgs = append(testArgs, "test")
+			if cmd.Args != nil {
+				if err := cmd.Args(cmd, testArgs); err != nil {
+					return []string{}, cobra.ShellCompDirectiveNoFileComp
+				}
+			}
+		}
+	}
+
+	client, err := completionClient(cmd)
+	if err != nil {
+		return []string{}, cobra.ShellCompDirectiveNoFileComp
+	}
+	defer func() { _ = client.Close() }()
+
+	realmName := getFlagValueWithDefault(cmd, "realm", "default")
+	spaceName := getFlagValueWithDefault(cmd, "space", "")
+	stackName := getFlagValueWithDefault(cmd, "stack", "")
+
+	if cmd.ValidArgsFunction != nil && len(args) == 0 {
+		if realmName == "" {
+			return []string{}, cobra.ShellCompDirectiveNoFileComp
+		}
+	}
+
+	ctx, cancel := context.WithTimeout(cmd.Context(), completionTimeout)
+	defer cancel()
+
+	volumes, err := client.ListVolumes(ctx, realmName, spaceName, stackName)
+	if err != nil {
+		return []string{}, cobra.ShellCompDirectiveNoFileComp
+	}
+
+	seen := make(map[string]bool)
+	names := make([]string, 0, len(volumes))
+	for _, vol := range volumes {
+		name := vol.Metadata.Name
+		if toComplete == "" || strings.HasPrefix(name, toComplete) {
+			if !seen[name] {
+				seen[name] = true
+				names = append(names, name)
+			}
+		}
+	}
+
+	return names, cobra.ShellCompDirectiveNoFileComp
+}
+
 // CompleteConfigNames provides shell completion for config name args by listing
 // every CellConfig visible in the active scope filter (issue #644). A Config is
 // never cell-scoped, so the filter bottoms out at stack. Errors swallow to an

--- a/cmd/config/env.go
+++ b/cmd/config/env.go
@@ -256,6 +256,15 @@ var (
 	//nolint:revive,gochecknoglobals,staticcheck // ignore linter warning about this variable
 	KUKE_CREATE_SECRET_STACK = DefineKV("KUKE_CREATE_SECRET_STACK", "kuke/create/secret/stack")
 
+	//nolint:revive,gochecknoglobals,staticcheck // ignore linter warning about this variable
+	KUKE_CREATE_VOLUME_NAME = DefineKV("KUKE_CREATE_VOLUME_NAME", "kuke/create/volume/name")
+	//nolint:revive,gochecknoglobals,staticcheck // ignore linter warning about this variable
+	KUKE_CREATE_VOLUME_REALM = DefineKV("KUKE_CREATE_VOLUME_REALM", "kuke/create/volume/realm", "default")
+	//nolint:revive,gochecknoglobals,staticcheck // ignore linter warning about this variable
+	KUKE_CREATE_VOLUME_SPACE = DefineKV("KUKE_CREATE_VOLUME_SPACE", "kuke/create/volume/space")
+	//nolint:revive,gochecknoglobals,staticcheck // ignore linter warning about this variable
+	KUKE_CREATE_VOLUME_STACK = DefineKV("KUKE_CREATE_VOLUME_STACK", "kuke/create/volume/stack")
+
 	// Get command variables
 	//nolint:revive,gochecknoglobals,staticcheck // ignore linter warning about this variable
 	KUKE_GET_REALM_NAME = DefineKV("KUKE_GET_REALM_NAME", "kuke/get/realm/name")
@@ -306,6 +315,14 @@ var (
 	//nolint:revive,gochecknoglobals,staticcheck // ignore linter warning about this variable
 	KUKE_GET_BLUEPRINT_STACK = DefineKV("KUKE_GET_BLUEPRINT_STACK", "kuke/get/blueprint/stack", "default")
 	//nolint:revive,gochecknoglobals,staticcheck // ignore linter warning about this variable
+	KUKE_GET_VOLUME_NAME = DefineKV("KUKE_GET_VOLUME_NAME", "kuke/get/volume/name")
+	//nolint:revive,gochecknoglobals,staticcheck // ignore linter warning about this variable
+	KUKE_GET_VOLUME_REALM = DefineKV("KUKE_GET_VOLUME_REALM", "kuke/get/volume/realm", "default")
+	//nolint:revive,gochecknoglobals,staticcheck // ignore linter warning about this variable
+	KUKE_GET_VOLUME_SPACE = DefineKV("KUKE_GET_VOLUME_SPACE", "kuke/get/volume/space")
+	//nolint:revive,gochecknoglobals,staticcheck // ignore linter warning about this variable
+	KUKE_GET_VOLUME_STACK = DefineKV("KUKE_GET_VOLUME_STACK", "kuke/get/volume/stack")
+	//nolint:revive,gochecknoglobals,staticcheck // ignore linter warning about this variable
 	KUKE_GET_CONFIG_NAME = DefineKV("KUKE_GET_CONFIG_NAME", "kuke/get/config/name")
 	//nolint:revive,gochecknoglobals,staticcheck // ignore linter warning about this variable
 	KUKE_GET_CONFIG_REALM = DefineKV("KUKE_GET_CONFIG_REALM", "kuke/get/config/realm", "default")
@@ -355,6 +372,14 @@ var (
 	KUKE_DELETE_BLUEPRINT_SPACE = DefineKV("KUKE_DELETE_BLUEPRINT_SPACE", "kuke/delete/blueprint/space")
 	//nolint:revive,gochecknoglobals,staticcheck // ignore linter warning about this variable
 	KUKE_DELETE_BLUEPRINT_STACK = DefineKV("KUKE_DELETE_BLUEPRINT_STACK", "kuke/delete/blueprint/stack")
+	//nolint:revive,gochecknoglobals,staticcheck // ignore linter warning about this variable
+	KUKE_DELETE_VOLUME_NAME = DefineKV("KUKE_DELETE_VOLUME_NAME", "kuke/delete/volume/name")
+	//nolint:revive,gochecknoglobals,staticcheck // ignore linter warning about this variable
+	KUKE_DELETE_VOLUME_REALM = DefineKV("KUKE_DELETE_VOLUME_REALM", "kuke/delete/volume/realm", "default")
+	//nolint:revive,gochecknoglobals,staticcheck // ignore linter warning about this variable
+	KUKE_DELETE_VOLUME_SPACE = DefineKV("KUKE_DELETE_VOLUME_SPACE", "kuke/delete/volume/space")
+	//nolint:revive,gochecknoglobals,staticcheck // ignore linter warning about this variable
+	KUKE_DELETE_VOLUME_STACK = DefineKV("KUKE_DELETE_VOLUME_STACK", "kuke/delete/volume/stack")
 	//nolint:revive,gochecknoglobals,staticcheck // ignore linter warning about this variable
 	KUKE_DELETE_CONFIG_NAME = DefineKV("KUKE_DELETE_CONFIG_NAME", "kuke/delete/config/name")
 	//nolint:revive,gochecknoglobals,staticcheck // ignore linter warning about this variable

--- a/cmd/kuke/create/create.go
+++ b/cmd/kuke/create/create.go
@@ -27,6 +27,7 @@ import (
 	secretcmd "github.com/eminwux/kukeon/cmd/kuke/create/secret"
 	spacecmd "github.com/eminwux/kukeon/cmd/kuke/create/space"
 	stackcmd "github.com/eminwux/kukeon/cmd/kuke/create/stack"
+	volumecmd "github.com/eminwux/kukeon/cmd/kuke/create/volume"
 	"github.com/spf13/cobra"
 )
 
@@ -37,7 +38,7 @@ func NewCreateCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "create",
 		Aliases: []string{"c"},
-		Short:   "Create Kukeon resources (realm, space, stack, cell, config, blueprint, secret, registry-credential)",
+		Short:   "Create Kukeon resources (realm, space, stack, cell, config, blueprint, secret, volume, registry-credential)",
 		Run: func(cmd *cobra.Command, _ []string) {
 			_ = cmd.Help()
 		},
@@ -53,6 +54,7 @@ func NewCreateCmd() *cobra.Command {
 		configcmd.NewConfigCmd(),
 		blueprintcmd.NewBlueprintCmd(),
 		secretcmd.NewSecretCmd(),
+		volumecmd.NewVolumeCmd(),
 		registrycredentialcmd.NewRegistryCredentialCmd(),
 	)
 
@@ -61,7 +63,9 @@ func NewCreateCmd() *cobra.Command {
 
 // completeCreateSubcommands provides shell completion for create subcommand names.
 func completeCreateSubcommands(_ *cobra.Command, _ []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-	subcommands := []string{"realm", "space", "stack", "cell", "config", "blueprint", "secret", "registry-credential"}
+	subcommands := []string{
+		"realm", "space", "stack", "cell", "config", "blueprint", "secret", "volume", "registry-credential",
+	}
 
 	if toComplete == "" {
 		return subcommands, cobra.ShellCompDirectiveNoFileComp

--- a/cmd/kuke/create/create_test.go
+++ b/cmd/kuke/create/create_test.go
@@ -41,7 +41,7 @@ func TestNewCreateCmdMetadata(t *testing.T) {
 		{
 			name: "short description",
 			check: func(t *testing.T, cmd *cobra.Command) {
-				expected := "Create Kukeon resources (realm, space, stack, cell, config, blueprint, secret, registry-credential)"
+				expected := "Create Kukeon resources (realm, space, stack, cell, config, blueprint, secret, volume, registry-credential)"
 				if cmd.Short != expected {
 					t.Fatalf("expected Short to be %q, got %q", expected, cmd.Short)
 				}
@@ -83,6 +83,7 @@ func TestNewCreateCmdRegistersSubcommands(t *testing.T) {
 		{name: "config"},
 		{name: "blueprint"},
 		{name: "secret"},
+		{name: "volume"},
 		{name: "registry-credential"},
 	}
 
@@ -106,7 +107,17 @@ func TestNewCreateCmd_AutocompleteRegistration(t *testing.T) {
 
 	// Test the completion function directly
 	completions, _ := cmd.ValidArgsFunction(cmd, []string{}, "")
-	expected := []string{"realm", "space", "stack", "cell", "config", "blueprint", "secret", "registry-credential"}
+	expected := []string{
+		"realm",
+		"space",
+		"stack",
+		"cell",
+		"config",
+		"blueprint",
+		"secret",
+		"volume",
+		"registry-credential",
+	}
 	if len(completions) != len(expected) {
 		t.Fatalf("expected %d completions, got %d", len(expected), len(completions))
 	}

--- a/cmd/kuke/create/volume/volume.go
+++ b/cmd/kuke/create/volume/volume.go
@@ -1,0 +1,142 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Package volume implements `kuke create volume <name>` (issue #1236, step 2 of
+// the volumes epic #1015). Unlike `kuke create blueprint` — which scaffolds a
+// YAML document to stdout because a CellBlueprint is declaratively complex — a
+// Volume's spec is empty and the resource is the on-host directory the daemon
+// provisions, so this verb is imperative like `kuke create secret`: it persists
+// the Volume to the daemon and prints the outcome. A Volume is scopable at
+// realm/space/stack only; cell scope is structurally unrepresentable (there is
+// no --cell flag), satisfying the AC's "cell scope rejected".
+package volume
+
+import (
+	"strings"
+
+	"github.com/eminwux/kukeon/cmd/config"
+	"github.com/eminwux/kukeon/cmd/kuke/create/shared"
+	kukeshared "github.com/eminwux/kukeon/cmd/kuke/shared"
+	"github.com/eminwux/kukeon/pkg/api/kukeonv1"
+	v1beta1 "github.com/eminwux/kukeon/pkg/api/model/v1beta1"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+)
+
+// MockControllerKey is used to inject a mock kukeonv1.Client via context in tests.
+type MockControllerKey struct{}
+
+// NewVolumeCmd builds `kuke create volume <name>` (issue #1236).
+func NewVolumeCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "volume [name]",
+		Aliases: []string{"vol"},
+		Short:   "Create a kind: Volume within a scope",
+		Long: "Create a standalone, daemon-managed Volume within a scope.\n\n" +
+			"A Volume is the on-host directory the daemon provisions; its spec is empty. " +
+			"It is scopable at realm/space/stack only — never cell — so a volume can outlive " +
+			"the cells that mount it (the mount kind lands in step 4, #1016).",
+		Args:          cobra.MaximumNArgs(1),
+		SilenceUsage:  true,
+		SilenceErrors: false,
+		RunE:          runCreateVolume,
+	}
+
+	cmd.Flags().String("realm", "", "Realm that owns the volume")
+	_ = viper.BindPFlag(config.KUKE_CREATE_VOLUME_REALM.ViperKey, cmd.Flags().Lookup("realm"))
+
+	cmd.Flags().String("space", "", "Space that owns the volume")
+	_ = viper.BindPFlag(config.KUKE_CREATE_VOLUME_SPACE.ViperKey, cmd.Flags().Lookup("space"))
+
+	cmd.Flags().String("stack", "", "Stack that owns the volume")
+	_ = viper.BindPFlag(config.KUKE_CREATE_VOLUME_STACK.ViperKey, cmd.Flags().Lookup("stack"))
+
+	_ = cmd.RegisterFlagCompletionFunc("realm", config.CompleteRealmNames)
+	_ = cmd.RegisterFlagCompletionFunc("space", config.CompleteSpaceNames)
+	_ = cmd.RegisterFlagCompletionFunc("stack", config.CompleteStackNames)
+
+	return cmd
+}
+
+func runCreateVolume(cmd *cobra.Command, args []string) error {
+	name, err := shared.RequireNameArgOrDefault(
+		cmd,
+		args,
+		"volume",
+		viper.GetString(config.KUKE_CREATE_VOLUME_NAME.ViperKey),
+	)
+	if err != nil {
+		return err
+	}
+
+	realm := strings.TrimSpace(viper.GetString(config.KUKE_CREATE_VOLUME_REALM.ViperKey))
+	if realm == "" {
+		realm = strings.TrimSpace(config.KUKE_CREATE_VOLUME_REALM.ValueOrDefault())
+	}
+	space := strings.TrimSpace(viper.GetString(config.KUKE_CREATE_VOLUME_SPACE.ViperKey))
+	if space == "" {
+		space = strings.TrimSpace(config.KUKE_CREATE_VOLUME_SPACE.ValueOrDefault())
+	}
+	stack := strings.TrimSpace(viper.GetString(config.KUKE_CREATE_VOLUME_STACK.ViperKey))
+	if stack == "" {
+		stack = strings.TrimSpace(config.KUKE_CREATE_VOLUME_STACK.ValueOrDefault())
+	}
+
+	client, err := resolveClient(cmd)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = client.Close() }()
+
+	doc := v1beta1.VolumeDoc{
+		APIVersion: v1beta1.APIVersionV1Beta1,
+		Kind:       v1beta1.KindVolume,
+		Metadata: v1beta1.VolumeMetadata{
+			Name:  name,
+			Realm: realm,
+			Space: space,
+			Stack: stack,
+		},
+	}
+
+	result, err := client.CreateVolume(cmd.Context(), doc)
+	if err != nil {
+		return err
+	}
+
+	printVolumeResult(cmd, result)
+	return nil
+}
+
+func resolveClient(cmd *cobra.Command) (kukeonv1.Client, error) {
+	if mockClient, ok := cmd.Context().Value(MockControllerKey{}).(kukeonv1.Client); ok {
+		return mockClient, nil
+	}
+	return kukeshared.DaemonClientFromCmd(cmd)
+}
+
+func printVolumeResult(cmd *cobra.Command, result kukeonv1.CreateVolumeResult) {
+	cmd.Printf(
+		"Volume %q (realm %q, space %q, stack %q)\n",
+		result.Volume.Metadata.Name,
+		result.Volume.Metadata.Realm,
+		result.Volume.Metadata.Space,
+		result.Volume.Metadata.Stack,
+	)
+	// The volume directory always exists post-create (WriteVolume is
+	// idempotent), so existsPost=true renders "already existed" on a re-create.
+	shared.PrintCreationOutcome(cmd, "directory", true, result.Created)
+}

--- a/cmd/kuke/create/volume/volume_test.go
+++ b/cmd/kuke/create/volume/volume_test.go
@@ -1,0 +1,155 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package volume_test
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"log/slog"
+	"strings"
+	"testing"
+
+	"github.com/eminwux/kukeon/cmd/kuke/create/volume"
+	"github.com/eminwux/kukeon/cmd/types"
+	"github.com/eminwux/kukeon/pkg/api/kukeonv1"
+	v1beta1 "github.com/eminwux/kukeon/pkg/api/model/v1beta1"
+	"github.com/spf13/viper"
+)
+
+type fakeClient struct {
+	kukeonv1.FakeClient
+
+	createVolumeFn func(doc v1beta1.VolumeDoc) (kukeonv1.CreateVolumeResult, error)
+}
+
+func (f *fakeClient) CreateVolume(_ context.Context, doc v1beta1.VolumeDoc) (kukeonv1.CreateVolumeResult, error) {
+	if f.createVolumeFn == nil {
+		return kukeonv1.CreateVolumeResult{}, errors.New("unexpected CreateVolume call")
+	}
+	return f.createVolumeFn(doc)
+}
+
+func TestNewVolumeCmdRunE(t *testing.T) {
+	t.Cleanup(viper.Reset)
+
+	tests := []struct {
+		name     string
+		args     []string
+		clientFn func(doc v1beta1.VolumeDoc) (kukeonv1.CreateVolumeResult, error)
+		wantErr  string
+		wantOut  string
+	}{
+		{
+			name: "happy path at default realm",
+			args: []string{"myvol"},
+			clientFn: func(doc v1beta1.VolumeDoc) (kukeonv1.CreateVolumeResult, error) {
+				if doc.Metadata.Name != "myvol" {
+					t.Errorf("unexpected name: %q", doc.Metadata.Name)
+				}
+				if doc.Metadata.Realm != "default" {
+					t.Errorf("unexpected realm: %q", doc.Metadata.Realm)
+				}
+				if doc.Kind != v1beta1.KindVolume {
+					t.Errorf("unexpected kind: %q", doc.Kind)
+				}
+				return kukeonv1.CreateVolumeResult{Volume: doc, Created: true}, nil
+			},
+			wantOut: `Volume "myvol" (realm "default", space "", stack "")`,
+		},
+		{
+			name: "scope flags threaded through",
+			args: []string{"scoped", "--realm=myrealm", "--space=myspace", "--stack=mystack"},
+			clientFn: func(doc v1beta1.VolumeDoc) (kukeonv1.CreateVolumeResult, error) {
+				if doc.Metadata.Realm != "myrealm" || doc.Metadata.Space != "myspace" ||
+					doc.Metadata.Stack != "mystack" {
+					t.Errorf("unexpected scope: %+v", doc.Metadata)
+				}
+				return kukeonv1.CreateVolumeResult{Volume: doc, Created: true}, nil
+			},
+			wantOut: `Volume "scoped" (realm "myrealm", space "myspace", stack "mystack")`,
+		},
+		{
+			name: "re-create reports already existed",
+			args: []string{"existing"},
+			clientFn: func(doc v1beta1.VolumeDoc) (kukeonv1.CreateVolumeResult, error) {
+				return kukeonv1.CreateVolumeResult{Volume: doc, Created: false}, nil
+			},
+			wantOut: "already existed",
+		},
+		{
+			name:    "no name rejected",
+			args:    []string{},
+			wantErr: "volume name is required",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Cleanup(viper.Reset)
+
+			cmd := volume.NewVolumeCmd()
+			out := &bytes.Buffer{}
+			cmd.SetOut(out)
+			cmd.SetErr(out)
+
+			logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+			ctx := context.WithValue(context.Background(), types.CtxLogger, logger)
+
+			if tt.clientFn != nil {
+				fake := &fakeClient{createVolumeFn: tt.clientFn}
+				ctx = context.WithValue(ctx, volume.MockControllerKey{}, kukeonv1.Client(fake))
+			}
+			cmd.SetContext(ctx)
+
+			cmd.SetArgs(tt.args)
+			err := cmd.Execute()
+
+			if tt.wantErr != "" {
+				if err == nil {
+					t.Fatal("expected error, got nil")
+				}
+				if !strings.Contains(err.Error(), tt.wantErr) {
+					t.Errorf("expected error containing %q, got %q", tt.wantErr, err.Error())
+				}
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			if tt.wantOut != "" && !strings.Contains(out.String(), tt.wantOut) {
+				t.Errorf("expected output to contain %q, got %q", tt.wantOut, out.String())
+			}
+		})
+	}
+}
+
+func TestNewVolumeCmd_FlagRegistration(t *testing.T) {
+	cmd := volume.NewVolumeCmd()
+	for _, name := range []string{"realm", "space", "stack"} {
+		if cmd.Flags().Lookup(name) == nil {
+			t.Errorf("expected %q flag to exist", name)
+		}
+	}
+	// A Volume is never cell-scoped; there must be no --cell flag.
+	if cmd.Flags().Lookup("cell") != nil {
+		t.Error("create volume should not expose a --cell flag (volumes are never cell-scoped)")
+	}
+}

--- a/cmd/kuke/delete/delete.go
+++ b/cmd/kuke/delete/delete.go
@@ -30,6 +30,7 @@ import (
 	"github.com/eminwux/kukeon/cmd/kuke/delete/shared"
 	"github.com/eminwux/kukeon/cmd/kuke/delete/space"
 	"github.com/eminwux/kukeon/cmd/kuke/delete/stack"
+	volumedelete "github.com/eminwux/kukeon/cmd/kuke/delete/volume"
 	kukshared "github.com/eminwux/kukeon/cmd/kuke/shared"
 	"github.com/eminwux/kukeon/internal/errdefs"
 	"github.com/eminwux/kukeon/pkg/api/kukeonv1"
@@ -49,7 +50,7 @@ func NewDeleteCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "delete [name]",
 		Aliases: []string{"d"},
-		Short:   "Delete Kukeon resources (realm, space, stack, cell, secret, blueprint, config)",
+		Short:   "Delete Kukeon resources (realm, space, stack, cell, secret, blueprint, volume, config)",
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			// Check if -f flag is provided
 			file, err := cmd.Flags().GetString("file")
@@ -92,6 +93,7 @@ func NewDeleteCmd() *cobra.Command {
 		cell.NewCellCmd(),
 		secretdelete.NewSecretCmd(),
 		blueprintdelete.NewBlueprintCmd(),
+		volumedelete.NewVolumeCmd(),
 		configdelete.NewConfigCmd(),
 	)
 
@@ -100,7 +102,7 @@ func NewDeleteCmd() *cobra.Command {
 
 // completeDeleteSubcommands provides shell completion for delete subcommand names.
 func completeDeleteSubcommands(_ *cobra.Command, _ []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-	subcommands := []string{"realm", "space", "stack", "cell", "secret", "blueprint", "config"}
+	subcommands := []string{"realm", "space", "stack", "cell", "secret", "blueprint", "volume", "config"}
 
 	if toComplete == "" {
 		return subcommands, cobra.ShellCompDirectiveNoFileComp

--- a/cmd/kuke/delete/delete_test.go
+++ b/cmd/kuke/delete/delete_test.go
@@ -50,7 +50,7 @@ func TestNewDeleteCmdMetadata(t *testing.T) {
 		{
 			name: "short description",
 			check: func(t *testing.T, cmd *cobra.Command) {
-				expected := "Delete Kukeon resources (realm, space, stack, cell, secret, blueprint, config)"
+				expected := "Delete Kukeon resources (realm, space, stack, cell, secret, blueprint, volume, config)"
 				if cmd.Short != expected {
 					t.Fatalf("expected Short to be %q, got %q", expected, cmd.Short)
 				}
@@ -206,7 +206,7 @@ func TestNewDeleteCmd_AutocompleteRegistration(t *testing.T) {
 
 	// Test the completion function directly
 	completions, _ := cmd.ValidArgsFunction(cmd, []string{}, "")
-	expected := []string{"realm", "space", "stack", "cell", "secret", "blueprint", "config"}
+	expected := []string{"realm", "space", "stack", "cell", "secret", "blueprint", "volume", "config"}
 	if len(completions) != len(expected) {
 		t.Fatalf("expected %d completions, got %d", len(expected), len(completions))
 	}

--- a/cmd/kuke/delete/volume/volume.go
+++ b/cmd/kuke/delete/volume/volume.go
@@ -1,0 +1,111 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package volume
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/eminwux/kukeon/cmd/config"
+	kukeshared "github.com/eminwux/kukeon/cmd/kuke/shared"
+	"github.com/eminwux/kukeon/internal/errdefs"
+	"github.com/eminwux/kukeon/pkg/api/kukeonv1"
+	v1beta1 "github.com/eminwux/kukeon/pkg/api/model/v1beta1"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+)
+
+// MockControllerKey is used to inject a mock kukeonv1.Client via context in tests.
+type MockControllerKey struct{}
+
+// NewVolumeCmd builds `kuke delete volume <name>` (issue #1236). It removes the
+// daemon-provisioned directory for a single named, scoped Volume. The volume is
+// identified by its name plus its binding scope (--realm/--space/--stack). A
+// Volume is never cell-scoped, so there is no --cell flag. There is no
+// live-mount refusal gate in this step: the container-side mount kind that
+// would reference a Volume lands in step 4 (#1016), where the delete gate
+// against a live mount is exercised.
+func NewVolumeCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:           "volume [name]",
+		Aliases:       []string{"vol"},
+		Short:         "Delete a kind: Volume",
+		Args:          cobra.ExactArgs(1),
+		SilenceUsage:  true,
+		SilenceErrors: false,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			name := strings.TrimSpace(args[0])
+
+			realm := strings.TrimSpace(config.KUKE_DELETE_VOLUME_REALM.ValueOrDefault())
+			space := config.KUKE_DELETE_VOLUME_SPACE.ValueOrDefault()
+			stack := config.KUKE_DELETE_VOLUME_STACK.ValueOrDefault()
+			if realm == "" {
+				return fmt.Errorf("%w (--realm)", errdefs.ErrRealmNameRequired)
+			}
+
+			doc := v1beta1.VolumeDoc{
+				APIVersion: v1beta1.APIVersionV1Beta1,
+				Kind:       v1beta1.KindVolume,
+				Metadata: v1beta1.VolumeMetadata{
+					Name:  name,
+					Realm: realm,
+					Space: strings.TrimSpace(space),
+					Stack: strings.TrimSpace(stack),
+				},
+			}
+
+			client, err := resolveClient(cmd)
+			if err != nil {
+				return err
+			}
+			defer func() { _ = client.Close() }()
+
+			result, err := client.DeleteVolume(cmd.Context(), doc)
+			if err != nil {
+				return err
+			}
+
+			volumeName := name
+			if result.Volume.Metadata.Name != "" {
+				volumeName = result.Volume.Metadata.Name
+			}
+			cmd.Printf("Deleted volume %q\n", volumeName)
+			return nil
+		},
+	}
+
+	cmd.Flags().String("realm", "", "Realm the volume is bound to")
+	_ = viper.BindPFlag(config.KUKE_DELETE_VOLUME_REALM.ViperKey, cmd.Flags().Lookup("realm"))
+	cmd.Flags().String("space", "", "Space the volume is bound to")
+	_ = viper.BindPFlag(config.KUKE_DELETE_VOLUME_SPACE.ViperKey, cmd.Flags().Lookup("space"))
+	cmd.Flags().String("stack", "", "Stack the volume is bound to")
+	_ = viper.BindPFlag(config.KUKE_DELETE_VOLUME_STACK.ViperKey, cmd.Flags().Lookup("stack"))
+
+	cmd.ValidArgsFunction = config.CompleteVolumeNames
+	_ = cmd.RegisterFlagCompletionFunc("realm", config.CompleteRealmNames)
+	_ = cmd.RegisterFlagCompletionFunc("space", config.CompleteSpaceNames)
+	_ = cmd.RegisterFlagCompletionFunc("stack", config.CompleteStackNames)
+
+	return cmd
+}
+
+func resolveClient(cmd *cobra.Command) (kukeonv1.Client, error) {
+	if mockClient, ok := cmd.Context().Value(MockControllerKey{}).(kukeonv1.Client); ok {
+		return mockClient, nil
+	}
+	return kukeshared.DaemonClientFromCmd(cmd)
+}

--- a/cmd/kuke/delete/volume/volume_test.go
+++ b/cmd/kuke/delete/volume/volume_test.go
@@ -1,0 +1,156 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package volume_test
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"log/slog"
+	"strings"
+	"testing"
+
+	volume "github.com/eminwux/kukeon/cmd/kuke/delete/volume"
+	"github.com/eminwux/kukeon/cmd/types"
+	"github.com/eminwux/kukeon/internal/errdefs"
+	"github.com/eminwux/kukeon/pkg/api/kukeonv1"
+	v1beta1 "github.com/eminwux/kukeon/pkg/api/model/v1beta1"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+)
+
+func TestDeleteVolume(t *testing.T) {
+	t.Cleanup(viper.Reset)
+
+	tests := []struct {
+		name       string
+		args       []string
+		setup      func(t *testing.T, cmd *cobra.Command)
+		fake       *fakeClient
+		wantErr    string
+		wantScope  v1beta1.VolumeMetadata
+		wantOutput string
+	}{
+		{
+			name: "success at realm scope",
+			args: []string{"vol1"},
+			setup: func(_ *testing.T, cmd *cobra.Command) {
+				_ = cmd.Flags().Set("realm", "r1")
+			},
+			fake: &fakeClient{
+				deleteVolumeFn: func(doc v1beta1.VolumeDoc) (kukeonv1.DeleteVolumeResult, error) {
+					return kukeonv1.DeleteVolumeResult{Volume: doc, Deleted: true}, nil
+				},
+			},
+			wantScope:  v1beta1.VolumeMetadata{Name: "vol1", Realm: "r1"},
+			wantOutput: `Deleted volume "vol1"`,
+		},
+		{
+			name: "success at stack scope passes full coordinates",
+			args: []string{"stack-vol"},
+			setup: func(_ *testing.T, cmd *cobra.Command) {
+				_ = cmd.Flags().Set("realm", "r1")
+				_ = cmd.Flags().Set("space", "s1")
+				_ = cmd.Flags().Set("stack", "st1")
+			},
+			fake: &fakeClient{
+				deleteVolumeFn: func(doc v1beta1.VolumeDoc) (kukeonv1.DeleteVolumeResult, error) {
+					return kukeonv1.DeleteVolumeResult{Volume: doc, Deleted: true}, nil
+				},
+			},
+			wantScope:  v1beta1.VolumeMetadata{Name: "stack-vol", Realm: "r1", Space: "s1", Stack: "st1"},
+			wantOutput: `Deleted volume "stack-vol"`,
+		},
+		{
+			name: "not found surfaces error",
+			args: []string{"missing"},
+			setup: func(_ *testing.T, cmd *cobra.Command) {
+				_ = cmd.Flags().Set("realm", "r1")
+			},
+			fake: &fakeClient{
+				deleteVolumeFn: func(_ v1beta1.VolumeDoc) (kukeonv1.DeleteVolumeResult, error) {
+					return kukeonv1.DeleteVolumeResult{}, errdefs.ErrVolumeNotFound
+				},
+			},
+			wantErr: "volume not found",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Cleanup(viper.Reset)
+
+			cmd := volume.NewVolumeCmd()
+			buf := &bytes.Buffer{}
+			cmd.SetOut(buf)
+			cmd.SetErr(buf)
+
+			logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+			ctx := context.WithValue(context.Background(), types.CtxLogger, logger)
+			ctx = context.WithValue(ctx, volume.MockControllerKey{}, kukeonv1.Client(tt.fake))
+			cmd.SetContext(ctx)
+
+			if tt.setup != nil {
+				tt.setup(t, cmd)
+			}
+
+			cmd.SetArgs(tt.args)
+			err := cmd.Execute()
+
+			if tt.wantErr != "" {
+				if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
+					t.Fatalf("want err %q, got %v", tt.wantErr, err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if tt.wantScope != (v1beta1.VolumeMetadata{}) && tt.fake.gotDoc.Metadata != tt.wantScope {
+				t.Errorf("scope passed = %+v, want %+v", tt.fake.gotDoc.Metadata, tt.wantScope)
+			}
+			if tt.wantOutput != "" && !strings.Contains(buf.String(), tt.wantOutput) {
+				t.Errorf("output missing %q\nGot:\n%s", tt.wantOutput, buf.String())
+			}
+		})
+	}
+}
+
+// TestDeleteVolume_NoCellFlag confirms the verb does not expose a --cell flag:
+// a Volume is never cell-scoped (issue #1018/#1236).
+func TestDeleteVolume_NoCellFlag(t *testing.T) {
+	cmd := volume.NewVolumeCmd()
+	if cmd.Flags().Lookup("cell") != nil {
+		t.Error("delete volume should not expose a --cell flag (volumes are never cell-scoped)")
+	}
+}
+
+type fakeClient struct {
+	kukeonv1.FakeClient
+
+	deleteVolumeFn func(doc v1beta1.VolumeDoc) (kukeonv1.DeleteVolumeResult, error)
+	gotDoc         v1beta1.VolumeDoc
+}
+
+func (f *fakeClient) DeleteVolume(_ context.Context, doc v1beta1.VolumeDoc) (kukeonv1.DeleteVolumeResult, error) {
+	f.gotDoc = doc
+	if f.deleteVolumeFn == nil {
+		return kukeonv1.DeleteVolumeResult{}, errors.New("unexpected DeleteVolume call")
+	}
+	return f.deleteVolumeFn(doc)
+}

--- a/cmd/kuke/get/get.go
+++ b/cmd/kuke/get/get.go
@@ -28,6 +28,7 @@ import (
 	secretcmd "github.com/eminwux/kukeon/cmd/kuke/get/secret"
 	spacecmd "github.com/eminwux/kukeon/cmd/kuke/get/space"
 	stackcmd "github.com/eminwux/kukeon/cmd/kuke/get/stack"
+	volumecmd "github.com/eminwux/kukeon/cmd/kuke/get/volume"
 	kukeshared "github.com/eminwux/kukeon/cmd/kuke/shared"
 	"github.com/spf13/cobra"
 )
@@ -39,7 +40,7 @@ func NewGetCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "get [name]",
 		Aliases: []string{"g"},
-		Short:   "Get or list Kukeon resources (realm, space, stack, cell, container, image, secret, blueprint, config)",
+		Short:   "Get or list Kukeon resources (realm, space, stack, cell, container, image, secret, blueprint, volume, config)",
 		Run: func(cmd *cobra.Command, _ []string) {
 			_ = cmd.Help()
 		},
@@ -64,6 +65,7 @@ func NewGetCmd() *cobra.Command {
 		imagecmd.NewImageCmd(),
 		secretcmd.NewSecretCmd(),
 		blueprintcmd.NewBlueprintCmd(),
+		volumecmd.NewVolumeCmd(),
 		configcmd.NewConfigCmd(),
 	)
 
@@ -72,7 +74,9 @@ func NewGetCmd() *cobra.Command {
 
 // completeGetSubcommands provides shell completion for get subcommand names.
 func completeGetSubcommands(_ *cobra.Command, _ []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-	subcommands := []string{"realm", "space", "stack", "cell", "container", "image", "secret", "blueprint", "config"}
+	subcommands := []string{
+		"realm", "space", "stack", "cell", "container", "image", "secret", "blueprint", "volume", "config",
+	}
 
 	if toComplete == "" {
 		return subcommands, cobra.ShellCompDirectiveNoFileComp

--- a/cmd/kuke/get/get_test.go
+++ b/cmd/kuke/get/get_test.go
@@ -41,7 +41,7 @@ func TestNewGetCmdMetadata(t *testing.T) {
 		{
 			name: "short description",
 			check: func(t *testing.T, cmd *cobra.Command) {
-				expected := "Get or list Kukeon resources (realm, space, stack, cell, container, image, secret, blueprint, config)"
+				expected := "Get or list Kukeon resources (realm, space, stack, cell, container, image, secret, blueprint, volume, config)"
 				if cmd.Short != expected {
 					t.Fatalf("expected Short to be %q, got %q", expected, cmd.Short)
 				}
@@ -105,7 +105,18 @@ func TestNewGetCmd_AutocompleteRegistration(t *testing.T) {
 
 	// Test the completion function directly
 	completions, _ := cmd.ValidArgsFunction(cmd, []string{}, "")
-	expected := []string{"realm", "space", "stack", "cell", "container", "image", "secret", "blueprint", "config"}
+	expected := []string{
+		"realm",
+		"space",
+		"stack",
+		"cell",
+		"container",
+		"image",
+		"secret",
+		"blueprint",
+		"volume",
+		"config",
+	}
 	if len(completions) != len(expected) {
 		t.Fatalf("expected %d completions, got %d", len(expected), len(completions))
 	}

--- a/cmd/kuke/get/volume/volume.go
+++ b/cmd/kuke/get/volume/volume.go
@@ -1,0 +1,193 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package volume
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/eminwux/kukeon/cmd/config"
+	"github.com/eminwux/kukeon/cmd/kuke/get/shared"
+	kukeshared "github.com/eminwux/kukeon/cmd/kuke/shared"
+	"github.com/eminwux/kukeon/internal/errdefs"
+	"github.com/eminwux/kukeon/pkg/api/kukeonv1"
+	v1beta1 "github.com/eminwux/kukeon/pkg/api/model/v1beta1"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+)
+
+// MockControllerKey is used to inject a mock kukeonv1.Client via context in tests.
+type MockControllerKey struct{}
+
+// NewVolumeCmd builds `kuke get volume(s)` (issue #1236). With a name it shows
+// one Volume's metadata; without one it lists every Volume bound to the filter
+// scope or any scope nested within it (subtree-filter semantics, matching
+// `kuke get blueprints`). A Volume is never cell-scoped, so there is no --cell
+// flag — the scope bottoms out at stack.
+func NewVolumeCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:           "volume [name]",
+		Aliases:       []string{"volumes", "vol"},
+		Short:         "Get or list kind: Volume metadata",
+		Args:          cobra.MaximumNArgs(1),
+		SilenceUsage:  true,
+		SilenceErrors: false,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			client, err := resolveClient(cmd)
+			if err != nil {
+				return err
+			}
+			defer func() { _ = client.Close() }()
+
+			outputFormat, err := shared.ParseOutputFormat(cmd)
+			if err != nil {
+				return err
+			}
+
+			// List filters: an unset flag means "no filter" (ExplicitFlag),
+			// so `kuke get volumes` with no flags lists the whole subtree.
+			realm := shared.ExplicitFlag(cmd, "realm", config.KUKE_GET_VOLUME_REALM.ViperKey)
+			space := shared.ExplicitFlag(cmd, "space", config.KUKE_GET_VOLUME_SPACE.ViperKey)
+			stack := shared.ExplicitFlag(cmd, "stack", config.KUKE_GET_VOLUME_STACK.ViperKey)
+
+			var name string
+			if len(args) > 0 {
+				name = strings.TrimSpace(args[0])
+			} else {
+				name = strings.TrimSpace(viper.GetString(config.KUKE_GET_VOLUME_NAME.ViperKey))
+			}
+
+			if name != "" {
+				// A single volume is identified by its name plus its exact
+				// binding scope. Default the realm to the operator's current
+				// realm; deeper coordinates stay unset unless provided. A
+				// realm-scoped Volume (space/stack unset) is reachable with no
+				// extra flags.
+				if realm == "" {
+					realm = strings.TrimSpace(config.KUKE_GET_VOLUME_REALM.ValueOrDefault())
+				}
+				if realm == "" {
+					return fmt.Errorf("%w (--realm)", errdefs.ErrRealmNameRequired)
+				}
+				lookup := v1beta1.VolumeDoc{
+					APIVersion: v1beta1.APIVersionV1Beta1,
+					Kind:       v1beta1.KindVolume,
+					Metadata: v1beta1.VolumeMetadata{
+						Name:  name,
+						Realm: realm,
+						Space: space,
+						Stack: stack,
+					},
+				}
+				result, getErr := client.GetVolume(cmd.Context(), lookup)
+				if getErr != nil {
+					if errors.Is(getErr, errdefs.ErrVolumeNotFound) {
+						return fmt.Errorf("volume %q not found", name)
+					}
+					return getErr
+				}
+				if !result.MetadataExists {
+					return fmt.Errorf("volume %q not found", name)
+				}
+				return printVolume(cmd, &result.Volume, outputFormat)
+			}
+
+			volumes, err := client.ListVolumes(cmd.Context(), realm, space, stack)
+			if err != nil {
+				return err
+			}
+			return printVolumes(cmd, volumes, outputFormat)
+		},
+	}
+
+	cmd.Flags().String("realm", "", "Filter volumes by realm name")
+	_ = viper.BindPFlag(config.KUKE_GET_VOLUME_REALM.ViperKey, cmd.Flags().Lookup("realm"))
+	cmd.Flags().String("space", "", "Filter volumes by space name")
+	_ = viper.BindPFlag(config.KUKE_GET_VOLUME_SPACE.ViperKey, cmd.Flags().Lookup("space"))
+	cmd.Flags().String("stack", "", "Filter volumes by stack name")
+	_ = viper.BindPFlag(config.KUKE_GET_VOLUME_STACK.ViperKey, cmd.Flags().Lookup("stack"))
+	cmd.Flags().
+		StringP("output", "o", "", "Output format (yaml, json, table, wide). Default: table for list, yaml for single resource")
+	_ = viper.BindPFlag(config.KUKE_GET_OUTPUT.ViperKey, cmd.Flags().Lookup("output"))
+	_ = viper.BindPFlag(config.KUKE_GET_OUTPUT.ViperKey, cmd.Flags().Lookup("o"))
+
+	cmd.ValidArgsFunction = config.CompleteVolumeNames
+	_ = cmd.RegisterFlagCompletionFunc("realm", config.CompleteRealmNames)
+	_ = cmd.RegisterFlagCompletionFunc("space", config.CompleteSpaceNames)
+	_ = cmd.RegisterFlagCompletionFunc("stack", config.CompleteStackNames)
+	_ = cmd.RegisterFlagCompletionFunc("output", config.CompleteOutputFormat)
+	_ = cmd.RegisterFlagCompletionFunc("o", config.CompleteOutputFormat)
+
+	return cmd
+}
+
+func resolveClient(cmd *cobra.Command) (kukeonv1.Client, error) {
+	if mockClient, ok := cmd.Context().Value(MockControllerKey{}).(kukeonv1.Client); ok {
+		return mockClient, nil
+	}
+	return kukeshared.ClientFromCmd(cmd)
+}
+
+func printVolume(cmd *cobra.Command, volume *v1beta1.VolumeDoc, format shared.OutputFormat) error {
+	switch format {
+	case shared.OutputFormatJSON:
+		return shared.PrintJSON(cmd, volume)
+	case shared.OutputFormatYAML, shared.OutputFormatTable, shared.OutputFormatWide:
+		return shared.PrintYAML(cmd, volume)
+	default:
+		return shared.PrintYAML(cmd, volume)
+	}
+}
+
+func printVolumes(cmd *cobra.Command, volumes []v1beta1.VolumeDoc, format shared.OutputFormat) error {
+	switch format {
+	case shared.OutputFormatYAML:
+		return shared.PrintYAML(cmd, volumes)
+	case shared.OutputFormatJSON:
+		return shared.PrintJSON(cmd, volumes)
+	case shared.OutputFormatTable, shared.OutputFormatWide:
+		if len(volumes) == 0 {
+			cmd.Println("No volumes found.")
+			return nil
+		}
+		headers := []string{"NAME", "REALM", "SPACE", "STACK"}
+		rows := make([][]string, 0, len(volumes))
+		for i := range volumes {
+			v := &volumes[i]
+			rows = append(rows, []string{
+				v.Metadata.Name,
+				dashIfEmpty(v.Metadata.Realm),
+				dashIfEmpty(v.Metadata.Space),
+				dashIfEmpty(v.Metadata.Stack),
+			})
+		}
+		shared.PrintTable(cmd, headers, rows)
+		return nil
+	default:
+		return shared.PrintYAML(cmd, volumes)
+	}
+}
+
+// dashIfEmpty renders an unset scope coordinate as "-" so the table column
+// never collapses to an unaligned blank cell.
+func dashIfEmpty(s string) string {
+	if strings.TrimSpace(s) == "" {
+		return "-"
+	}
+	return s
+}

--- a/cmd/kuke/get/volume/volume_test.go
+++ b/cmd/kuke/get/volume/volume_test.go
@@ -1,0 +1,202 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package volume_test
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"log/slog"
+	"strings"
+	"testing"
+
+	volume "github.com/eminwux/kukeon/cmd/kuke/get/volume"
+	"github.com/eminwux/kukeon/cmd/types"
+	"github.com/eminwux/kukeon/internal/errdefs"
+	"github.com/eminwux/kukeon/pkg/api/kukeonv1"
+	v1beta1 "github.com/eminwux/kukeon/pkg/api/model/v1beta1"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+)
+
+func TestNewVolumeCmd(t *testing.T) {
+	t.Cleanup(viper.Reset)
+
+	tests := []struct {
+		name       string
+		args       []string
+		setup      func(t *testing.T, cmd *cobra.Command)
+		fake       *fakeClient
+		wantErr    string
+		wantOutput string
+	}{
+		{
+			// Single-resource get renders YAML to os.Stdout (not the command
+			// buffer), so this case only asserts the happy path returns no error.
+			name: "get single volume metadata",
+			args: []string{"vol1"},
+			setup: func(_ *testing.T, cmd *cobra.Command) {
+				_ = cmd.Flags().Set("realm", "r1")
+				_ = cmd.Flags().Set("space", "s1")
+			},
+			fake: &fakeClient{
+				getVolumeFn: func(doc v1beta1.VolumeDoc) (kukeonv1.GetVolumeResult, error) {
+					return kukeonv1.GetVolumeResult{
+						Volume:         v1beta1.VolumeDoc{Metadata: doc.Metadata},
+						MetadataExists: true,
+					}, nil
+				},
+			},
+		},
+		{
+			name: "get not found surfaces friendly error",
+			args: []string{"missing"},
+			setup: func(_ *testing.T, cmd *cobra.Command) {
+				_ = cmd.Flags().Set("realm", "r1")
+			},
+			fake: &fakeClient{
+				getVolumeFn: func(_ v1beta1.VolumeDoc) (kukeonv1.GetVolumeResult, error) {
+					return kukeonv1.GetVolumeResult{}, errdefs.ErrVolumeNotFound
+				},
+			},
+			wantErr: `volume "missing" not found`,
+		},
+		{
+			name: "get not found via MetadataExists=false",
+			args: []string{"missing"},
+			setup: func(_ *testing.T, cmd *cobra.Command) {
+				_ = cmd.Flags().Set("realm", "r1")
+			},
+			fake: &fakeClient{
+				getVolumeFn: func(_ v1beta1.VolumeDoc) (kukeonv1.GetVolumeResult, error) {
+					return kukeonv1.GetVolumeResult{MetadataExists: false}, nil
+				},
+			},
+			wantErr: `volume "missing" not found`,
+		},
+		{
+			name: "list empty prints no resources found",
+			fake: &fakeClient{
+				listVolumesFn: func(_, _, _ string) ([]v1beta1.VolumeDoc, error) {
+					return nil, nil
+				},
+			},
+			wantOutput: "No volumes found.",
+		},
+		{
+			name: "list table renders scope columns",
+			fake: &fakeClient{
+				listVolumesFn: func(_, _, _ string) ([]v1beta1.VolumeDoc, error) {
+					return []v1beta1.VolumeDoc{
+						{Metadata: v1beta1.VolumeMetadata{Name: "realm-vol", Realm: "default"}},
+						{
+							Metadata: v1beta1.VolumeMetadata{
+								Name:  "stack-vol",
+								Realm: "default",
+								Space: "s",
+								Stack: "st",
+							},
+						},
+					}, nil
+				},
+			},
+			wantOutput: "realm-vol",
+		},
+		{
+			name: "list passes filter scope through",
+			setup: func(_ *testing.T, cmd *cobra.Command) {
+				_ = cmd.Flags().Set("realm", "default")
+				_ = cmd.Flags().Set("space", "team-a")
+			},
+			fake: &fakeClient{
+				listVolumesFn: func(realm, space, _ string) ([]v1beta1.VolumeDoc, error) {
+					if realm != "default" || space != "team-a" {
+						return nil, errors.New("unexpected filter scope")
+					}
+					return []v1beta1.VolumeDoc{
+						{Metadata: v1beta1.VolumeMetadata{Name: "space-vol", Realm: realm, Space: space}},
+					}, nil
+				},
+			},
+			wantOutput: "space-vol",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Cleanup(viper.Reset)
+
+			cmd := volume.NewVolumeCmd()
+			buf := &bytes.Buffer{}
+			cmd.SetOut(buf)
+			cmd.SetErr(buf)
+
+			logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+			ctx := context.WithValue(context.Background(), types.CtxLogger, logger)
+			ctx = context.WithValue(ctx, volume.MockControllerKey{}, kukeonv1.Client(tt.fake))
+			cmd.SetContext(ctx)
+
+			if tt.setup != nil {
+				tt.setup(t, cmd)
+			}
+
+			cmd.SetArgs(tt.args)
+			err := cmd.Execute()
+
+			if tt.wantErr != "" {
+				if err == nil {
+					t.Fatalf("expected error containing %q, got nil", tt.wantErr)
+				}
+				if !strings.Contains(err.Error(), tt.wantErr) {
+					t.Fatalf("expected error containing %q, got %v", tt.wantErr, err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if tt.wantOutput != "" && !strings.Contains(buf.String(), tt.wantOutput) {
+				t.Errorf("output missing %q\nGot:\n%s", tt.wantOutput, buf.String())
+			}
+		})
+	}
+}
+
+type fakeClient struct {
+	kukeonv1.FakeClient
+
+	getVolumeFn   func(doc v1beta1.VolumeDoc) (kukeonv1.GetVolumeResult, error)
+	listVolumesFn func(realm, space, stack string) ([]v1beta1.VolumeDoc, error)
+}
+
+func (f *fakeClient) GetVolume(_ context.Context, doc v1beta1.VolumeDoc) (kukeonv1.GetVolumeResult, error) {
+	if f.getVolumeFn == nil {
+		return kukeonv1.GetVolumeResult{}, errors.New("unexpected GetVolume call")
+	}
+	return f.getVolumeFn(doc)
+}
+
+func (f *fakeClient) ListVolumes(
+	_ context.Context,
+	realm, space, stack string,
+) ([]v1beta1.VolumeDoc, error) {
+	if f.listVolumesFn == nil {
+		return nil, errors.New("unexpected ListVolumes call")
+	}
+	return f.listVolumesFn(realm, space, stack)
+}

--- a/internal/client/local/local.go
+++ b/internal/client/local/local.go
@@ -337,6 +337,21 @@ func (c *Client) GetSecret(_ context.Context, doc v1beta1.SecretDoc) (kukeonv1.G
 	}, nil
 }
 
+func (c *Client) GetVolume(_ context.Context, doc v1beta1.VolumeDoc) (kukeonv1.GetVolumeResult, error) {
+	internal, _, err := apischeme.NormalizeVolume(doc)
+	if err != nil {
+		return kukeonv1.GetVolumeResult{}, fmt.Errorf("%w: %w", errdefs.ErrConversionFailed, err)
+	}
+	res, err := c.ctrl.GetVolume(internal)
+	if err != nil {
+		return kukeonv1.GetVolumeResult{}, err
+	}
+	return kukeonv1.GetVolumeResult{
+		Volume:         apischeme.ConvertVolumeToExternal(res.Volume),
+		MetadataExists: res.MetadataExists,
+	}, nil
+}
+
 func (c *Client) GetBlueprint(
 	_ context.Context, doc v1beta1.CellBlueprintDoc,
 ) (kukeonv1.GetBlueprintResult, error) {
@@ -396,6 +411,23 @@ func (c *Client) CreateSecret(
 	ext := apischeme.ConvertSecretToExternal(res.Secret)
 	return kukeonv1.CreateSecretResult{
 		Secret:  ext,
+		Created: res.Created,
+	}, nil
+}
+
+func (c *Client) CreateVolume(
+	_ context.Context, doc v1beta1.VolumeDoc,
+) (kukeonv1.CreateVolumeResult, error) {
+	internal, _, err := apischeme.NormalizeVolume(doc)
+	if err != nil {
+		return kukeonv1.CreateVolumeResult{}, fmt.Errorf("%w: %w", errdefs.ErrConversionFailed, err)
+	}
+	res, err := c.ctrl.CreateVolume(internal)
+	if err != nil {
+		return kukeonv1.CreateVolumeResult{}, err
+	}
+	return kukeonv1.CreateVolumeResult{
+		Volume:  apischeme.ConvertVolumeToExternal(res.Volume),
 		Created: res.Created,
 	}, nil
 }
@@ -498,6 +530,17 @@ func (c *Client) ListSecrets(
 		return nil, err
 	}
 	return apischeme.ConvertSecretListToExternal(secrets), nil
+}
+
+func (c *Client) ListVolumes(
+	_ context.Context,
+	realmName, spaceName, stackName string,
+) ([]v1beta1.VolumeDoc, error) {
+	volumes, err := c.ctrl.ListVolumes(realmName, spaceName, stackName)
+	if err != nil {
+		return nil, err
+	}
+	return apischeme.ConvertVolumeListToExternal(volumes), nil
 }
 
 func (c *Client) ListBlueprints(
@@ -702,6 +745,21 @@ func (c *Client) DeleteSecret(_ context.Context, doc v1beta1.SecretDoc) (kukeonv
 	}
 	return kukeonv1.DeleteSecretResult{
 		Secret:  apischeme.ConvertSecretToExternal(res.Secret),
+		Deleted: res.Deleted,
+	}, nil
+}
+
+func (c *Client) DeleteVolume(_ context.Context, doc v1beta1.VolumeDoc) (kukeonv1.DeleteVolumeResult, error) {
+	internal, _, err := apischeme.NormalizeVolume(doc)
+	if err != nil {
+		return kukeonv1.DeleteVolumeResult{}, fmt.Errorf("%w: %w", errdefs.ErrConversionFailed, err)
+	}
+	res, err := c.ctrl.DeleteVolume(internal)
+	if err != nil {
+		return kukeonv1.DeleteVolumeResult{}, err
+	}
+	return kukeonv1.DeleteVolumeResult{
+		Volume:  apischeme.ConvertVolumeToExternal(res.Volume),
 		Deleted: res.Deleted,
 	}, nil
 }

--- a/internal/controller/volume.go
+++ b/internal/controller/volume.go
@@ -21,9 +21,38 @@ import (
 	"fmt"
 	"strings"
 
+	applypkg "github.com/eminwux/kukeon/internal/controller/apply"
 	"github.com/eminwux/kukeon/internal/errdefs"
 	intmodel "github.com/eminwux/kukeon/internal/modelhub"
 )
+
+// CreateVolumeResult reports the outcome of provisioning a Volume's directory.
+type CreateVolumeResult struct {
+	Volume  intmodel.Volume
+	Created bool
+}
+
+// CreateVolume provisions a Volume's daemon-managed directory via the apply
+// reconciler (issue #1236). It mirrors CreateSecret: the scope coordinates are
+// validated first, then ReconcileVolume verifies the scope exists and writes
+// the directory idempotently (re-creating reports created=false). A Volume is
+// never cell-scoped — VolumeMetadata has no cell coordinate — so the AC's "cell
+// scope rejected" holds by construction (there is no --cell flag to set).
+func (b *Exec) CreateVolume(volume intmodel.Volume) (CreateVolumeResult, error) {
+	var res CreateVolumeResult
+
+	if err := validateVolumeLookup(volume.Metadata); err != nil {
+		return res, err
+	}
+
+	reconcile, err := applypkg.ReconcileVolume(b.runner, volume)
+	if err != nil {
+		return res, err
+	}
+	res.Created = reconcile.Action == "created"
+	res.Volume = volume
+	return res, nil
+}
 
 // GetVolumeResult reports the metadata-only view of a single `kind: Volume`
 // (issue #1018). A Volume carries no body, so this is scope coordinates and

--- a/internal/controller/volume_test.go
+++ b/internal/controller/volume_test.go
@@ -149,6 +149,64 @@ func TestListVolumes_PassesThrough(t *testing.T) {
 	}
 }
 
+// TestCreateVolume_Provisions confirms the imperative create path routes
+// through ReconcileVolume → WriteVolume and reports created=true.
+func TestCreateVolume_Provisions(t *testing.T) {
+	var wrote []intmodel.Volume
+	mock := &fakeRunner{
+		GetRealmFn: func(r intmodel.Realm) (intmodel.Realm, error) { return r, nil },
+		GetSpaceFn: func(s intmodel.Space) (intmodel.Space, error) { return s, nil },
+		WriteVolumeFn: func(v intmodel.Volume) (bool, error) {
+			wrote = append(wrote, v)
+			return true, nil
+		},
+	}
+	ctrl := setupTestController(t, mock)
+
+	res, err := ctrl.CreateVolume(intmodel.Volume{
+		Metadata: intmodel.VolumeMetadata{Name: "data", Realm: "default", Space: "agents"},
+	})
+	if err != nil {
+		t.Fatalf("CreateVolume() error = %v", err)
+	}
+	if !res.Created {
+		t.Errorf("Created = false, want true")
+	}
+	if len(wrote) != 1 || wrote[0].Metadata.Name != "data" {
+		t.Errorf("WriteVolume calls = %+v, want one volume named data", wrote)
+	}
+}
+
+// TestCreateVolume_ReReportsUpdated confirms re-creating an existing volume
+// reports created=false (WriteVolume is idempotent).
+func TestCreateVolume_ReReportsUpdated(t *testing.T) {
+	mock := &fakeRunner{
+		GetRealmFn:    func(r intmodel.Realm) (intmodel.Realm, error) { return r, nil },
+		WriteVolumeFn: func(intmodel.Volume) (bool, error) { return false, nil },
+	}
+	ctrl := setupTestController(t, mock)
+
+	res, err := ctrl.CreateVolume(intmodel.Volume{
+		Metadata: intmodel.VolumeMetadata{Name: "data", Realm: "default"},
+	})
+	if err != nil {
+		t.Fatalf("CreateVolume() error = %v", err)
+	}
+	if res.Created {
+		t.Errorf("Created = true, want false for re-create")
+	}
+}
+
+// TestCreateVolume_NameRequired confirms the lookup scope guard fires before
+// the runner is touched.
+func TestCreateVolume_NameRequired(t *testing.T) {
+	ctrl := setupTestController(t, &fakeRunner{})
+	_, err := ctrl.CreateVolume(intmodel.Volume{Metadata: intmodel.VolumeMetadata{Realm: "default"}})
+	if !errors.Is(err, errdefs.ErrVolumeNameRequired) {
+		t.Errorf("CreateVolume(no name) = %v, want ErrVolumeNameRequired", err)
+	}
+}
+
 // TestApplyDocuments_VolumeRoutesToReconcile pins the AC end-to-end: a parsed
 // `kind: Volume` document routes through ApplyDocuments → ReconcileVolume →
 // WriteVolume and surfaces a "created" resource result.

--- a/internal/daemon/rpcservice.go
+++ b/internal/daemon/rpcservice.go
@@ -167,6 +167,13 @@ func (s *KukeonV1Service) GetBlueprint(args *kukeonv1.GetBlueprintArgs, reply *k
 	return nil
 }
 
+func (s *KukeonV1Service) GetVolume(args *kukeonv1.GetVolumeArgs, reply *kukeonv1.GetVolumeReply) error {
+	result, err := s.core.GetVolume(s.ctx, args.Doc)
+	reply.Result = result
+	reply.Err = kukeonv1.ToAPIError(err)
+	return nil
+}
+
 func (s *KukeonV1Service) GetConfig(args *kukeonv1.GetConfigArgs, reply *kukeonv1.GetConfigReply) error {
 	result, err := s.core.GetConfig(s.ctx, args.Doc)
 	reply.Result = result
@@ -187,6 +194,16 @@ func (s *KukeonV1Service) CreateSecret(args *kukeonv1.CreateSecretArgs, reply *k
 	reply.Err = kukeonv1.ToAPIError(err)
 	if err != nil {
 		s.logger.DebugContext(s.ctx, "CreateSecret returned error", "error", err)
+	}
+	return nil
+}
+
+func (s *KukeonV1Service) CreateVolume(args *kukeonv1.CreateVolumeArgs, reply *kukeonv1.CreateVolumeReply) error {
+	result, err := s.core.CreateVolume(s.ctx, args.Doc)
+	reply.Result = result
+	reply.Err = kukeonv1.ToAPIError(err)
+	if err != nil {
+		s.logger.DebugContext(s.ctx, "CreateVolume returned error", "error", err)
 	}
 	return nil
 }
@@ -240,6 +257,15 @@ func (s *KukeonV1Service) ListBlueprints(
 ) error {
 	blueprints, err := s.core.ListBlueprints(s.ctx, args.RealmName, args.SpaceName, args.StackName)
 	reply.Blueprints = blueprints
+	reply.Err = kukeonv1.ToAPIError(err)
+	return nil
+}
+
+func (s *KukeonV1Service) ListVolumes(
+	args *kukeonv1.ListVolumesArgs, reply *kukeonv1.ListVolumesReply,
+) error {
+	volumes, err := s.core.ListVolumes(s.ctx, args.RealmName, args.SpaceName, args.StackName)
+	reply.Volumes = volumes
 	reply.Err = kukeonv1.ToAPIError(err)
 	return nil
 }
@@ -348,6 +374,15 @@ func (s *KukeonV1Service) DeleteBlueprint(
 	args *kukeonv1.DeleteBlueprintArgs, reply *kukeonv1.DeleteBlueprintReply,
 ) error {
 	result, err := s.core.DeleteBlueprint(s.ctx, args.Doc)
+	reply.Result = result
+	reply.Err = kukeonv1.ToAPIError(err)
+	return nil
+}
+
+func (s *KukeonV1Service) DeleteVolume(
+	args *kukeonv1.DeleteVolumeArgs, reply *kukeonv1.DeleteVolumeReply,
+) error {
+	result, err := s.core.DeleteVolume(s.ctx, args.Doc)
 	reply.Result = result
 	reply.Err = kukeonv1.ToAPIError(err)
 	return nil

--- a/pkg/api/kukeonv1/client.go
+++ b/pkg/api/kukeonv1/client.go
@@ -60,6 +60,12 @@ type Client interface {
 	// write-through). The resulting SecretDoc is metadata-only (Spec.Data
 	// is never echoed back).
 	CreateSecret(ctx context.Context, doc v1beta1.SecretDoc) (CreateSecretResult, error)
+	// CreateVolume provisions a new Volume's daemon-managed directory (issue
+	// #1236). The write is idempotent (the daemon's runner.WriteVolume re-
+	// asserts the directory mode/owner), and the resulting VolumeDoc is
+	// metadata-only. A Volume is never cell-scoped, so the doc carries
+	// realm/space/stack coordinates only — cell scope is unrepresentable.
+	CreateVolume(ctx context.Context, doc v1beta1.VolumeDoc) (CreateVolumeResult, error)
 
 	GetRealm(ctx context.Context, doc v1beta1.RealmDoc) (GetRealmResult, error)
 	GetSpace(ctx context.Context, doc v1beta1.SpaceDoc) (GetSpaceResult, error)
@@ -76,6 +82,10 @@ type Client interface {
 	// so `kuke run -b` can materialize it. The input doc carries the name and
 	// scope coordinates only; the spec is ignored.
 	GetBlueprint(ctx context.Context, doc v1beta1.CellBlueprintDoc) (GetBlueprintResult, error)
+	// GetVolume reports the metadata-only view of a single named, scoped
+	// `kind: Volume` (issue #1236). A Volume carries no body, so only its
+	// scope coordinates and name are returned.
+	GetVolume(ctx context.Context, doc v1beta1.VolumeDoc) (GetVolumeResult, error)
 	// GetConfig reads one named, scoped `kind: CellConfig`'s full document
 	// from daemon storage (issue #644). Like GetBlueprint the whole document
 	// is returned — a Config carries no credential bytes — so the blueprint
@@ -100,6 +110,11 @@ type Client interface {
 	// realmName lists across all realms. A Blueprint is never cell-scoped, so
 	// there is no cell coordinate. The spec is not populated for a list.
 	ListBlueprints(ctx context.Context, realmName, spaceName, stackName string) ([]v1beta1.CellBlueprintDoc, error)
+	// ListVolumes enumerates the metadata of every Volume bound to the filter
+	// scope or any scope nested within it (issue #1236). An empty realmName
+	// lists across all realms. A Volume is never cell-scoped, so there is no
+	// cell coordinate.
+	ListVolumes(ctx context.Context, realmName, spaceName, stackName string) ([]v1beta1.VolumeDoc, error)
 	// ListConfigs enumerates the metadata of every CellConfig bound to the
 	// filter scope or any scope nested within it (issue #644). An empty
 	// realmName lists across all realms. A Config is never cell-scoped, so
@@ -131,6 +146,11 @@ type Client interface {
 	// daemon-stored document (issue #643). No live-reference gate: cells
 	// materialized from a blueprint are independent copies (#620).
 	DeleteBlueprint(ctx context.Context, doc v1beta1.CellBlueprintDoc) (DeleteBlueprintResult, error)
+	// DeleteVolume removes a single named, scoped Volume's daemon-provisioned
+	// directory (issue #1236). No live-mount gate yet: the container-side mount
+	// kind that would reference a Volume lands in step 4 (#1016), where the
+	// delete gate against a live mount is exercised.
+	DeleteVolume(ctx context.Context, doc v1beta1.VolumeDoc) (DeleteVolumeResult, error)
 	// DeleteConfig removes a single named, scoped CellConfig's daemon-stored
 	// document (issue #644). No live-reference gate: deleting a Config never
 	// deletes the cell it materialized. The result reports any live cells that
@@ -248,6 +268,7 @@ const (
 	MethodMaterializeCell = ServiceName + ".MaterializeCell"
 	MethodCreateConfig    = ServiceName + ".CreateConfig"
 	MethodCreateSecret    = ServiceName + ".CreateSecret"
+	MethodCreateVolume    = ServiceName + ".CreateVolume"
 
 	MethodGetRealm     = ServiceName + ".GetRealm"
 	MethodGetSpace     = ServiceName + ".GetSpace"
@@ -257,6 +278,7 @@ const (
 	MethodGetSecret    = ServiceName + ".GetSecret"
 	MethodGetBlueprint = ServiceName + ".GetBlueprint"
 	MethodGetConfig    = ServiceName + ".GetConfig"
+	MethodGetVolume    = ServiceName + ".GetVolume"
 
 	MethodListRealms     = ServiceName + ".ListRealms"
 	MethodListSpaces     = ServiceName + ".ListSpaces"
@@ -266,6 +288,7 @@ const (
 	MethodListSecrets    = ServiceName + ".ListSecrets"
 	MethodListBlueprints = ServiceName + ".ListBlueprints"
 	MethodListConfigs    = ServiceName + ".ListConfigs"
+	MethodListVolumes    = ServiceName + ".ListVolumes"
 
 	MethodStartCell       = ServiceName + ".StartCell"
 	MethodAttachContainer = ServiceName + ".AttachContainer"
@@ -280,11 +303,12 @@ const (
 	MethodDeleteSecret    = ServiceName + ".DeleteSecret"
 	MethodDeleteBlueprint = ServiceName + ".DeleteBlueprint"
 	MethodDeleteConfig    = ServiceName + ".DeleteConfig"
+	MethodDeleteVolume    = ServiceName + ".DeleteVolume"
 
-	MethodPurgeRealm     = ServiceName + ".PurgeRealm"
-	MethodPurgeSpace     = ServiceName + ".PurgeSpace"
-	MethodPurgeStack     = ServiceName + ".PurgeStack"
-	MethodPurgeCell      = ServiceName + ".PurgeCell"
+	MethodPurgeRealm = ServiceName + ".PurgeRealm"
+	MethodPurgeSpace = ServiceName + ".PurgeSpace"
+	MethodPurgeStack = ServiceName + ".PurgeStack"
+	MethodPurgeCell  = ServiceName + ".PurgeCell"
 
 	MethodRefreshAll      = ServiceName + ".RefreshAll"
 	MethodApplyDocuments  = ServiceName + ".ApplyDocuments"

--- a/pkg/api/kukeonv1/fake.go
+++ b/pkg/api/kukeonv1/fake.go
@@ -65,6 +65,10 @@ func (FakeClient) CreateSecret(context.Context, v1beta1.SecretDoc) (CreateSecret
 	return CreateSecretResult{}, ErrUnexpectedCall
 }
 
+func (FakeClient) CreateVolume(context.Context, v1beta1.VolumeDoc) (CreateVolumeResult, error) {
+	return CreateVolumeResult{}, ErrUnexpectedCall
+}
+
 func (FakeClient) GetRealm(context.Context, v1beta1.RealmDoc) (GetRealmResult, error) {
 	return GetRealmResult{}, ErrUnexpectedCall
 }
@@ -91,6 +95,10 @@ func (FakeClient) GetSecret(context.Context, v1beta1.SecretDoc) (GetSecretResult
 
 func (FakeClient) GetBlueprint(context.Context, v1beta1.CellBlueprintDoc) (GetBlueprintResult, error) {
 	return GetBlueprintResult{}, ErrUnexpectedCall
+}
+
+func (FakeClient) GetVolume(context.Context, v1beta1.VolumeDoc) (GetVolumeResult, error) {
+	return GetVolumeResult{}, ErrUnexpectedCall
 }
 
 func (FakeClient) GetConfig(context.Context, v1beta1.CellConfigDoc) (GetConfigResult, error) {
@@ -122,6 +130,10 @@ func (FakeClient) ListSecrets(context.Context, string, string, string, string) (
 }
 
 func (FakeClient) ListBlueprints(context.Context, string, string, string) ([]v1beta1.CellBlueprintDoc, error) {
+	return nil, ErrUnexpectedCall
+}
+
+func (FakeClient) ListVolumes(context.Context, string, string, string) ([]v1beta1.VolumeDoc, error) {
 	return nil, ErrUnexpectedCall
 }
 
@@ -171,6 +183,10 @@ func (FakeClient) DeleteSecret(context.Context, v1beta1.SecretDoc) (DeleteSecret
 
 func (FakeClient) DeleteBlueprint(context.Context, v1beta1.CellBlueprintDoc) (DeleteBlueprintResult, error) {
 	return DeleteBlueprintResult{}, ErrUnexpectedCall
+}
+
+func (FakeClient) DeleteVolume(context.Context, v1beta1.VolumeDoc) (DeleteVolumeResult, error) {
+	return DeleteVolumeResult{}, ErrUnexpectedCall
 }
 
 func (FakeClient) DeleteConfig(context.Context, v1beta1.CellConfigDoc) (DeleteConfigResult, error) {

--- a/pkg/api/kukeonv1/rpcclient.go
+++ b/pkg/api/kukeonv1/rpcclient.go
@@ -276,6 +276,19 @@ func (c *UnixClient) GetSecret(ctx context.Context, doc v1beta1.SecretDoc) (GetS
 	return reply.Result, nil
 }
 
+// GetVolume implements Client (#1236).
+func (c *UnixClient) GetVolume(ctx context.Context, doc v1beta1.VolumeDoc) (GetVolumeResult, error) {
+	args := &GetVolumeArgs{Doc: doc}
+	reply := &GetVolumeReply{}
+	if err := c.call(ctx, MethodGetVolume, args, reply); err != nil {
+		return GetVolumeResult{}, err
+	}
+	if reply.Err != nil {
+		return reply.Result, FromAPIError(reply.Err)
+	}
+	return reply.Result, nil
+}
+
 // GetBlueprint implements Client.
 func (c *UnixClient) GetBlueprint(
 	ctx context.Context, doc v1beta1.CellBlueprintDoc,
@@ -329,6 +342,21 @@ func (c *UnixClient) CreateSecret(
 	reply := &CreateSecretReply{}
 	if err := c.call(ctx, MethodCreateSecret, args, reply); err != nil {
 		return CreateSecretResult{}, err
+	}
+	if reply.Err != nil {
+		return reply.Result, FromAPIError(reply.Err)
+	}
+	return reply.Result, nil
+}
+
+// CreateVolume implements Client (#1236).
+func (c *UnixClient) CreateVolume(
+	ctx context.Context, doc v1beta1.VolumeDoc,
+) (CreateVolumeResult, error) {
+	args := &CreateVolumeArgs{Doc: doc}
+	reply := &CreateVolumeReply{}
+	if err := c.call(ctx, MethodCreateVolume, args, reply); err != nil {
+		return CreateVolumeResult{}, err
 	}
 	if reply.Err != nil {
 		return reply.Result, FromAPIError(reply.Err)
@@ -418,6 +446,22 @@ func (c *UnixClient) ListSecrets(
 		return reply.Secrets, FromAPIError(reply.Err)
 	}
 	return reply.Secrets, nil
+}
+
+// ListVolumes implements Client (#1236).
+func (c *UnixClient) ListVolumes(
+	ctx context.Context,
+	realmName, spaceName, stackName string,
+) ([]v1beta1.VolumeDoc, error) {
+	args := &ListVolumesArgs{RealmName: realmName, SpaceName: spaceName, StackName: stackName}
+	reply := &ListVolumesReply{}
+	if err := c.call(ctx, MethodListVolumes, args, reply); err != nil {
+		return nil, err
+	}
+	if reply.Err != nil {
+		return reply.Volumes, FromAPIError(reply.Err)
+	}
+	return reply.Volumes, nil
 }
 
 // ListBlueprints implements Client.
@@ -593,6 +637,19 @@ func (c *UnixClient) DeleteSecret(ctx context.Context, doc v1beta1.SecretDoc) (D
 	reply := &DeleteSecretReply{}
 	if err := c.call(ctx, MethodDeleteSecret, args, reply); err != nil {
 		return DeleteSecretResult{}, err
+	}
+	if reply.Err != nil {
+		return reply.Result, FromAPIError(reply.Err)
+	}
+	return reply.Result, nil
+}
+
+// DeleteVolume implements Client (#1236).
+func (c *UnixClient) DeleteVolume(ctx context.Context, doc v1beta1.VolumeDoc) (DeleteVolumeResult, error) {
+	args := &DeleteVolumeArgs{Doc: doc}
+	reply := &DeleteVolumeReply{}
+	if err := c.call(ctx, MethodDeleteVolume, args, reply); err != nil {
+		return DeleteVolumeResult{}, err
 	}
 	if reply.Err != nil {
 		return reply.Result, FromAPIError(reply.Err)

--- a/pkg/api/kukeonv1/types.go
+++ b/pkg/api/kukeonv1/types.go
@@ -501,6 +501,68 @@ type CreateSecretResult struct {
 	Created bool
 }
 
+// CreateVolumeArgs is the wire request for CreateVolume (issue #1236).
+type CreateVolumeArgs struct {
+	Doc v1beta1.VolumeDoc
+}
+
+// CreateVolumeReply is the wire response for CreateVolume.
+type CreateVolumeReply struct {
+	Result CreateVolumeResult
+	Err    *APIError
+}
+
+// CreateVolumeResult reports the outcome of provisioning a Volume's directory.
+type CreateVolumeResult struct {
+	Volume  v1beta1.VolumeDoc
+	Created bool
+}
+
+type GetVolumeArgs struct {
+	Doc v1beta1.VolumeDoc
+}
+
+type GetVolumeReply struct {
+	Result GetVolumeResult
+	Err    *APIError
+}
+
+// GetVolumeResult carries the metadata-only view of a Volume (issue #1236). A
+// Volume has no body, so this is its scope coordinates and name only.
+type GetVolumeResult struct {
+	Volume         v1beta1.VolumeDoc
+	MetadataExists bool
+}
+
+type ListVolumesArgs struct {
+	RealmName string
+	SpaceName string
+	StackName string
+}
+
+// ListVolumesReply carries metadata-only VolumeDocs — a Volume is never
+// cell-scoped, so the filter bottoms out at stack (issue #1236).
+type ListVolumesReply struct {
+	Volumes []v1beta1.VolumeDoc
+	Err     *APIError
+}
+
+type DeleteVolumeArgs struct {
+	Doc v1beta1.VolumeDoc
+}
+
+type DeleteVolumeReply struct {
+	Result DeleteVolumeResult
+	Err    *APIError
+}
+
+// DeleteVolumeResult reports the removed Volume (metadata only) and whether the
+// directory existed to delete.
+type DeleteVolumeResult struct {
+	Volume  v1beta1.VolumeDoc
+	Deleted bool
+}
+
 type DeleteBlueprintArgs struct {
 	Doc v1beta1.CellBlueprintDoc
 }


### PR DESCRIPTION
## Summary

Step 2 of the volumes epic (#1015): wires imperative `kuke create/get/delete volume` verbs over the standalone `Volume` resource that step 1 (#1238, closing #1018) shipped.

- `kuke create volume <name> --realm … [--space …] [--stack …]` — provisions the Volume's daemon-managed directory at the named scope.
- `kuke get volume(s)` — `-o wide`/`-o yaml`/`-o json`/table, scope-filtered subtree list; an empty list prints `No volumes found.` (the standard "no resources found", not an error).
- `kuke delete volume <name>` — removes an unmounted volume's directory.

### Scope note: the issue's "mirror the blueprint trio (~6 files)" premise undercounted

The issue framed this as mirroring the `create/get/delete blueprint` trio (~6 files). Two facts about the post-step-1 codebase reshaped the actual diff; flagging per the dev playbook so the reviewer can push back:

1. **`kuke create blueprint` is a YAML *scaffold* (no daemon call)** because a CellBlueprint is declaratively complex. A `Volume`'s spec is empty and the resource *is* the on-host directory, and the AC explicitly says create "creates the Volume at the named scope." So `create volume` is modelled on the imperative **`kuke create secret`** (persists to the daemon), not blueprint-create's scaffold. `get`/`delete volume` do mirror the blueprint trio (realm/space/stack scope, no `--cell`).
2. **Step 1 shipped the controller read methods (`GetVolume`/`ListVolumes`/`DeleteVolume`) and runner storage, but no client-facing surface.** The `kukeonv1.Client` interface, its wire types, the JSON-RPC client, the in-process client, the daemon RPC handlers, and a `CreateVolume` controller method did not exist for volumes. Adding the verbs therefore required the full client+RPC plumbing across every layer (the established pattern for every other resource), not just the 3 cmd files + 3 tests. New `CreateVolume` controller method routes through the existing `applypkg.ReconcileVolume` → `runner.WriteVolume`, exactly as `CreateSecret` routes through `ReconcileSecret`.

**"cell scope rejected" (AC) holds by construction:** `VolumeMetadata` has no cell coordinate, so there is no `--cell` flag to set on any of the three verbs (asserted by tests).

### Layers touched
- `internal/controller/volume.go`: new `CreateVolume` + `CreateVolumeResult`.
- `pkg/api/kukeonv1`: interface methods, wire `Args`/`Reply`/`Result` types, `Method*` constants, `UnixClient` RPC methods, `FakeClient` stubs.
- `internal/client/local/local.go`: in-process client methods.
- `internal/daemon/rpcservice.go`: daemon RPC handlers.
- `cmd/config/{env.go,autocomplete.go}`: `KUKE_{CREATE,GET,DELETE}_VOLUME_*` config keys + `CompleteVolumeNames`.
- `cmd/kuke/{create,get,delete}/volume/`: the three verbs + tests; wired into the parent commands.

## Test plan
- [x] `make test` (full CI suite: `test-root` + `test-kukebuild`) — green.
- [x] `GOWORK=off go build ./...` — clean.
- [x] CLI tests for all three verbs (`cmd/kuke/{create,get,delete}/volume/*_test.go`): happy path, scope threading, not-found, empty-list `No volumes found.`, and no-`--cell`-flag assertions.
- [x] Controller `CreateVolume` unit tests (`internal/controller/volume_test.go`): provisions, idempotent re-create, name-required guard.
- [x] `pre-commit run` on all changed files — Passed (gofmt, go-mod-tidy, golangci-lint, addlicense). `CompleteVolumeNames` carries a `//nolint:dupl` matching the intentional per-kind-completer convention.
- [ ] `make dev-init` smoke — not run. The change is additive CLI/RPC plumbing; it does not touch `kuke init`, realm provisioning, the `/opt/kukeon` layout, or the `get realms` daemon-parity surface the smoke guards, and dev-init does not exercise volume verbs. CI's `make e2e` job exercises daemon bringup with the new RPC handlers registered.

Closes #1236