### PR TITLE
feat: add Volume reclaimPolicy Retain with selective cascade reclaim (step 3)

### DIFF
--- a/internal/apischeme/volume.go
+++ b/internal/apischeme/volume.go
@@ -24,9 +24,9 @@ import (
 )
 
 // ConvertVolumeDocToInternal converts an external VolumeDoc to the internal hub
-// carrier (issue #1018). Unlike a CellBlueprint there is no body to serialize —
-// a Volume's spec is empty and the resource is the on-host directory — so this
-// is a flat copy of the scope coordinates onto the metadata.
+// carrier (issue #1018). The resource is the on-host directory, so this is a
+// flat copy of the scope coordinates onto the metadata, plus the reclaim policy
+// from the spec (step 3, #1237) — the one declarative field a Volume carries.
 func ConvertVolumeDocToInternal(in ext.VolumeDoc) (intmodel.Volume, error) {
 	switch in.APIVersion {
 	case VersionV1Beta1, "": // default/empty treated as v1beta1
@@ -36,6 +36,9 @@ func ConvertVolumeDocToInternal(in ext.VolumeDoc) (intmodel.Volume, error) {
 				Realm: in.Metadata.Realm,
 				Space: in.Metadata.Space,
 				Stack: in.Metadata.Stack,
+			},
+			Spec: intmodel.VolumeSpec{
+				ReclaimPolicy: intmodel.ReclaimPolicy(in.Spec.ReclaimPolicy),
 			},
 		}, nil
 	default:
@@ -54,9 +57,12 @@ func NormalizeVolume(req ext.VolumeDoc) (intmodel.Volume, ext.Version, error) {
 	return internal, version, nil
 }
 
-// ConvertVolumeToExternal builds a metadata-only external VolumeDoc from the
-// internal carrier (issue #1018). A Volume has no body, so the external doc is
-// its canonical apiVersion/kind plus the scope coordinates and name.
+// ConvertVolumeToExternal builds an external VolumeDoc from the internal
+// carrier (issue #1018). A Volume has no body, so the external doc is its
+// canonical apiVersion/kind plus the scope coordinates and name, plus the
+// reclaim policy the runner reads back from the volume's on-disk manifest
+// (step 3, #1237) so `kuke get volume -o yaml` surfaces a retained volume's
+// policy.
 func ConvertVolumeToExternal(in intmodel.Volume) ext.VolumeDoc {
 	return ext.VolumeDoc{
 		APIVersion: ext.APIVersionV1Beta1,
@@ -66,6 +72,9 @@ func ConvertVolumeToExternal(in intmodel.Volume) ext.VolumeDoc {
 			Realm: in.Metadata.Realm,
 			Space: in.Metadata.Space,
 			Stack: in.Metadata.Stack,
+		},
+		Spec: ext.VolumeSpec{
+			ReclaimPolicy: ext.ReclaimPolicy(in.Spec.ReclaimPolicy),
 		},
 	}
 }

--- a/internal/apischeme/volume_test.go
+++ b/internal/apischeme/volume_test.go
@@ -1,0 +1,49 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package apischeme_test
+
+import (
+	"testing"
+
+	"github.com/eminwux/kukeon/internal/apischeme"
+	ext "github.com/eminwux/kukeon/pkg/api/model/v1beta1"
+)
+
+// TestVolumeReclaimPolicyRoundTrip confirms reclaimPolicy survives the external
+// → internal → external conversion in both directions (#1237). The empty
+// (omitted) policy stays empty so existing specs are unaffected.
+func TestVolumeReclaimPolicyRoundTrip(t *testing.T) {
+	for _, policy := range []ext.ReclaimPolicy{"", ext.ReclaimRetain, ext.ReclaimDelete} {
+		in := ext.VolumeDoc{
+			APIVersion: ext.APIVersionV1Beta1,
+			Kind:       ext.KindVolume,
+			Metadata:   ext.VolumeMetadata{Name: "data", Realm: "r1"},
+			Spec:       ext.VolumeSpec{ReclaimPolicy: policy},
+		}
+		internal, err := apischeme.ConvertVolumeDocToInternal(in)
+		if err != nil {
+			t.Fatalf("ConvertVolumeDocToInternal(%q) error = %v", policy, err)
+		}
+		if got := internal.Spec.ReclaimPolicy; string(got) != string(policy) {
+			t.Errorf("internal reclaimPolicy = %q, want %q", got, policy)
+		}
+		out := apischeme.ConvertVolumeToExternal(internal)
+		if got := out.Spec.ReclaimPolicy; got != policy {
+			t.Errorf("round-tripped reclaimPolicy = %q, want %q", got, policy)
+		}
+	}
+}

--- a/internal/apply/parser/parser.go
+++ b/internal/apply/parser/parser.go
@@ -579,7 +579,23 @@ func validateVolume(doc *Document) *ValidationError {
 	if scopeErr := validateVolumeScope(vol.Metadata); scopeErr != nil {
 		return &ValidationError{Index: doc.Index, Kind: doc.Kind, Name: vol.Metadata.Name, Err: scopeErr}
 	}
+	if policyErr := validateReclaimPolicy(vol.Spec.ReclaimPolicy); policyErr != nil {
+		return &ValidationError{Index: doc.Index, Kind: doc.Kind, Name: vol.Metadata.Name, Err: policyErr}
+	}
 	return nil
+}
+
+// validateReclaimPolicy accepts an empty value (omitted ⇒ Delete) or one of the
+// two named policies; anything else is rejected so a typo'd reclaimPolicy
+// surfaces at apply time rather than silently degrading to delete-with-scope
+// (step 3, #1237).
+func validateReclaimPolicy(p v1beta1.ReclaimPolicy) error {
+	switch p {
+	case "", v1beta1.ReclaimRetain, v1beta1.ReclaimDelete:
+		return nil
+	default:
+		return fmt.Errorf("%w (got %q)", errdefs.ErrVolumeReclaimPolicyInvalid, p)
+	}
 }
 
 // validateVolumeScope enforces the Volume scope-coordinate contract:

--- a/internal/apply/parser/volume_test.go
+++ b/internal/apply/parser/volume_test.go
@@ -106,3 +106,33 @@ func TestValidateDocument_Volume_UnsafeNameRejected(t *testing.T) {
 	doc := parseVolume(t, "apiVersion: v1beta1\nkind: Volume\nmetadata:\n  name: ../escape\n  realm: default\n")
 	requireValidationErr(t, parser.ValidateDocument(doc), errdefs.ErrVolumeCoordUnsafe)
 }
+
+// TestValidateDocument_Volume_ReclaimPolicy covers the step-3 spec field: an
+// omitted policy and the two named policies validate, and a typo is rejected so
+// it cannot silently degrade to delete-with-scope (#1237).
+func TestValidateDocument_Volume_ReclaimPolicy(t *testing.T) {
+	base := "apiVersion: v1beta1\nkind: Volume\nmetadata:\n  name: data\n  realm: default\n"
+
+	for _, policy := range []string{"Retain", "Delete"} {
+		doc := parseVolume(t, base+"spec:\n  reclaimPolicy: "+policy+"\n")
+		if err := parser.ValidateDocument(doc); err != nil {
+			t.Fatalf("reclaimPolicy %q should be valid, got: %v", policy, err)
+		}
+		if got := doc.VolumeDoc.Spec.ReclaimPolicy; string(got) != policy {
+			t.Errorf("parsed reclaimPolicy = %q, want %q", got, policy)
+		}
+	}
+
+	// Omitted spec ⇒ empty policy, still valid (delete-with-scope default).
+	doc := parseVolume(t, base)
+	if err := parser.ValidateDocument(doc); err != nil {
+		t.Fatalf("omitted reclaimPolicy should be valid, got: %v", err)
+	}
+	if doc.VolumeDoc.Spec.ReclaimPolicy != "" {
+		t.Errorf("omitted reclaimPolicy = %q, want empty", doc.VolumeDoc.Spec.ReclaimPolicy)
+	}
+
+	// A typo is rejected.
+	bad := parseVolume(t, base+"spec:\n  reclaimPolicy: retainn\n")
+	requireValidationErr(t, parser.ValidateDocument(bad), errdefs.ErrVolumeReclaimPolicyInvalid)
+}

--- a/internal/consts/consts.go
+++ b/internal/consts/consts.go
@@ -75,6 +75,20 @@ const (
 	// when configured) so a mounting container can write into it (#1016).
 	KukeonVolumesSubdir = "volumes"
 
+	// KukeonVolumeMetaSubdir is the basename of the per-scope subdirectory that
+	// holds daemon-owned reclaim manifests for `kind: Volume` resources (step 3,
+	// #1237). It is a sibling of KukeonVolumesSubdir under the same scope
+	// metadata directory (e.g. <RunPath>/data/<realm>/volume-meta/<name>.json)
+	// rather than living inside the volume's own directory: that directory is the
+	// container-writable mount target (#1016), so a manifest stored there would
+	// both leak into the container mount and be tamperable by the mounting
+	// container — neither acceptable for a retention guarantee. A manifest is
+	// written only for a `Retain` volume, so a scope with none keeps the step-1
+	// blunt-RemoveAll cascade unchanged. Like the other reserved resource
+	// subdirs it is excluded from child-scope enumeration (see
+	// runner.reservedScopeSubdirs) so it is never mistaken for a phantom scope.
+	KukeonVolumeMetaSubdir = "volume-meta"
+
 	// KukeonContainerTTYDir is the basename of the per-container directory
 	// that owns the sbsh terminal socket plus its capture and log siblings.
 	// kukeon bind-mounts this directory (not a single file) into the

--- a/internal/controller/runner/purge_realm.go
+++ b/internal/controller/runner/purge_realm.go
@@ -176,9 +176,14 @@ func (r *Exec) PurgeRealm(realm intmodel.Realm) (bool, error) {
 		}
 	}
 
-	// Remove all metadata directories for realm and children
+	// Remove all metadata directories for realm and children, preserving any
+	// reclaimPolicy: Retain volume in the realm subtree (step 3, #1237). With no
+	// retained volume this is the same blunt RemoveAll as before.
 	metadataRunPath := fs.RealmMetadataDir(r.opts.RunPath, realmForOps.Metadata.Name)
-	_ = os.RemoveAll(metadataRunPath)
+	if reclaimErr := r.reclaimScopeMetadata(metadataRunPath); reclaimErr != nil {
+		r.logger.WarnContext(r.ctx, "selective scope reclaim failed during realm purge",
+			"path", metadataRunPath, "error", reclaimErr)
+	}
 
 	// Force remove realm cgroup
 	// Try to use stored CgroupPath first, fallback to DefaultRealmSpec if not available

--- a/internal/controller/runner/purge_space.go
+++ b/internal/controller/runner/purge_space.go
@@ -19,7 +19,6 @@ package runner
 import (
 	"errors"
 	"fmt"
-	"os"
 	"strings"
 
 	"github.com/eminwux/kukeon/internal/ctr"
@@ -103,13 +102,18 @@ func (r *Exec) PurgeSpace(space intmodel.Space) error {
 		_ = r.ctrClient.DeleteCgroup(spec.Group, mountpoint)
 	}
 
-	// Remove metadata directory completely
+	// Remove metadata directory, preserving any reclaimPolicy: Retain volume in
+	// the space or its stacks (step 3, #1237). With no retained volume this is
+	// the same blunt RemoveAll as before.
 	metadataRunPath := fs.SpaceMetadataDir(
 		r.opts.RunPath,
 		spaceForOps.Spec.RealmName,
 		spaceForOps.Metadata.Name,
 	)
-	_ = os.RemoveAll(metadataRunPath)
+	if reclaimErr := r.reclaimScopeMetadata(metadataRunPath); reclaimErr != nil {
+		r.logger.WarnContext(r.ctx, "selective scope reclaim failed during space purge",
+			"path", metadataRunPath, "error", reclaimErr)
+	}
 
 	return nil
 }

--- a/internal/controller/runner/purge_stack.go
+++ b/internal/controller/runner/purge_stack.go
@@ -19,7 +19,6 @@ package runner
 import (
 	"errors"
 	"fmt"
-	"os"
 	"strings"
 
 	"github.com/eminwux/kukeon/internal/ctr"
@@ -110,14 +109,19 @@ func (r *Exec) PurgeStack(stack intmodel.Stack) error {
 		_ = r.ctrClient.DeleteCgroup(spec.Group, mountpoint)
 	}
 
-	// Remove metadata directory completely
+	// Remove metadata directory, preserving any reclaimPolicy: Retain volume in
+	// the stack (step 3, #1237). With no retained volume this is the same blunt
+	// RemoveAll as before.
 	metadataRunPath := fs.StackMetadataDir(
 		r.opts.RunPath,
 		stackForOps.Spec.RealmName,
 		stackForOps.Spec.SpaceName,
 		stackForOps.Metadata.Name,
 	)
-	_ = os.RemoveAll(metadataRunPath)
+	if reclaimErr := r.reclaimScopeMetadata(metadataRunPath); reclaimErr != nil {
+		r.logger.WarnContext(r.ctx, "selective scope reclaim failed during stack purge",
+			"path", metadataRunPath, "error", reclaimErr)
+	}
 
 	return nil
 }

--- a/internal/controller/runner/reclaim_scope.go
+++ b/internal/controller/runner/reclaim_scope.go
@@ -1,0 +1,178 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package runner
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+
+	"github.com/eminwux/kukeon/internal/consts"
+	intmodel "github.com/eminwux/kukeon/internal/modelhub"
+)
+
+// reclaimScopeMetadata removes a scope's on-disk metadata tree on cascade purge,
+// preserving any `reclaimPolicy: Retain` volume in the subtree (step 3, #1237).
+//
+// When the scope holds no retained volume it falls through to the blunt
+// os.RemoveAll(scopeDir) the three purge paths ran before this rework, so a
+// scope with only default-policy volumes is reclaimed byte-identically to step
+// 1 — no behavior change for existing specs.
+//
+// When at least one retained volume exists, the scope dir, the intervening
+// scope skeleton, the volumes/ container dir, the retained volume directory
+// (with its container-written contents) and its volume-meta/ reclaim manifest
+// are all preserved; everything else under the scope — the scope's own
+// metadata.json, cells, child scopes, non-retained volumes, secrets/blueprints/
+// configs — is removed. The surviving scope dir carries no metadata.json, so a
+// list/get of the scope itself still reports it gone (those gate on the
+// metadata file), while the retained volume stays discoverable and deletable at
+// its original coordinates (ListVolumes/GetVolume/DeleteVolume walk by
+// directory presence).
+func (r *Exec) reclaimScopeMetadata(scopeDir string) error {
+	leaves, ancestors, err := r.collectRetainedPreserveSet(scopeDir)
+	if err != nil {
+		return err
+	}
+	if len(leaves) == 0 {
+		return os.RemoveAll(scopeDir)
+	}
+	return pruneExcept(scopeDir, leaves, ancestors)
+}
+
+// collectRetainedPreserveSet walks scopeDir for reclaim manifests marking a
+// volume Retain and returns two sets keyed by absolute path: leaves (retained
+// volume directories and their manifest files — kept whole, not recursed) and
+// ancestors (every directory on the path from scopeDir down to a leaf — kept and
+// recursed so the skeleton survives). An empty leaves set means no retained
+// volume, the blunt-RemoveAll fast path.
+func (r *Exec) collectRetainedPreserveSet(scopeDir string) (leaves, ancestors map[string]struct{}, err error) {
+	leaves = map[string]struct{}{}
+	ancestors = map[string]struct{}{}
+
+	walkErr := filepath.WalkDir(scopeDir, func(path string, d fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if !d.IsDir() {
+			return nil
+		}
+		switch d.Name() {
+		case consts.KukeonVolumesSubdir:
+			// Volume data directories never hold manifests; don't descend into
+			// container-written contents looking for them.
+			return filepath.SkipDir
+		case consts.KukeonVolumeMetaSubdir:
+			if collectErr := r.collectRetainedInMetaDir(path, leaves, ancestors, scopeDir); collectErr != nil {
+				return collectErr
+			}
+			return filepath.SkipDir
+		default:
+			return nil
+		}
+	})
+	if walkErr != nil {
+		return nil, nil, fmt.Errorf("scan scope %q for retained volumes: %w", scopeDir, walkErr)
+	}
+	return leaves, ancestors, nil
+}
+
+// collectRetainedInMetaDir reads every reclaim manifest in a volume-meta/ dir
+// and, for each one marking Retain, records the manifest file and the matching
+// volume directory as preserve leaves plus their ancestor chain up to scopeDir.
+func (r *Exec) collectRetainedInMetaDir(metaDir string, leaves, ancestors map[string]struct{}, scopeDir string) error {
+	entries, err := os.ReadDir(metaDir)
+	if err != nil {
+		return fmt.Errorf("read volume-meta dir %q: %w", metaDir, err)
+	}
+	// The scope dir holding this volume-meta/ is its parent; the sibling volumes/
+	// dir holds the actual volume directories.
+	ownerScopeDir := filepath.Dir(metaDir)
+	volumesDir := filepath.Join(ownerScopeDir, consts.KukeonVolumesSubdir)
+
+	for _, entry := range entries {
+		name := entry.Name()
+		if entry.IsDir() || filepath.Ext(name) != ".json" {
+			// Skip subdirectories and in-flight ".volume-meta-*.tmp" temp files.
+			continue
+		}
+		manifestPath := filepath.Join(metaDir, name)
+		data, readErr := os.ReadFile(manifestPath)
+		if readErr != nil {
+			return fmt.Errorf("read reclaim manifest %q: %w", manifestPath, readErr)
+		}
+		var manifest volumeReclaimManifest
+		if jsonErr := json.Unmarshal(data, &manifest); jsonErr != nil {
+			return fmt.Errorf("parse reclaim manifest %q: %w", manifestPath, jsonErr)
+		}
+		if intmodel.ReclaimPolicy(manifest.ReclaimPolicy) != intmodel.ReclaimRetain {
+			continue
+		}
+		volName := name[:len(name)-len(".json")]
+		volDir := filepath.Join(volumesDir, volName)
+
+		leaves[manifestPath] = struct{}{}
+		leaves[volDir] = struct{}{}
+		addAncestors(ancestors, scopeDir, manifestPath)
+		addAncestors(ancestors, scopeDir, volDir)
+	}
+	return nil
+}
+
+// addAncestors records every directory on the path from scopeDir (inclusive)
+// down to leaf's parent (inclusive) so pruneExcept keeps and recurses into them
+// rather than removing them. leaf itself is not added (it is a preserve leaf).
+func addAncestors(ancestors map[string]struct{}, scopeDir, leaf string) {
+	for dir := filepath.Dir(leaf); ; dir = filepath.Dir(dir) {
+		ancestors[dir] = struct{}{}
+		if dir == scopeDir {
+			return
+		}
+		// Defensive stop: never climb above scopeDir (the leaf is always a
+		// descendant, so this only guards against a malformed input).
+		if len(dir) <= len(scopeDir) {
+			return
+		}
+	}
+}
+
+// pruneExcept removes every entry under dir except preserve leaves (kept whole)
+// and ancestors (kept and recursed). dir itself is never removed.
+func pruneExcept(dir string, leaves, ancestors map[string]struct{}) error {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return fmt.Errorf("read dir %q during selective reclaim: %w", dir, err)
+	}
+	for _, entry := range entries {
+		full := filepath.Join(dir, entry.Name())
+		if _, ok := leaves[full]; ok {
+			continue
+		}
+		if _, ok := ancestors[full]; ok {
+			if err := pruneExcept(full, leaves, ancestors); err != nil {
+				return err
+			}
+			continue
+		}
+		if err := os.RemoveAll(full); err != nil {
+			return fmt.Errorf("remove %q during selective reclaim: %w", full, err)
+		}
+	}
+	return nil
+}

