### PR TITLE
fix: guard volume lookup path segments

### DIFF
--- a/internal/controller/volume.go
+++ b/internal/controller/volume.go
@@ -19,6 +19,7 @@ package controller
 import (
 	"errors"
 	"fmt"
+	"path/filepath"
 	"strings"
 
 	applypkg "github.com/eminwux/kukeon/internal/controller/apply"
@@ -142,11 +143,42 @@ func validateVolumeLookup(md intmodel.VolumeMetadata) error {
 	if strings.TrimSpace(md.Name) == "" {
 		return errdefs.ErrVolumeNameRequired
 	}
-	if strings.TrimSpace(md.Realm) == "" {
+	name := strings.TrimSpace(md.Name)
+	realm := strings.TrimSpace(md.Realm)
+	space := strings.TrimSpace(md.Space)
+	stack := strings.TrimSpace(md.Stack)
+
+	if realm == "" {
 		return errdefs.ErrVolumeRealmRequired
 	}
-	if strings.TrimSpace(md.Stack) != "" && strings.TrimSpace(md.Space) == "" {
+	if stack != "" && space == "" {
 		return fmt.Errorf("%w (stack set without space)", errdefs.ErrVolumeScopeIncomplete)
+	}
+	for _, seg := range []struct{ field, value string }{
+		{"metadata.name", name},
+		{"metadata.realm", realm},
+		{"metadata.space", space},
+		{"metadata.stack", stack},
+	} {
+		if err := validateVolumeSegment(seg.value); err != nil {
+			return fmt.Errorf("%w (%s)", err, seg.field)
+		}
+	}
+	return nil
+}
+
+func validateVolumeSegment(value string) error {
+	if value == "" {
+		return nil
+	}
+	if value == "." || value == ".." {
+		return errdefs.ErrVolumeCoordUnsafe
+	}
+	if strings.ContainsRune(value, 0) ||
+		strings.ContainsRune(value, '/') ||
+		strings.ContainsRune(value, '\\') ||
+		strings.ContainsRune(value, filepath.Separator) {
+		return errdefs.ErrVolumeCoordUnsafe
 	}
 	return nil
 }

--- a/internal/controller/volume_test.go
+++ b/internal/controller/volume_test.go
@@ -83,6 +83,43 @@ func TestGetVolume_NameRequired(t *testing.T) {
 	}
 }
 
+// TestGetVolume_RejectsUnsafeLookupSegments confirms imperative lookups apply
+// the same path-segment guard as the apply parser before reaching the runner.
+func TestGetVolume_RejectsUnsafeLookupSegments(t *testing.T) {
+	ctrl := setupTestController(t, &fakeRunner{})
+
+	tests := []struct {
+		name string
+		md   intmodel.VolumeMetadata
+	}{
+		{
+			name: "name slash",
+			md:   intmodel.VolumeMetadata{Name: "data/escape", Realm: "default"},
+		},
+		{
+			name: "realm dotdot",
+			md:   intmodel.VolumeMetadata{Name: "data", Realm: ".."},
+		},
+		{
+			name: "space backslash",
+			md:   intmodel.VolumeMetadata{Name: "data", Realm: "default", Space: `bad\space`},
+		},
+		{
+			name: "stack nul",
+			md:   intmodel.VolumeMetadata{Name: "data", Realm: "default", Space: "agents", Stack: "stack\x00bad"},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := ctrl.GetVolume(intmodel.Volume{Metadata: tc.md})
+			if !errors.Is(err, errdefs.ErrVolumeCoordUnsafe) {
+				t.Fatalf("GetVolume() error = %v, want ErrVolumeCoordUnsafe", err)
+			}
+		})
+	}
+}
+
 // TestDeleteVolume_NotFound confirms an absent volume surfaces a clear "not
 // found" error rather than a silent success.
 func TestDeleteVolume_NotFound(t *testing.T) {
@@ -117,6 +154,18 @@ func TestDeleteVolume_Success(t *testing.T) {
 	}
 	if !res.Deleted {
 		t.Errorf("Deleted = false, want true")
+	}
+}
+
+// TestDeleteVolume_RejectsUnsafeLookupSegment confirms delete uses the shared
+// lookup guard before a raw name can reach fs.VolumePath via the runner.
+func TestDeleteVolume_RejectsUnsafeLookupSegment(t *testing.T) {
+	ctrl := setupTestController(t, &fakeRunner{})
+	_, err := ctrl.DeleteVolume(intmodel.Volume{
+		Metadata: intmodel.VolumeMetadata{Name: "..", Realm: "default"},
+	})
+	if !errors.Is(err, errdefs.ErrVolumeCoordUnsafe) {
+		t.Errorf("DeleteVolume(unsafe name) = %v, want ErrVolumeCoordUnsafe", err)
 	}
 }
 
@@ -204,6 +253,18 @@ func TestCreateVolume_NameRequired(t *testing.T) {
 	_, err := ctrl.CreateVolume(intmodel.Volume{Metadata: intmodel.VolumeMetadata{Realm: "default"}})
 	if !errors.Is(err, errdefs.ErrVolumeNameRequired) {
 		t.Errorf("CreateVolume(no name) = %v, want ErrVolumeNameRequired", err)
+	}
+}
+
+// TestCreateVolume_RejectsUnsafeLookupSegment confirms create also shares the
+// daemon-side segment guard before ReconcileVolume reaches WriteVolume.
+func TestCreateVolume_RejectsUnsafeLookupSegment(t *testing.T) {
+	ctrl := setupTestController(t, &fakeRunner{})
+	_, err := ctrl.CreateVolume(intmodel.Volume{
+		Metadata: intmodel.VolumeMetadata{Name: "data", Realm: "default", Space: "."},
+	})
+	if !errors.Is(err, errdefs.ErrVolumeCoordUnsafe) {
+		t.Errorf("CreateVolume(unsafe space) = %v, want ErrVolumeCoordUnsafe", err)
 	}
 }
 


### PR DESCRIPTION
## Summary
- add controller-side volume segment validation for lookup paths before runner access
- cover unsafe name/realm/space/stack inputs through create/get/delete volume controller methods

## Test plan
- [x] `GOWORK=off go test ./internal/controller`
- [x] `make test-root`
- [x] `make test-kukebuild`

Note: bare `go test ./internal/controller` fails in workspace mode on the existing root `go.work` dependency union with `github.com/containerd/cgroups/v2` (`cannot use pids.Limit ... as int64`). The Makefile documents and exports `GOWORK=off`, which is the repo/CI path used above.

Closes #1247