--- a/internal/controller/runner/reclaim_scope_test.go
+++ b/internal/controller/runner/reclaim_scope_test.go
@@ -1,0 +1,337 @@
+//go:build !integration
+
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+//nolint:testpackage // tests the unexported reclaimScopeMetadata cascade path
+package runner
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/eminwux/kukeon/internal/consts"
+	"github.com/eminwux/kukeon/internal/errdefs"
+	intmodel "github.com/eminwux/kukeon/internal/modelhub"
+	"github.com/eminwux/kukeon/internal/util/fs"
+)
+
+// retainSpec / deleteSpec build a Volume carrier with the two reclaim policies.
+func retainVol(md intmodel.VolumeMetadata) intmodel.Volume {
+	return intmodel.Volume{Metadata: md, Spec: intmodel.VolumeSpec{ReclaimPolicy: intmodel.ReclaimRetain}}
+}
+
+func deleteVol(md intmodel.VolumeMetadata) intmodel.Volume {
+	return intmodel.Volume{Metadata: md} // empty policy == Delete
+}
+
+// seedScopeMetadataFile writes a scope's own metadata.json so a test can assert
+// the cascade removes it (the marker list/get gate on to report the scope gone).
+func seedScopeMetadataFile(t *testing.T, scopeDir string) {
+	t.Helper()
+	if err := os.MkdirAll(scopeDir, 0o755); err != nil {
+		t.Fatalf("mkdir scope dir %q: %v", scopeDir, err)
+	}
+	if err := os.WriteFile(filepath.Join(scopeDir, consts.KukeonMetadataFile), []byte("{}"), 0o644); err != nil {
+		t.Fatalf("write scope metadata.json: %v", err)
+	}
+}
+
+// seedNonVolumeContent writes a child-scope dir and a secrets/ entry under the
+// scope so a test can assert non-volume content is fully reclaimed.
+func seedNonVolumeContent(t *testing.T, scopeDir string) (childDir, secretFile string) {
+	t.Helper()
+	childDir = filepath.Join(scopeDir, "child")
+	if err := os.MkdirAll(childDir, 0o755); err != nil {
+		t.Fatalf("mkdir child scope: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(childDir, consts.KukeonMetadataFile), []byte("{}"), 0o644); err != nil {
+		t.Fatalf("write child metadata.json: %v", err)
+	}
+	secretsDir := filepath.Join(scopeDir, consts.KukeonSecretsSubdir)
+	if err := os.MkdirAll(secretsDir, 0o755); err != nil {
+		t.Fatalf("mkdir secrets: %v", err)
+	}
+	secretFile = filepath.Join(secretsDir, "sec1")
+	if err := os.WriteFile(secretFile, []byte("x"), 0o600); err != nil {
+		t.Fatalf("write secret: %v", err)
+	}
+	return childDir, secretFile
+}
+
+func assertGone(t *testing.T, path, label string) {
+	t.Helper()
+	if _, err := os.Stat(path); !errors.Is(err, os.ErrNotExist) {
+		t.Errorf("%s survived cascade reclaim (%q): stat err = %v", label, path, err)
+	}
+}
+
+func assertExists(t *testing.T, path, label string) {
+	t.Helper()
+	if _, err := os.Stat(path); err != nil {
+		t.Errorf("%s was reclaimed but should survive (%q): %v", label, path, err)
+	}
+}
+
+// TestReclaimScopeMetadata_PreservesRetainedAtScope drives the exact selective
+// reclaim every one of the three purge paths (purge_stack/space/realm) runs —
+// they all delegate to reclaimScopeMetadata — and confirms a reclaimPolicy:
+// Retain volume at the purged scope survives while the scope's own metadata,
+// child scopes, secrets, and a sibling default-policy volume are all reclaimed.
+func TestReclaimScopeMetadata_PreservesRetainedAtScope(t *testing.T) {
+	cases := []struct {
+		name     string
+		retained intmodel.VolumeMetadata
+		deflt    intmodel.VolumeMetadata
+		scopeDir func(runPath string) string
+	}{
+		{
+			name:     "stack",
+			retained: intmodel.VolumeMetadata{Name: "keep", Realm: "r1", Space: "s1", Stack: "st1"},
+			deflt:    intmodel.VolumeMetadata{Name: "drop", Realm: "r1", Space: "s1", Stack: "st1"},
+			scopeDir: func(rp string) string { return fs.StackMetadataDir(rp, "r1", "s1", "st1") },
+		},
+		{
+			name:     "space",
+			retained: intmodel.VolumeMetadata{Name: "keep", Realm: "r1", Space: "s1"},
+			deflt:    intmodel.VolumeMetadata{Name: "drop", Realm: "r1", Space: "s1"},
+			scopeDir: func(rp string) string { return fs.SpaceMetadataDir(rp, "r1", "s1") },
+		},
+		{
+			name:     "realm",
+			retained: intmodel.VolumeMetadata{Name: "keep", Realm: "r1"},
+			deflt:    intmodel.VolumeMetadata{Name: "drop", Realm: "r1"},
+			scopeDir: func(rp string) string { return fs.RealmMetadataDir(rp, "r1") },
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			runPath := t.TempDir()
+			r := newMetadataTestExec(t, runPath, time.Now())
+			scopeDir := tc.scopeDir(runPath)
+
+			seedScopeMetadataFile(t, scopeDir)
+			childDir, secretFile := seedNonVolumeContent(t, scopeDir)
+			if _, err := r.WriteVolume(retainVol(tc.retained)); err != nil {
+				t.Fatalf("WriteVolume(retained) error = %v", err)
+			}
+			if _, err := r.WriteVolume(deleteVol(tc.deflt)); err != nil {
+				t.Fatalf("WriteVolume(default) error = %v", err)
+			}
+
+			if err := r.reclaimScopeMetadata(scopeDir); err != nil {
+				t.Fatalf("reclaimScopeMetadata error = %v", err)
+			}
+
+			md := tc.retained
+			retainedPath := fs.VolumePath(runPath, md.Realm, md.Space, md.Stack, md.Name)
+			retainedManifest := fs.VolumeMetaPath(runPath, md.Realm, md.Space, md.Stack, md.Name)
+			dropPath := fs.VolumePath(runPath, tc.deflt.Realm, tc.deflt.Space, tc.deflt.Stack, tc.deflt.Name)
+
+			assertExists(t, scopeDir, "scope skeleton")
+			assertExists(t, retainedPath, "retained volume dir")
+			assertExists(t, retainedManifest, "retained volume manifest")
+			assertGone(t, dropPath, "default-policy volume")
+			assertGone(t, filepath.Join(scopeDir, consts.KukeonMetadataFile), "scope metadata.json")
+			assertGone(t, childDir, "child scope")
+			assertGone(t, secretFile, "secret")
+
+			// The retained volume is still discoverable and reports its policy.
+			got, err := r.GetVolume(intmodel.Volume{Metadata: md})
+			if err != nil {
+				t.Fatalf("GetVolume(retained) after reclaim error = %v", err)
+			}
+			if got.Spec.ReclaimPolicy != intmodel.ReclaimRetain {
+				t.Errorf("retained volume reclaimPolicy = %q, want %q", got.Spec.ReclaimPolicy, intmodel.ReclaimRetain)
+			}
+			vols, err := r.ListVolumes(md.Realm, md.Space, md.Stack)
+			if err != nil {
+				t.Fatalf("ListVolumes after reclaim error = %v", err)
+			}
+			if len(vols) != 1 || vols[0].Metadata.Name != md.Name {
+				t.Errorf("ListVolumes = %+v, want only retained %q", vols, md.Name)
+			}
+			// And still deletable, leaving no orphan manifest.
+			if err := r.DeleteVolume(intmodel.Volume{Metadata: md}); err != nil {
+				t.Fatalf("DeleteVolume(retained) after reclaim error = %v", err)
+			}
+			assertGone(t, retainedPath, "retained volume dir after delete")
+			assertGone(t, retainedManifest, "retained volume manifest after delete")
+		})
+	}
+}
+
+// TestReclaimScopeMetadata_PreservesDeeplyNestedRetained confirms a stack-scoped
+// Retain volume survives a *realm* cascade purge: the realm, space, and stack
+// metadata.json files are all reclaimed (the scopes report gone), the skeleton
+// dirs down to the volume survive, and the volume itself plus its manifest are
+// preserved and remain discoverable under the realm filter.
+func TestReclaimScopeMetadata_PreservesDeeplyNestedRetained(t *testing.T) {
+	runPath := t.TempDir()
+	r := newMetadataTestExec(t, runPath, time.Now())
+
+	realmDir := fs.RealmMetadataDir(runPath, "r1")
+	spaceDir := fs.SpaceMetadataDir(runPath, "r1", "s1")
+	stackDir := fs.StackMetadataDir(runPath, "r1", "s1", "st1")
+	seedScopeMetadataFile(t, realmDir)
+	seedScopeMetadataFile(t, spaceDir)
+	seedScopeMetadataFile(t, stackDir)
+
+	md := intmodel.VolumeMetadata{Name: "deep", Realm: "r1", Space: "s1", Stack: "st1"}
+	if _, err := r.WriteVolume(retainVol(md)); err != nil {
+		t.Fatalf("WriteVolume(deep retained) error = %v", err)
+	}
+	// A sibling default volume at the realm level must still be reclaimed.
+	shallow := intmodel.VolumeMetadata{Name: "drop", Realm: "r1"}
+	if _, err := r.WriteVolume(deleteVol(shallow)); err != nil {
+		t.Fatalf("WriteVolume(shallow default) error = %v", err)
+	}
+
+	if err := r.reclaimScopeMetadata(realmDir); err != nil {
+		t.Fatalf("reclaimScopeMetadata(realm) error = %v", err)
+	}
+
+	assertExists(t, fs.VolumePath(runPath, "r1", "s1", "st1", "deep"), "deep retained volume")
+	assertExists(t, fs.VolumeMetaPath(runPath, "r1", "s1", "st1", "deep"), "deep retained manifest")
+	assertExists(t, stackDir, "stack skeleton")
+	assertExists(t, spaceDir, "space skeleton")
+	assertExists(t, realmDir, "realm skeleton")
+	assertGone(t, filepath.Join(realmDir, consts.KukeonMetadataFile), "realm metadata.json")
+	assertGone(t, filepath.Join(spaceDir, consts.KukeonMetadataFile), "space metadata.json")
+	assertGone(t, filepath.Join(stackDir, consts.KukeonMetadataFile), "stack metadata.json")
+	assertGone(t, fs.VolumePath(runPath, "r1", "", "", "drop"), "shallow default volume")
+
+	vols, err := r.ListVolumes("r1", "", "")
+	if err != nil {
+		t.Fatalf("ListVolumes(r1) error = %v", err)
+	}
+	if len(vols) != 1 || vols[0].Metadata.Name != "deep" {
+		t.Errorf("ListVolumes(r1) = %+v, want only deep retained volume", vols)
+	}
+}
+
+// TestReclaimScopeMetadata_NoRetainedRemovesWholeScope confirms the fast path:
+// a scope with only default-policy volumes (no manifests) is removed wholesale,
+// byte-identical to the step-1 blunt os.RemoveAll — no skeleton left behind.
+func TestReclaimScopeMetadata_NoRetainedRemovesWholeScope(t *testing.T) {
+	runPath := t.TempDir()
+	r := newMetadataTestExec(t, runPath, time.Now())
+
+	scopeDir := fs.StackMetadataDir(runPath, "r1", "s1", "st1")
+	seedScopeMetadataFile(t, scopeDir)
+	md := intmodel.VolumeMetadata{Name: "drop", Realm: "r1", Space: "s1", Stack: "st1"}
+	if _, err := r.WriteVolume(deleteVol(md)); err != nil {
+		t.Fatalf("WriteVolume(default) error = %v", err)
+	}
+
+	if err := r.reclaimScopeMetadata(scopeDir); err != nil {
+		t.Fatalf("reclaimScopeMetadata error = %v", err)
+	}
+	assertGone(t, scopeDir, "scope dir (no retained volume)")
+}
+
+// TestReclaimScopeMetadata_RetainOutsideScopeUntouched confirms the reclaim only
+// touches the named scope: a Retain volume in a sibling scope is irrelevant and
+// the purge of one scope never reaches another.
+func TestReclaimScopeMetadata_RetainOutsideScopeUntouched(t *testing.T) {
+	runPath := t.TempDir()
+	r := newMetadataTestExec(t, runPath, time.Now())
+
+	purged := fs.StackMetadataDir(runPath, "r1", "s1", "st1")
+	seedScopeMetadataFile(t, purged)
+	if _, err := r.WriteVolume(deleteVol(intmodel.VolumeMetadata{Name: "drop", Realm: "r1", Space: "s1", Stack: "st1"})); err != nil {
+		t.Fatalf("WriteVolume error = %v", err)
+	}
+	// A retained volume in a different stack.
+	other := intmodel.VolumeMetadata{Name: "keep", Realm: "r1", Space: "s1", Stack: "st2"}
+	if _, err := r.WriteVolume(retainVol(other)); err != nil {
+		t.Fatalf("WriteVolume(other) error = %v", err)
+	}
+
+	if err := r.reclaimScopeMetadata(purged); err != nil {
+		t.Fatalf("reclaimScopeMetadata error = %v", err)
+	}
+	assertGone(t, purged, "purged stack")
+	assertExists(t, fs.VolumePath(runPath, "r1", "s1", "st2", "keep"), "retained volume in sibling stack")
+}
+
+// TestWriteVolume_RetainPersistsManifest pins the persistence contract: a Retain
+// volume writes a root-only manifest GetVolume echoes back, re-applying with the
+// policy flipped to Delete drops the manifest, and a corrupt manifest surfaces
+// as an error rather than a silent downgrade.
+func TestWriteVolume_RetainPersistsManifest(t *testing.T) {
+	runPath := t.TempDir()
+	r := newMetadataTestExec(t, runPath, time.Now())
+	md := intmodel.VolumeMetadata{Name: "data", Realm: "r1"}
+
+	if _, err := r.WriteVolume(retainVol(md)); err != nil {
+		t.Fatalf("WriteVolume(retain) error = %v", err)
+	}
+	manifestPath := fs.VolumeMetaPath(runPath, "r1", "", "", "data")
+	info, err := os.Stat(manifestPath)
+	if err != nil {
+		t.Fatalf("stat manifest: %v", err)
+	}
+	if perm := info.Mode().Perm(); perm != 0o600 {
+		t.Errorf("manifest mode = %o, want 600 (root-only)", perm)
+	}
+	if dirInfo, statErr := os.Stat(filepath.Dir(manifestPath)); statErr != nil {
+		t.Errorf("stat volume-meta dir: %v", statErr)
+	} else if perm := dirInfo.Mode().Perm(); perm != 0o700 {
+		t.Errorf("volume-meta dir mode = %o, want 700 (root-only)", perm)
+	}
+
+	got, err := r.GetVolume(intmodel.Volume{Metadata: md})
+	if err != nil {
+		t.Fatalf("GetVolume error = %v", err)
+	}
+	if got.Spec.ReclaimPolicy != intmodel.ReclaimRetain {
+		t.Errorf("GetVolume reclaimPolicy = %q, want Retain", got.Spec.ReclaimPolicy)
+	}
+
+	// Re-apply with Delete drops the manifest.
+	if _, err := r.WriteVolume(intmodel.Volume{
+		Metadata: md,
+		Spec:     intmodel.VolumeSpec{ReclaimPolicy: intmodel.ReclaimDelete},
+	}); err != nil {
+		t.Fatalf("WriteVolume(delete re-apply) error = %v", err)
+	}
+	if _, err := os.Stat(manifestPath); !errors.Is(err, os.ErrNotExist) {
+		t.Errorf("manifest survived Delete re-apply: stat err = %v", err)
+	}
+	got, err = r.GetVolume(intmodel.Volume{Metadata: md})
+	if err != nil {
+		t.Fatalf("GetVolume after delete re-apply error = %v", err)
+	}
+	if got.Spec.ReclaimPolicy != "" {
+		t.Errorf("reclaimPolicy after Delete re-apply = %q, want empty", got.Spec.ReclaimPolicy)
+	}
+
+	// A corrupt manifest is an error, not a silent Delete downgrade.
+	if _, err := r.WriteVolume(retainVol(md)); err != nil {
+		t.Fatalf("WriteVolume(retain again) error = %v", err)
+	}
+	if err := os.WriteFile(manifestPath, []byte("{not json"), 0o600); err != nil {
+		t.Fatalf("corrupt manifest: %v", err)
+	}
+	if _, err := r.GetVolume(intmodel.Volume{Metadata: md}); !errors.Is(err, errdefs.ErrGetVolume) {
+		t.Errorf("GetVolume over corrupt manifest = %v, want ErrGetVolume", err)
+	}
+}

--- a/internal/controller/runner/scope_children.go
+++ b/internal/controller/runner/scope_children.go
@@ -28,7 +28,8 @@ import (
 // reservedScopeSubdirs is the single source of truth for the per-scope
 // subdirectory names that hold resources (not child scopes) under
 // <RunPath>/data/<realm>/[<space>/[<stack>/[<cell>/]]]: secrets/ (#619),
-// blueprints/ (#620), configs/ (#624), and volumes/ (#1018). The subtree-list
+// blueprints/ (#620), configs/ (#624), volumes/ (#1018), and volume-meta/
+// (#1237, the daemon-owned reclaim manifests for volumes). The subtree-list
 // walkers in secret.go / blueprint.go / config.go / volume.go enumerate child
 // scopes by reading the scope dir and must skip every entry in this set,
 // otherwise a reserved resource subdir would be mistaken for a phantom
@@ -44,6 +45,7 @@ var reservedScopeSubdirs = map[string]struct{}{
 	consts.KukeonBlueprintsSubdir: {},
 	consts.KukeonConfigsSubdir:    {},
 	consts.KukeonVolumesSubdir:    {},
+	consts.KukeonVolumeMetaSubdir: {},
 }
 
 // childScopeNames returns the child-scope subdirectory names directly under

--- a/internal/controller/runner/volume.go
+++ b/internal/controller/runner/volume.go
@@ -110,6 +110,14 @@ func (r *Exec) WriteVolume(volume intmodel.Volume) (bool, error) {
 		}
 	}
 
+	// Reconcile the reclaim manifest after the volume dir is in place: a Retain
+	// policy writes the root-only marker cascade purge consults; any other value
+	// drops a stale marker so re-applying with the policy flipped to Delete loses
+	// protection (step 3, #1237).
+	if err := r.persistVolumeReclaimPolicy(volume); err != nil {
+		return false, err
+	}
+
 	action := "updated"
 	if created {
 		action = "created"
@@ -119,6 +127,7 @@ func (r *Exec) WriteVolume(volume intmodel.Volume) (bool, error) {
 		"realm", md.Realm,
 		"space", md.Space,
 		"stack", md.Stack,
+		"reclaimPolicy", string(volume.Spec.ReclaimPolicy),
 	)
 	return created, nil
 }
@@ -143,7 +152,15 @@ func (r *Exec) GetVolume(volume intmodel.Volume) (intmodel.Volume, error) {
 		return intmodel.Volume{}, errdefs.ErrVolumeNotFound
 	}
 
-	return intmodel.Volume{Metadata: md}, nil
+	policy, err := r.readVolumeReclaimPolicy(md)
+	if err != nil {
+		return intmodel.Volume{}, fmt.Errorf("%w: %w", errdefs.ErrGetVolume, err)
+	}
+
+	return intmodel.Volume{
+		Metadata: md,
+		Spec:     intmodel.VolumeSpec{ReclaimPolicy: policy},
+	}, nil
 }
 
 // ListVolumes enumerates the metadata of every Volume bound to the scope
@@ -227,13 +244,19 @@ func (r *Exec) collectVolumesInScope(out *[]intmodel.Volume, realm, space, stack
 		if !entry.IsDir() {
 			continue
 		}
+		vmd := intmodel.VolumeMetadata{
+			Name:  entry.Name(),
+			Realm: realm,
+			Space: space,
+			Stack: stack,
+		}
+		policy, err := r.readVolumeReclaimPolicy(vmd)
+		if err != nil {
+			return err
+		}
 		*out = append(*out, intmodel.Volume{
-			Metadata: intmodel.VolumeMetadata{
-				Name:  entry.Name(),
-				Realm: realm,
-				Space: space,
-				Stack: stack,
-			},
+			Metadata: vmd,
+			Spec:     intmodel.VolumeSpec{ReclaimPolicy: policy},
 		})
 	}
 	return nil
@@ -262,6 +285,11 @@ func (r *Exec) DeleteVolume(volume intmodel.Volume) error {
 
 	if err := os.RemoveAll(path); err != nil {
 		return fmt.Errorf("%w: %w", errdefs.ErrDeleteVolume, err)
+	}
+	// Drop the reclaim manifest too so deleting a retained volume leaves no
+	// orphan marker behind (step 3, #1237).
+	if err := r.removeVolumeReclaimManifest(md); err != nil {
+		return fmt.Errorf("%w: remove reclaim manifest: %w", errdefs.ErrDeleteVolume, err)
 	}
 
 	r.logger.InfoContext(r.ctx, "volume deleted",

--- a/internal/controller/runner/volume_meta.go
+++ b/internal/controller/runner/volume_meta.go
@@ -1,0 +1,116 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package runner
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+
+	"github.com/eminwux/kukeon/internal/errdefs"
+	intmodel "github.com/eminwux/kukeon/internal/modelhub"
+	"github.com/eminwux/kukeon/internal/util/fs"
+)
+
+// volumeMetaDirMode is the mode of the per-scope volume-meta/ directory: root-
+// only (0o700, no group or world access). Unlike the volumes/ container dir —
+// which a non-root party traverses to reach a volume it mounts — the reclaim
+// manifests are daemon-private: only kukeond (root) reads them, at cascade-purge
+// time, to decide which volumes survive. Keeping the directory root-only is what
+// makes a Retain marker un-tamperable by a mounting container.
+const volumeMetaDirMode os.FileMode = 0o700
+
+// volumeMetaFileMode is the mode of a single reclaim manifest (0o600, root-only).
+const volumeMetaFileMode os.FileMode = 0o600
+
+// volumeReclaimManifest is the on-disk shape of a volume's reclaim manifest.
+// Only a Retain volume has one (a Delete/omitted policy writes nothing and
+// removes any stale manifest), so its mere presence already implies Retain; the
+// explicit field future-proofs the format and lets GetVolume echo the exact
+// value back.
+type volumeReclaimManifest struct {
+	ReclaimPolicy string `json:"reclaimPolicy"`
+}
+
+// persistVolumeReclaimPolicy reconciles the on-disk reclaim manifest for a
+// volume to match its desired spec. A Retain policy writes the manifest
+// (creating the root-only volume-meta/ dir on demand); any other value
+// (including the empty default) removes any manifest left from a prior Retain so
+// re-applying a volume with the policy flipped back to Delete drops its
+// protection. Called from WriteVolume after the volume directory is in place.
+func (r *Exec) persistVolumeReclaimPolicy(volume intmodel.Volume) error {
+	md := volume.Metadata
+	metaPath := fs.VolumeMetaPath(r.opts.RunPath, md.Realm, md.Space, md.Stack, md.Name)
+
+	if volume.Spec.ReclaimPolicy != intmodel.ReclaimRetain {
+		if err := os.Remove(metaPath); err != nil && !os.IsNotExist(err) {
+			return fmt.Errorf("%w: remove stale reclaim manifest: %w", errdefs.ErrWriteVolume, err)
+		}
+		return nil
+	}
+
+	dir := fs.VolumeMetaDir(r.opts.RunPath, md.Realm, md.Space, md.Stack)
+	if err := os.MkdirAll(dir, volumeMetaDirMode); err != nil {
+		return fmt.Errorf("%w: create volume-meta dir: %w", errdefs.ErrWriteVolume, err)
+	}
+	// MkdirAll honors only the rwx bits and leaves a pre-existing directory's
+	// mode intact; chmod so the root-only contract holds even if a parent
+	// created the dir with looser bits or the umask stripped them.
+	if err := os.Chmod(dir, volumeMetaDirMode); err != nil {
+		return fmt.Errorf("%w: chmod volume-meta dir: %w", errdefs.ErrWriteVolume, err)
+	}
+
+	data, err := json.Marshal(volumeReclaimManifest{ReclaimPolicy: string(intmodel.ReclaimRetain)})
+	if err != nil {
+		return fmt.Errorf("%w: marshal reclaim manifest: %w", errdefs.ErrWriteVolume, err)
+	}
+	if err := atomicWriteFileMode(dir, metaPath, ".volume-meta-*.tmp", data, volumeMetaFileMode); err != nil {
+		return fmt.Errorf("%w: write reclaim manifest: %w", errdefs.ErrWriteVolume, err)
+	}
+	return nil
+}
+
+// readVolumeReclaimPolicy returns the reclaim policy persisted for a volume, or
+// the empty policy (Delete semantics) when no manifest exists. A manifest that
+// fails to parse is reported as an error so a corrupt marker surfaces rather
+// than silently downgrading a Retain volume to Delete.
+func (r *Exec) readVolumeReclaimPolicy(md intmodel.VolumeMetadata) (intmodel.ReclaimPolicy, error) {
+	metaPath := fs.VolumeMetaPath(r.opts.RunPath, md.Realm, md.Space, md.Stack, md.Name)
+	data, err := os.ReadFile(metaPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return "", nil
+		}
+		return "", err
+	}
+	var manifest volumeReclaimManifest
+	if err := json.Unmarshal(data, &manifest); err != nil {
+		return "", fmt.Errorf("parse reclaim manifest %q: %w", metaPath, err)
+	}
+	return intmodel.ReclaimPolicy(manifest.ReclaimPolicy), nil
+}
+
+// removeVolumeReclaimManifest deletes a volume's reclaim manifest, ignoring a
+// missing manifest (the common case — only Retain volumes have one). Called
+// from DeleteVolume so deleting a retained volume leaves no orphan marker.
+func (r *Exec) removeVolumeReclaimManifest(md intmodel.VolumeMetadata) error {
+	metaPath := fs.VolumeMetaPath(r.opts.RunPath, md.Realm, md.Space, md.Stack, md.Name)
+	if err := os.Remove(metaPath); err != nil && !os.IsNotExist(err) {
+		return err
+	}
+	return nil
+}

--- a/internal/errdefs/errdefs.go
+++ b/internal/errdefs/errdefs.go
@@ -514,6 +514,12 @@ var (
 	ErrGetVolume           = errors.New("failed to get volume")
 	ErrListVolumes         = errors.New("failed to list volumes")
 	ErrDeleteVolume        = errors.New("failed to delete volume")
+	// ErrVolumeReclaimPolicyInvalid rejects a spec.reclaimPolicy that is neither
+	// "Retain" nor "Delete" (an empty value is allowed and means Delete). The
+	// selective cascade reclaim lands in step 3 (#1237).
+	ErrVolumeReclaimPolicyInvalid = errors.New(
+		`volume spec.reclaimPolicy must be "Retain" or "Delete" (or omitted)`,
+	)
 
 	// CellConfig kind (kind: CellConfig) errors (issue #624, phase 4b-i of #423).
 

--- a/internal/modelhub/volume.go
+++ b/internal/modelhub/volume.go
@@ -17,16 +17,35 @@
 package modelhub
 
 // Volume is the internal carrier for a standalone, daemon-managed storage
-// volume (kind: Volume, issue #1018). Unlike CellBlueprint/CellConfig it
-// carries no Document: a Volume's spec is empty in step 1, and the resource
-// itself is the on-host directory the daemon provisions — not a serialized
-// document round-tripped back out. Like a Secret's metadata-only view, the
-// carrier holds only the scope coordinates and name, which the storage runner
-// resolves to (and derives from) the on-disk path. When `reclaimPolicy` lands
-// (step 3, #1237) a Spec field will join the carrier.
+// volume (kind: Volume, issue #1018). The resource itself is the on-host
+// directory the daemon provisions — not a serialized document round-tripped
+// back out — so the carrier holds the scope coordinates and name (which the
+// storage runner resolves to, and derives from, the on-disk path) plus the
+// small Spec introduced in step 3 (#1237): the reclaim policy a cascade purge
+// consults. Unlike CellBlueprint/CellConfig there is still no Document.
 type Volume struct {
 	Metadata VolumeMetadata
+	Spec     VolumeSpec
 }
+
+// VolumeSpec carries the volume's declarative configuration. Its only field is
+// the reclaim policy (step 3, #1237); an empty ReclaimPolicy means the step-1
+// delete-with-scope behavior. See external v1beta1.VolumeSpec for the contract.
+type VolumeSpec struct {
+	ReclaimPolicy ReclaimPolicy
+}
+
+// ReclaimPolicy mirrors v1beta1.ReclaimPolicy: the per-Volume policy a cascade
+// purge consults to decide whether the volume is reclaimed with its owning
+// scope (ReclaimDelete, the empty-value default) or preserved (ReclaimRetain).
+type ReclaimPolicy string
+
+const (
+	// ReclaimDelete reclaims the volume with its owning scope on cascade purge.
+	ReclaimDelete ReclaimPolicy = "Delete"
+	// ReclaimRetain preserves the volume across its owning scope's cascade purge.
+	ReclaimRetain ReclaimPolicy = "Retain"
+)
 
 // VolumeMetadata identifies a Volume by name and the scope it binds to. A
 // Volume is scopable at realm, space, or stack only — never cell. The scope is

--- a/internal/util/fs/metadata.go
+++ b/internal/util/fs/metadata.go
@@ -385,6 +385,31 @@ func VolumePath(baseRunPath, realmName, spaceName, stackName, volumeName string)
 	)
 }
 
+// VolumeMetaDir returns the per-scope volume-meta directory — the root-owned
+// sibling of the volumes/ dir that holds daemon-owned reclaim manifests, one
+// per Retain volume (step 3, #1237). Kept outside the volume's own directory
+// because that directory is the container-writable mount target (#1016): a
+// reclaim manifest stored there would leak into the container mount and be
+// tamperable by the mounting container.
+func VolumeMetaDir(baseRunPath, realmName, spaceName, stackName string) string {
+	return filepath.Join(
+		VolumeScopeDir(baseRunPath, realmName, spaceName, stackName),
+		consts.KukeonVolumeMetaSubdir,
+	)
+}
+
+// VolumeMetaPath returns the host-side path of a single volume's reclaim
+// manifest: <scope>/volume-meta/<name>.json. The ".json" suffix keeps the
+// manifest a file (volumes are directories), so the volumes/ enumerator — which
+// collects directories — never sees it, and it can never collide with a volume
+// directory of the same scope.
+func VolumeMetaPath(baseRunPath, realmName, spaceName, stackName, volumeName string) string {
+	return filepath.Join(
+		VolumeMetaDir(baseRunPath, realmName, spaceName, stackName),
+		volumeName+".json",
+	)
+}
+
 type metadataHeader struct {
 	APIVersion string `json:"apiVersion"`
 	Kind       string `json:"kind"`

--- a/pkg/api/model/v1beta1/volume.go
+++ b/pkg/api/model/v1beta1/volume.go
@@ -53,11 +53,31 @@ type VolumeMetadata struct {
 	Stack string `json:"stack,omitempty" yaml:"stack,omitempty"`
 }
 
-// VolumeSpec carries the volume's declarative configuration. It is empty in
-// step 1 (#1018): the volume's identity is its scope plus its name, and the
-// resource is the directory the daemon provisions. The first spec field —
-// `reclaimPolicy: Retain` — lands in step 3 (#1237), where it reworks cascade
-// purge from the blunt scope-dir RemoveAll to enumerate-and-selectively-
-// preserve. The struct exists now so that addition is a field append rather
-// than a schema reshape.
-type VolumeSpec struct{}
+// VolumeSpec carries the volume's declarative configuration. The first — and so
+// far only — field is `reclaimPolicy` (step 3, #1237), which decides whether an
+// owning-scope cascade purge reclaims the volume with its scope or preserves it.
+// It is optional: an omitted reclaimPolicy keeps step 1's delete-with-scope
+// behavior, so existing specs are unaffected.
+type VolumeSpec struct {
+	// ReclaimPolicy decides what an owning-scope cascade purge does with the
+	// volume. Omitted (or "Delete") ⇒ the volume is reclaimed with its scope,
+	// the step-1 behavior. "Retain" ⇒ the volume survives the cascade and stays
+	// discoverable and deletable at its original scope coordinates.
+	ReclaimPolicy ReclaimPolicy `json:"reclaimPolicy,omitempty" yaml:"reclaimPolicy,omitempty"`
+}
+
+// ReclaimPolicy is the per-Volume policy a stack/space/realm cascade purge
+// consults to decide whether a volume is reclaimed with its owning scope or
+// preserved. The values mirror the Kubernetes PersistentVolume reclaim-policy
+// vocabulary (Retain/Delete) the issue's `reclaimPolicy: Retain` spelling
+// adopts. An empty value is treated as ReclaimDelete.
+type ReclaimPolicy string
+
+const (
+	// ReclaimDelete reclaims the volume with its owning scope on cascade purge.
+	// It is the default an omitted reclaimPolicy resolves to.
+	ReclaimDelete ReclaimPolicy = "Delete"
+	// ReclaimRetain preserves the volume across its owning scope's cascade
+	// purge; everything else in the scope is still reclaimed.
+	ReclaimRetain ReclaimPolicy = "Retain"
+)


### PR DESCRIPTION
## Summary

Step 3 of the volumes epic (umbrella #1015). Adds an optional `reclaimPolicy` to the Volume schema and reworks owning-scope cascade purge so a `Retain` volume survives its scope's purge while everything else in the scope is still reclaimed. Omitted ⇒ today's delete-with-scope behavior, byte-identical for existing specs.

- **Schema:** `VolumeSpec.ReclaimPolicy` (`Retain` / `Delete`, K8s-PV vocabulary matching the issue's `reclaimPolicy: Retain` spelling) in v1beta1 + internal model + both conversion directions; parser rejects a typo'd policy.
- **Persistence:** a Retain volume gets a daemon-owned reclaim manifest; `GetVolume`/`ListVolumes` echo the policy back, `DeleteVolume` drops it.
- **Cascade:** all three purge paths (`purge_stack`/`space`/`realm`) delegate to a shared `reclaimScopeMetadata` helper that selectively preserves retained volumes; a scope with none falls through to the original blunt `os.RemoveAll`.

## Design decision — where a Retain volume survives, and where the policy lives

The issue flags two real design calls; both documented here for reviewer pushback.

**1. Survival location: in-place, at original coordinates.** A retained volume stays exactly where it was (`<scope>/volumes/<name>`). Cascade purge removes the scope's own `metadata.json`, child scopes, secrets/blueprints/configs, and non-retained volumes, but preserves the skeleton dirs down to each retained volume. Because scope existence is gated on `metadata.json` (`ListSpaces`/`ListStacks`/`ListCells` skip dirs that fail `read*Internal`), the purged scope correctly reports **gone** even though its skeleton dir survives to host the volume — no phantom scope. Meanwhile `ListVolumes`/`GetVolume`/`DeleteVolume` walk by directory presence, so the retained volume stays discoverable and deletable at its original realm/space/stack coordinates. Rejected alternatives: *relocation to a parent scope* (mutates the volume's scope identity, and a realm-scoped volume has no parent) and *refusing the purge* (contradicts the AC's "reclaim everything else in the scope").

**2. Policy persistence: a root-only sibling manifest, not inside the volume dir.** Step 4 (#1016) mounts **the volume's own directory** (`<scope>/volumes/<name>`) read-write into the container, so a manifest stored inside it would both leak into the container mount and be tamperable by the mounting container — unacceptable for a retention guarantee. Instead the policy persists at `<scope>/volume-meta/<name>.json`, a new reserved per-scope subdir (`consts.KukeonVolumeMetaSubdir`, added to the single-source-of-truth `reservedScopeSubdirs` set per its documented extension point) that is root-only (0o700/0o600), collision-proof (the `.json` file can never clash with a volume *directory*), and enumeration-invisible (the volumes/ walker collects directories; scope walkers gate on `metadata.json`). A manifest is written **only** for a Retain volume, so a scope with no retained volume creates no `volume-meta/` artifacts and its cascade stays byte-identical to step 1.

## Test plan

- [x] `make test` — full CI unit suite, **pass** (exit 0).
- [x] `go build ./...` / `go vet ./...` (GOWORK=off, per the workspace's single-module resolution) — clean.
- [x] New runner tests: `Retain` survives each of the three cascade paths (stack/space/realm) via the shared `reclaimScopeMetadata`; a deeply-nested (stack-scoped) `Retain` survives a *realm* purge; default-policy volumes + non-volume scope contents are still fully reclaimed; a sibling-scope retained volume is untouched; post-purge `GetVolume`/`ListVolumes`/`DeleteVolume` work.
- [x] New persistence test: Retain writes a root-only manifest `GetVolume` echoes back; re-applying with `Delete` drops it; a corrupt manifest surfaces `ErrGetVolume` rather than silently downgrading.
- [x] New conversion + parser-validation tests (reclaimPolicy round-trips both directions; typo rejected; omitted/`Retain`/`Delete` accepted).
- [ ] `make dev-init` smoke — **environment-blocked, not run to completion.** The image-build phase fails at `RUN go mod download` with `no space left on device` inside the BuildKit build sandbox (the host `/` has 57G free; the sandbox's `/go/pkg/mod` is separately bounded). Reproduced on two consecutive runs; freeing 3G of host go-build cache did not help because the limit is inside the sandbox, not the host. The failure is at dependency download, before any changed source compiles into the image, so it is independent of this change and reproduces identically on `main`. The dev-init nested-mode safety held ("parent attach plumbing still intact"). dev-init bootstraps realms and never creates volumes or purges scopes, so it does not exercise this PR's reclaim logic; the cascade paths are covered by the runner unit tests above (the same granularity step 1's `TestVolume_ReclaimedByScopeCascade` used).

Closes #1237