### PR TITLE
feat: add volumeRef container mount kind (step 4)

### DIFF
--- a/internal/apischeme/scheme.go
+++ b/internal/apischeme/scheme.go
@@ -18,6 +18,8 @@ package apischeme
 
 import (
 	"fmt"
+	"path/filepath"
+	"strings"
 
 	"github.com/eminwux/kukeon/internal/errdefs"
 	intmodel "github.com/eminwux/kukeon/internal/modelhub"
@@ -389,6 +391,9 @@ func ConvertContainerDocToInternal(in ext.ContainerDoc) (intmodel.Container, err
 		if err := validateContainerGit(in.Spec); err != nil {
 			return intmodel.Container{}, err
 		}
+		if err := validateContainerVolumes(in.Spec); err != nil {
+			return intmodel.Container{}, err
+		}
 		return intmodel.Container{
 			Metadata: intmodel.ContainerMetadata{
 				Name:   in.Metadata.Name,
@@ -747,6 +752,114 @@ func validateContainerCreateStagePersistence(spec ext.ContainerSpec) error {
 			"survive container recreate, or move the work into a runOn: %q stage",
 		spec.ID, ext.RunOnCreate, ext.RunOnStart,
 	)
+}
+
+// validateContainerVolumes enforces the per-kind VolumeMount contract, with the
+// volume-reference (kind: volume) case the focus of step 4 (#1016). The bind
+// and tmpfs kinds keep their historical lenient handling — an empty/relative
+// bind source is still skipped downstream rather than rejected here, so existing
+// specs are unaffected — except that a volumeRef block is only ever valid on a
+// volume-kind mount. The volume kind requires exactly one of a same-scope
+// `source: <name>` or a cross-scope `volumeRef:`, a name (not an absolute path)
+// for the same-scope form, a complete-and-safe ref scope for the cross-scope
+// form, and an absolute Target.
+func validateContainerVolumes(spec ext.ContainerSpec) error {
+	for i, v := range spec.Volumes {
+		if v.VolumeRef != nil && v.Kind != ext.VolumeKindVolume {
+			return fmt.Errorf(
+				"container %q volume %d: volumeRef is only valid on a kind: volume mount",
+				spec.ID, i,
+			)
+		}
+		switch v.Kind {
+		case ext.VolumeKindVolume:
+			if err := validateVolumeKindMount(v); err != nil {
+				return fmt.Errorf("container %q volume %d: %w", spec.ID, i, err)
+			}
+		case ext.VolumeKindTmpfs:
+			if v.Source != "" {
+				return fmt.Errorf("container %q volume %d: %w", spec.ID, i, errdefs.ErrVolumeTmpfsSourceForbidden)
+			}
+		case "", ext.VolumeKindBind:
+			// Lenient: an empty/relative bind source is skipped by the OCI
+			// mount builder, not rejected — preserving pre-#1016 behavior.
+		default:
+			return fmt.Errorf("container %q volume %d: %w (got %q)", spec.ID, i, errdefs.ErrVolumeKindUnknown, v.Kind)
+		}
+	}
+	return nil
+}
+
+// validateVolumeKindMount validates a single kind: volume VolumeMount: exactly
+// one of Source (same-scope name) or VolumeRef (cross-scope) is set, a same-
+// scope Source is a name rather than an absolute path, a VolumeRef carries a
+// complete and path-safe scope, and the Target is absolute.
+func validateVolumeKindMount(v ext.VolumeMount) error {
+	hasSource := strings.TrimSpace(v.Source) != ""
+	hasRef := v.VolumeRef != nil
+	switch {
+	case hasSource && hasRef:
+		return errdefs.ErrVolumeRefSourceExclusive
+	case !hasSource && !hasRef:
+		return errdefs.ErrVolumeRefSourceMissing
+	}
+	if hasSource {
+		if filepath.IsAbs(v.Source) {
+			return errdefs.ErrVolumeSourceNotName
+		}
+		if !volumeSegmentSafe(v.Source) {
+			return errdefs.ErrVolumeCoordUnsafe
+		}
+	}
+	if hasRef {
+		if err := validateVolumeRefScope(*v.VolumeRef); err != nil {
+			return err
+		}
+	}
+	if strings.TrimSpace(v.Target) == "" {
+		return errdefs.ErrVolumeTargetRequired
+	}
+	if !filepath.IsAbs(v.Target) {
+		return errdefs.ErrVolumeTargetNotAbsolute
+	}
+	return nil
+}
+
+// validateVolumeRefScope enforces the VolumeRef scope contract: Name and Realm
+// are mandatory, a deeper coordinate requires every shallower one, and every
+// coordinate must be path-safe (no "/", "..", or NUL that would escape the
+// volumes tree once fs.VolumePath joins it). Mirrors the parser's
+// validateVolumeScope, bounded at stack depth — a Volume is never cell-scoped.
+func validateVolumeRefScope(ref ext.VolumeRef) error {
+	name := strings.TrimSpace(ref.Name)
+	realm := strings.TrimSpace(ref.Realm)
+	space := strings.TrimSpace(ref.Space)
+	stack := strings.TrimSpace(ref.Stack)
+	if name == "" {
+		return errdefs.ErrVolumeRefNameRequired
+	}
+	if realm == "" {
+		return errdefs.ErrVolumeRefRealmRequired
+	}
+	if stack != "" && space == "" {
+		return errdefs.ErrVolumeRefScopeIncomplete
+	}
+	for _, seg := range []string{name, realm, space, stack} {
+		if seg != "" && !volumeSegmentSafe(seg) {
+			return errdefs.ErrVolumeCoordUnsafe
+		}
+	}
+	return nil
+}
+
+// volumeSegmentSafe reports whether a volume name or scope coordinate is safe to
+// filepath.Join into the volumes tree — no path separator, parent-dir token, or
+// NUL that would let the resolved mount escape its scope.
+func volumeSegmentSafe(seg string) bool {
+	if seg == "." || seg == ".." {
+		return false
+	}
+	return !strings.ContainsAny(seg, "/\x00") && !strings.Contains(seg, "..")
 }
 
 // validateTtyLogLevel accepts the empty string (the daemon defaults to
@@ -1317,6 +1430,7 @@ func volumeMountsToInternal(in []ext.VolumeMount) []intmodel.VolumeMount {
 			Kind:      intmodel.VolumeKind(v.Kind),
 			Source:    v.Source,
 			Target:    v.Target,
+			VolumeRef: volumeRefToInternal(v.VolumeRef),
 			ReadOnly:  v.ReadOnly,
 			SizeBytes: v.SizeBytes,
 			Mode:      v.Mode,
@@ -1335,12 +1449,40 @@ func volumeMountsToExternal(in []intmodel.VolumeMount) []ext.VolumeMount {
 			Kind:      ext.VolumeKind(v.Kind),
 			Source:    v.Source,
 			Target:    v.Target,
+			VolumeRef: volumeRefToExternal(v.VolumeRef),
 			ReadOnly:  v.ReadOnly,
 			SizeBytes: v.SizeBytes,
 			Mode:      v.Mode,
 		}
 	}
 	return out
+}
+
+// volumeRefToInternal converts an external VolumeRef to the internal hub type,
+// preserving nil so a same-scope (bare-source) mount stays ref-less.
+func volumeRefToInternal(in *ext.VolumeRef) *intmodel.VolumeRef {
+	if in == nil {
+		return nil
+	}
+	return &intmodel.VolumeRef{
+		Name:  in.Name,
+		Realm: in.Realm,
+		Space: in.Space,
+		Stack: in.Stack,
+	}
+}
+
+// volumeRefToExternal is the inverse of volumeRefToInternal.
+func volumeRefToExternal(in *intmodel.VolumeRef) *ext.VolumeRef {
+	if in == nil {
+		return nil
+	}
+	return &ext.VolumeRef{
+		Name:  in.Name,
+		Realm: in.Realm,
+		Space: in.Space,
+		Stack: in.Stack,
+	}
 }
 
 // convertContainerStatusesToInternal converts a slice of external ContainerStatus to internal ContainerStatus.
@@ -1398,6 +1540,9 @@ func ConvertCellDocToInternal(in ext.CellDoc) (intmodel.Cell, error) {
 				return intmodel.Cell{}, err
 			}
 			if err := validateContainerGit(c); err != nil {
+				return intmodel.Cell{}, err
+			}
+			if err := validateContainerVolumes(c); err != nil {
 				return intmodel.Cell{}, err
 			}
 		}

--- a/internal/apischeme/scheme_test.go
+++ b/internal/apischeme/scheme_test.go
@@ -897,6 +897,165 @@ func TestContainerRoundTripVolumeKindTmpfsV1Beta1(t *testing.T) {
 	}
 }
 
+// TestContainerRoundTripVolumeKindVolumeV1Beta1 pins the step-4 (#1016) volume
+// reference surface through Normalize → controller → Build: a same-scope
+// `source: <name>` and a cross-scope `volumeRef:` both survive the round trip
+// with Kind, Source, and the VolumeRef scope coordinates intact.
+func TestContainerRoundTripVolumeKindVolumeV1Beta1(t *testing.T) {
+	input := ext.ContainerDoc{
+		APIVersion: ext.APIVersionV1Beta1,
+		Kind:       ext.KindContainer,
+		Metadata:   ext.ContainerMetadata{Name: "container-vol"},
+		Spec: ext.ContainerSpec{
+			ID:      "container-vol",
+			RealmID: "realm0",
+			SpaceID: "space0",
+			StackID: "stack0",
+			CellID:  "cell0",
+			Image:   "alpine:latest",
+			Volumes: []ext.VolumeMount{
+				{Kind: ext.VolumeKindVolume, Source: "data", Target: "/data"},
+				{
+					Kind:      ext.VolumeKindVolume,
+					Target:    "/cache",
+					ReadOnly:  true,
+					VolumeRef: &ext.VolumeRef{Name: "cache", Realm: "shared", Space: "team"},
+				},
+			},
+		},
+	}
+
+	internal, version, err := apischeme.NormalizeContainer(input)
+	if err != nil {
+		t.Fatalf("NormalizeContainer: %v", err)
+	}
+	if internal.Spec.Volumes[0].Kind != intmodel.VolumeKindVolume ||
+		internal.Spec.Volumes[0].Source != "data" {
+		t.Errorf("internal volume[0] = %+v, want same-scope volume kind data", internal.Spec.Volumes[0])
+	}
+	ref := internal.Spec.Volumes[1].VolumeRef
+	if ref == nil || ref.Name != "cache" || ref.Realm != "shared" || ref.Space != "team" {
+		t.Errorf("internal volume[1].VolumeRef = %+v, want shared/team/cache", ref)
+	}
+
+	output, err := apischeme.BuildContainerExternalFromInternal(internal, version)
+	if err != nil {
+		t.Fatalf("BuildContainerExternalFromInternal: %v", err)
+	}
+	if output.Spec.Volumes[0] != input.Spec.Volumes[0] {
+		t.Errorf("volume[0] round trip = %+v, want %+v", output.Spec.Volumes[0], input.Spec.Volumes[0])
+	}
+	gotRef := output.Spec.Volumes[1].VolumeRef
+	if gotRef == nil || *gotRef != *input.Spec.Volumes[1].VolumeRef {
+		t.Errorf("volume[1].VolumeRef round trip = %+v, want %+v", gotRef, input.Spec.Volumes[1].VolumeRef)
+	}
+	if gotRef == input.Spec.Volumes[1].VolumeRef {
+		t.Error("VolumeRef round trip shares the pointer with the input — conversion must deep-copy")
+	}
+}
+
+func TestValidateContainerVolumes(t *testing.T) {
+	mk := func(v ext.VolumeMount) ext.ContainerDoc {
+		return ext.ContainerDoc{
+			APIVersion: ext.APIVersionV1Beta1,
+			Kind:       ext.KindContainer,
+			Metadata:   ext.ContainerMetadata{Name: "c"},
+			Spec: ext.ContainerSpec{
+				ID: "c", RealmID: "r", SpaceID: "s", StackID: "st", CellID: "cl",
+				Image: "alpine", Volumes: []ext.VolumeMount{v},
+			},
+		}
+	}
+	tests := []struct {
+		name    string
+		mount   ext.VolumeMount
+		wantErr error
+	}{
+		{
+			name:  "same-scope source ok",
+			mount: ext.VolumeMount{Kind: ext.VolumeKindVolume, Source: "data", Target: "/data"},
+		},
+		{
+			name:  "cross-scope ref ok",
+			mount: ext.VolumeMount{Kind: ext.VolumeKindVolume, Target: "/c", VolumeRef: &ext.VolumeRef{Name: "n", Realm: "r"}},
+		},
+		{
+			name:    "source and ref exclusive",
+			mount:   ext.VolumeMount{Kind: ext.VolumeKindVolume, Source: "data", Target: "/d", VolumeRef: &ext.VolumeRef{Name: "n", Realm: "r"}},
+			wantErr: errdefs.ErrVolumeRefSourceExclusive,
+		},
+		{
+			name:    "neither source nor ref",
+			mount:   ext.VolumeMount{Kind: ext.VolumeKindVolume, Target: "/d"},
+			wantErr: errdefs.ErrVolumeRefSourceMissing,
+		},
+		{
+			name:    "absolute source rejected",
+			mount:   ext.VolumeMount{Kind: ext.VolumeKindVolume, Source: "/abs/path", Target: "/d"},
+			wantErr: errdefs.ErrVolumeSourceNotName,
+		},
+		{
+			name:    "unsafe source rejected",
+			mount:   ext.VolumeMount{Kind: ext.VolumeKindVolume, Source: "../escape", Target: "/d"},
+			wantErr: errdefs.ErrVolumeCoordUnsafe,
+		},
+		{
+			name:    "missing target",
+			mount:   ext.VolumeMount{Kind: ext.VolumeKindVolume, Source: "data"},
+			wantErr: errdefs.ErrVolumeTargetRequired,
+		},
+		{
+			name:    "relative target rejected",
+			mount:   ext.VolumeMount{Kind: ext.VolumeKindVolume, Source: "data", Target: "rel"},
+			wantErr: errdefs.ErrVolumeTargetNotAbsolute,
+		},
+		{
+			name:    "ref missing realm",
+			mount:   ext.VolumeMount{Kind: ext.VolumeKindVolume, Target: "/d", VolumeRef: &ext.VolumeRef{Name: "n"}},
+			wantErr: errdefs.ErrVolumeRefRealmRequired,
+		},
+		{
+			name:    "ref incomplete scope",
+			mount:   ext.VolumeMount{Kind: ext.VolumeKindVolume, Target: "/d", VolumeRef: &ext.VolumeRef{Name: "n", Realm: "r", Stack: "st"}},
+			wantErr: errdefs.ErrVolumeRefScopeIncomplete,
+		},
+		{
+			name:    "volumeRef on bind kind rejected",
+			mount:   ext.VolumeMount{Kind: ext.VolumeKindBind, Source: "/a", Target: "/b", VolumeRef: &ext.VolumeRef{Name: "n", Realm: "r"}},
+			wantErr: nil, // distinct inline error, asserted as non-nil below
+		},
+		{
+			name:    "tmpfs with source forbidden",
+			mount:   ext.VolumeMount{Kind: ext.VolumeKindTmpfs, Source: "/x", Target: "/t"},
+			wantErr: errdefs.ErrVolumeTmpfsSourceForbidden,
+		},
+		{
+			name:    "unknown kind",
+			mount:   ext.VolumeMount{Kind: "bogus", Target: "/t"},
+			wantErr: errdefs.ErrVolumeKindUnknown,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			_, _, err := apischeme.NormalizeContainer(mk(tc.mount))
+			switch {
+			case tc.name == "volumeRef on bind kind rejected":
+				if err == nil {
+					t.Errorf("expected error for volumeRef on bind kind, got nil")
+				}
+			case tc.wantErr == nil:
+				if err != nil {
+					t.Errorf("unexpected error: %v", err)
+				}
+			default:
+				if !errors.Is(err, tc.wantErr) {
+					t.Errorf("err = %v, want %v", err, tc.wantErr)
+				}
+			}
+		})
+	}
+}
+
 // TestCellRoundTripVolumeKindTmpfsV1Beta1 mirrors the standalone Container
 // test for the nested-container path that `apply -f cell.yaml` and the
 // CellProfile materializer travel: a tmpfs entry inside CellSpec.Containers[]

--- a/internal/controller/controller_test.go
+++ b/internal/controller/controller_test.go
@@ -73,10 +73,11 @@ type fakeRunner struct {
 	DeleteBlueprintFn func(bp intmodel.CellBlueprint) error
 
 	// Volume methods
-	WriteVolumeFn  func(volume intmodel.Volume) (bool, error)
-	GetVolumeFn    func(volume intmodel.Volume) (intmodel.Volume, error)
-	ListVolumesFn  func(realmName, spaceName, stackName string) ([]intmodel.Volume, error)
-	DeleteVolumeFn func(volume intmodel.Volume) error
+	WriteVolumeFn             func(volume intmodel.Volume) (bool, error)
+	GetVolumeFn               func(volume intmodel.Volume) (intmodel.Volume, error)
+	ListVolumesFn             func(realmName, spaceName, stackName string) ([]intmodel.Volume, error)
+	DeleteVolumeFn            func(volume intmodel.Volume) error
+	VolumeMountedByLiveCellFn func(volume intmodel.Volume) (string, bool, error)
 
 	// Config methods
 	WriteConfigFn         func(config intmodel.CellConfig) (bool, error)
@@ -380,6 +381,15 @@ func (f *fakeRunner) DeleteVolume(volume intmodel.Volume) error {
 		return f.DeleteVolumeFn(volume)
 	}
 	return errors.New("unexpected call to DeleteVolume")
+}
+
+func (f *fakeRunner) VolumeMountedByLiveCell(volume intmodel.Volume) (string, bool, error) {
+	if f.VolumeMountedByLiveCellFn != nil {
+		return f.VolumeMountedByLiveCellFn(volume)
+	}
+	// Default: nothing mounts it, so the delete gate is a no-op unless a test
+	// opts in by setting VolumeMountedByLiveCellFn.
+	return "", false, nil
 }
 
 // Config methods

--- a/internal/controller/runner/runner.go
+++ b/internal/controller/runner/runner.go
@@ -192,6 +192,12 @@ type Runner interface {
 	// scoped Volume (issue #1018). Returns errdefs.ErrVolumeNotFound when the
 	// directory is absent.
 	DeleteVolume(volume intmodel.Volume) error
+	// VolumeMountedByLiveCell reports the scoped reference of the first running
+	// cell that mounts the given Volume via a kind: volume mount, gating
+	// `kuke delete volume` against a live mount (issue #1016). Returns
+	// (ref, true, nil) naming the mounting cell when one is found, ("", false,
+	// nil) when no running cell mounts it.
+	VolumeMountedByLiveCell(volume intmodel.Volume) (cellRef string, mounted bool, err error)
 
 	// WriteConfig persists a `kind: CellConfig`'s serialized document to the
 	// daemon-managed, root-owned, world-readable file under the scope's metadata

--- a/internal/controller/runner/volume.go
+++ b/internal/controller/runner/volume.go
@@ -21,7 +21,9 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
+	"github.com/eminwux/kukeon/internal/ctr"
 	"github.com/eminwux/kukeon/internal/errdefs"
 	intmodel "github.com/eminwux/kukeon/internal/modelhub"
 	"github.com/eminwux/kukeon/internal/util/fs"
@@ -299,4 +301,63 @@ func (r *Exec) DeleteVolume(volume intmodel.Volume) error {
 		"stack", md.Stack,
 	)
 	return nil
+}
+
+// VolumeMountedByLiveCell scans every cell across all realms for a running cell
+// that mounts the given Volume through a kind: volume mount, the live-reference
+// gate `kuke delete volume` consults (issue #1016). A cell counts as a live
+// mounter when its last-reconciled state is Ready and one of its container
+// specs declares a kind: volume mount that resolves — via the same scope walk
+// the create path uses — to this Volume's exact scope + name. The first match
+// short-circuits and returns the cell's scoped reference (realm/space/stack/
+// cell); a mount that fails to resolve is skipped rather than failing the gate
+// (it cannot be referencing the still-present target). Returns ("", false, nil)
+// when no running cell mounts the Volume.
+func (r *Exec) VolumeMountedByLiveCell(volume intmodel.Volume) (string, bool, error) {
+	cells, err := r.ListCells("", "", "")
+	if err != nil {
+		return "", false, fmt.Errorf("%w: enumerate cells: %w", errdefs.ErrDeleteVolume, err)
+	}
+	target := volume.Metadata
+	for i := range cells {
+		cell := cells[i]
+		if cell.Status.State != intmodel.CellStateReady {
+			continue
+		}
+		scope := ctr.VolumeScope{
+			Realm: cell.Spec.RealmName,
+			Space: cell.Spec.SpaceName,
+			Stack: cell.Spec.StackName,
+		}
+		for ci := range cell.Spec.Containers {
+			for _, m := range cell.Spec.Containers[ci].Volumes {
+				if m.Kind != intmodel.VolumeKindVolume {
+					continue
+				}
+				resolved, rerr := ctr.ResolveVolumeMount(r.opts.RunPath, scope, m)
+				if rerr != nil {
+					continue
+				}
+				if resolved.Realm == target.Realm &&
+					resolved.Space == target.Space &&
+					resolved.Stack == target.Stack &&
+					resolved.Name == target.Name {
+					return cellScopedRef(scope, cell.Metadata.Name), true, nil
+				}
+			}
+		}
+	}
+	return "", false, nil
+}
+
+// cellScopedRef renders a cell's realm/space/stack/name as a slash-joined
+// reference for the in-use error message, skipping empty scope coordinates.
+func cellScopedRef(scope ctr.VolumeScope, cellName string) string {
+	parts := make([]string, 0, 4)
+	for _, p := range []string{scope.Realm, scope.Space, scope.Stack, cellName} {
+		if p != "" {
+			parts = append(parts, p)
+		}
+	}
+	return strings.Join(parts, "/")
 }

--- a/internal/controller/runner/volume_ref_gate_test.go
+++ b/internal/controller/runner/volume_ref_gate_test.go
@@ -1,0 +1,188 @@
+//go:build !integration
+
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+//nolint:testpackage // exercises the unexported VolumeMountedByLiveCell path against a temp RunPath
+package runner
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/eminwux/kukeon/internal/metadata"
+	intmodel "github.com/eminwux/kukeon/internal/modelhub"
+	"github.com/eminwux/kukeon/internal/util/fs"
+	v1beta1 "github.com/eminwux/kukeon/pkg/api/model/v1beta1"
+)
+
+// seedVolumeRefCell writes a cell metadata doc with a single workload container
+// that mounts the named same-scope Volume via a kind: volume mount, in the
+// given persisted cell state. ListCells reads it back through the validating
+// converter, so the mount must be a valid volume reference.
+func seedVolumeRefCell(
+	t *testing.T,
+	r *Exec,
+	realm, space, stack, cellName, volumeName string,
+	state v1beta1.CellState,
+) {
+	t.Helper()
+	doc := v1beta1.CellDoc{
+		APIVersion: v1beta1.APIVersionV1Beta1,
+		Kind:       v1beta1.KindCell,
+		Metadata:   v1beta1.CellMetadata{Name: cellName},
+		Spec: v1beta1.CellSpec{
+			ID:      cellName,
+			RealmID: realm,
+			SpaceID: space,
+			StackID: stack,
+			Containers: []v1beta1.ContainerSpec{
+				{
+					ID:      "workload",
+					RealmID: realm,
+					SpaceID: space,
+					StackID: stack,
+					CellID:  cellName,
+					Image:   "alpine:latest",
+					Volumes: []v1beta1.VolumeMount{
+						{Kind: v1beta1.VolumeKindVolume, Source: volumeName, Target: "/data"},
+					},
+				},
+			},
+		},
+		Status: v1beta1.CellStatus{State: state},
+	}
+	path := fs.CellMetadataPath(r.opts.RunPath, realm, space, stack, cellName)
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("mkdir cell metadata dir: %v", err)
+	}
+	if err := metadata.WriteMetadata(r.ctx, r.logger, doc, path); err != nil {
+		t.Fatalf("write cell metadata: %v", err)
+	}
+}
+
+func TestVolumeMountedByLiveCell_ReadyCellMountingRefuses(t *testing.T) {
+	runPath := t.TempDir()
+	r := newMetadataTestExec(t, runPath, time.Now())
+
+	vol := intmodel.Volume{Metadata: intmodel.VolumeMetadata{Name: "data", Realm: "default", Space: "app", Stack: "web"}}
+	if _, err := r.WriteVolume(vol); err != nil {
+		t.Fatalf("WriteVolume: %v", err)
+	}
+	seedVolumeRefCell(t, r, "default", "app", "web", "db", "data", v1beta1.CellStateReady)
+
+	ref, mounted, err := r.VolumeMountedByLiveCell(vol)
+	if err != nil {
+		t.Fatalf("VolumeMountedByLiveCell: %v", err)
+	}
+	if !mounted {
+		t.Fatal("mounted = false, want true for a Ready cell mounting the volume")
+	}
+	if want := "default/app/web/db"; ref != want {
+		t.Errorf("cell ref = %q, want %q", ref, want)
+	}
+}
+
+func TestVolumeMountedByLiveCell_StoppedCellAllows(t *testing.T) {
+	runPath := t.TempDir()
+	r := newMetadataTestExec(t, runPath, time.Now())
+
+	vol := intmodel.Volume{Metadata: intmodel.VolumeMetadata{Name: "data", Realm: "default", Space: "app", Stack: "web"}}
+	if _, err := r.WriteVolume(vol); err != nil {
+		t.Fatalf("WriteVolume: %v", err)
+	}
+	// A stopped cell that references the volume must not gate its delete.
+	seedVolumeRefCell(t, r, "default", "app", "web", "db", "data", v1beta1.CellStateStopped)
+
+	_, mounted, err := r.VolumeMountedByLiveCell(vol)
+	if err != nil {
+		t.Fatalf("VolumeMountedByLiveCell: %v", err)
+	}
+	if mounted {
+		t.Error("mounted = true for a stopped cell, want false (gate keys off running state)")
+	}
+}
+
+func TestVolumeMountedByLiveCell_DifferentVolumeAllows(t *testing.T) {
+	runPath := t.TempDir()
+	r := newMetadataTestExec(t, runPath, time.Now())
+
+	target := intmodel.Volume{Metadata: intmodel.VolumeMetadata{Name: "data", Realm: "default", Space: "app", Stack: "web"}}
+	other := intmodel.Volume{Metadata: intmodel.VolumeMetadata{Name: "logs", Realm: "default", Space: "app", Stack: "web"}}
+	for _, v := range []intmodel.Volume{target, other} {
+		if _, err := r.WriteVolume(v); err != nil {
+			t.Fatalf("WriteVolume %q: %v", v.Metadata.Name, err)
+		}
+	}
+	// A Ready cell mounts "logs", not the "data" volume we attempt to delete.
+	seedVolumeRefCell(t, r, "default", "app", "web", "db", "logs", v1beta1.CellStateReady)
+
+	_, mounted, err := r.VolumeMountedByLiveCell(target)
+	if err != nil {
+		t.Fatalf("VolumeMountedByLiveCell: %v", err)
+	}
+	if mounted {
+		t.Error("mounted = true, want false — the live cell mounts a different volume")
+	}
+}
+
+// TestVolume_SurvivesCellDelete pins AC #5: a Volume and its contents persist
+// when a cell that mounted it is deleted. The Volume directory lives under the
+// scope's volumes/ tree, never under any cell's metadata subtree, so removing
+// the cell (here, its on-disk metadata directory — the unit-level proxy for
+// `kuke delete cell`) cannot reclaim it, and a new cell referencing the same
+// Volume sees the prior sentinel contents.
+func TestVolume_SurvivesCellDelete(t *testing.T) {
+	runPath := t.TempDir()
+	r := newMetadataTestExec(t, runPath, time.Now())
+
+	vol := intmodel.Volume{Metadata: intmodel.VolumeMetadata{Name: "data", Realm: "default", Space: "app", Stack: "web"}}
+	if _, err := r.WriteVolume(vol); err != nil {
+		t.Fatalf("WriteVolume: %v", err)
+	}
+	volPath := fs.VolumePath(runPath, "default", "app", "web", "data")
+	sentinel := filepath.Join(volPath, "sentinel")
+	if err := os.WriteFile(sentinel, []byte("persisted"), 0o600); err != nil {
+		t.Fatalf("write sentinel: %v", err)
+	}
+
+	// The volume directory must not live under the cell's metadata subtree.
+	cellMetaDir := filepath.Dir(fs.CellMetadataPath(runPath, "default", "app", "web", "db"))
+	if strings.HasPrefix(filepath.Clean(volPath), filepath.Clean(cellMetaDir)+string(filepath.Separator)) {
+		t.Fatalf("volume dir %q lives under cell metadata dir %q — cell delete would reclaim it", volPath, cellMetaDir)
+	}
+
+	// Simulate the cell's deletion by removing its metadata subtree.
+	seedVolumeRefCell(t, r, "default", "app", "web", "db", "data", v1beta1.CellStateReady)
+	if err := os.RemoveAll(cellMetaDir); err != nil {
+		t.Fatalf("remove cell metadata: %v", err)
+	}
+
+	// The volume and its sentinel survive, and remain resolvable for a new cell.
+	got, err := os.ReadFile(sentinel)
+	if err != nil {
+		t.Fatalf("read sentinel after cell delete: %v", err)
+	}
+	if string(got) != "persisted" {
+		t.Errorf("sentinel contents = %q, want %q", got, "persisted")
+	}
+	if _, err := r.GetVolume(vol); err != nil {
+		t.Errorf("GetVolume after cell delete: %v (volume must outlive the cell)", err)
+	}
+}

--- a/internal/controller/volume.go
+++ b/internal/controller/volume.go
@@ -113,14 +113,22 @@ type DeleteVolumeResult struct {
 
 // DeleteVolume removes a single named, scoped Volume's daemon-provisioned
 // directory. Returns a "not found" error when the volume does not exist,
-// matching the DeleteBlueprint contract. There is no live-reference gate in
-// step 1: the container-side mount kind that would reference a Volume lands in
-// step 4 (#1016), where the delete gate against a live mount is exercised.
+// matching the DeleteBlueprint contract. A running cell that mounts the Volume
+// via a kind: volume mount gates the delete (issue #1016): the request is
+// refused with ErrVolumeInUse naming the mounting cell so the directory is
+// never pulled out from under a live mount. A Volume mounted only by stopped
+// cells, or by none, deletes cleanly.
 func (b *Exec) DeleteVolume(volume intmodel.Volume) (DeleteVolumeResult, error) {
 	var res DeleteVolumeResult
 
 	if err := validateVolumeLookup(volume.Metadata); err != nil {
 		return res, err
+	}
+
+	if cellRef, mounted, err := b.runner.VolumeMountedByLiveCell(volume); err != nil {
+		return res, err
+	} else if mounted {
+		return res, fmt.Errorf("%w: mounted by cell %q", errdefs.ErrVolumeInUse, cellRef)
 	}
 
 	if err := b.runner.DeleteVolume(volume); err != nil {

--- a/internal/controller/volume_test.go
+++ b/internal/controller/volume_test.go
@@ -20,6 +20,7 @@ package controller_test
 
 import (
 	"errors"
+	"strings"
 	"testing"
 
 	"github.com/eminwux/kukeon/internal/apply/parser"
@@ -166,6 +167,62 @@ func TestDeleteVolume_RejectsUnsafeLookupSegment(t *testing.T) {
 	})
 	if !errors.Is(err, errdefs.ErrVolumeCoordUnsafe) {
 		t.Errorf("DeleteVolume(unsafe name) = %v, want ErrVolumeCoordUnsafe", err)
+	}
+}
+
+// TestDeleteVolume_InUseRefused pins AC #7 (the delete gate): a Volume mounted
+// by a running cell cannot be deleted. The controller refuses with
+// ErrVolumeInUse naming the mounting cell, and the runner's DeleteVolume is
+// never reached — the directory is left intact under the live mount.
+func TestDeleteVolume_InUseRefused(t *testing.T) {
+	deleteCalled := false
+	mockRunner := &fakeRunner{
+		VolumeMountedByLiveCellFn: func(intmodel.Volume) (string, bool, error) {
+			return "default/app/web/db", true, nil
+		},
+		DeleteVolumeFn: func(intmodel.Volume) error {
+			deleteCalled = true
+			return nil
+		},
+	}
+	ctrl := setupTestController(t, mockRunner)
+
+	res, err := ctrl.DeleteVolume(intmodel.Volume{
+		Metadata: intmodel.VolumeMetadata{Name: "data", Realm: "default"},
+	})
+	if !errors.Is(err, errdefs.ErrVolumeInUse) {
+		t.Fatalf("DeleteVolume(in-use) error = %v, want ErrVolumeInUse", err)
+	}
+	if !strings.Contains(err.Error(), "default/app/web/db") {
+		t.Errorf("error %q does not name the mounting cell", err)
+	}
+	if res.Deleted {
+		t.Errorf("Deleted = true for an in-use volume")
+	}
+	if deleteCalled {
+		t.Errorf("runner.DeleteVolume was called despite the live-mount gate")
+	}
+}
+
+// TestDeleteVolume_NotMountedDeletes confirms the gate is a no-op when no
+// running cell mounts the volume — the delete proceeds to the runner.
+func TestDeleteVolume_NotMountedDeletes(t *testing.T) {
+	mockRunner := &fakeRunner{
+		VolumeMountedByLiveCellFn: func(intmodel.Volume) (string, bool, error) {
+			return "", false, nil
+		},
+		DeleteVolumeFn: func(intmodel.Volume) error { return nil },
+	}
+	ctrl := setupTestController(t, mockRunner)
+
+	res, err := ctrl.DeleteVolume(intmodel.Volume{
+		Metadata: intmodel.VolumeMetadata{Name: "data", Realm: "default"},
+	})
+	if err != nil {
+		t.Fatalf("DeleteVolume() error = %v", err)
+	}
+	if !res.Deleted {
+		t.Errorf("Deleted = false, want true")
 	}
 }
 

--- a/internal/ctr/container.go
+++ b/internal/ctr/container.go
@@ -556,7 +556,7 @@ func (c *client) CreateContainerFromSpec(
 	for _, apply := range opts {
 		apply(&bo)
 	}
-	resolved, err := resolveSecrets(containerdID, containerSpec.Secrets, DefaultSecretsStagingDir, bo.secretRunPath)
+	resolved, err := resolveSecrets(containerdID, containerSpec.Secrets, DefaultSecretsStagingDir, bo.runPath)
 	if err != nil {
 		c.logger.ErrorContext(
 			c.ctx,
@@ -572,6 +572,28 @@ func (c *client) CreateContainerFromSpec(
 	}
 	if len(resolved.MountAdds) > 0 {
 		containerSpec.Volumes = append(containerSpec.Volumes, resolved.MountAdds...)
+	}
+
+	// Resolve kind: volume mounts to their on-disk Volume directories before
+	// building the OCI spec, so the downstream bind emitter sees a plain host
+	// path. A same-scope `source: <name>` walks the container's own scope; a
+	// `volumeRef:` resolves cross-scope. An unknown reference is a hard error
+	// (no auto-create). Specs with no volume reference are returned untouched.
+	volScope := VolumeScope{
+		Realm: containerSpec.RealmName,
+		Space: containerSpec.SpaceName,
+		Stack: containerSpec.StackName,
+	}
+	containerSpec.Volumes, err = resolveVolumeMounts(bo.runPath, volScope, containerSpec.Volumes)
+	if err != nil {
+		c.logger.ErrorContext(
+			c.ctx,
+			"failed to resolve container volume references",
+			"id", containerSpec.ID,
+			"cell", cellID,
+			"err", formatError(err),
+		)
+		return nil, fmt.Errorf("failed to resolve volume references: %w", err)
 	}
 
 	// Convert to ctr.ContainerSpec using BuildContainerSpec

--- a/internal/ctr/spec.go
+++ b/internal/ctr/spec.go
@@ -179,9 +179,12 @@ type BuildOption func(*buildOpts)
 type buildOpts struct {
 	attachable              AttachableInjection
 	defaultMemoryLimitBytes int64
-	secretRunPath           string
-	extraLabels             map[string]string
-	kukeonGroupGID          uint32
+	// runPath is the daemon's RunPath, used to resolve scoped references off
+	// disk: a ContainerSecret.secretRef from its scope's secrets tree (#623)
+	// and a kind: volume VolumeMount from its scope's volumes tree (#1016).
+	runPath        string
+	extraLabels    map[string]string
+	kukeonGroupGID uint32
 }
 
 // WithAttachableInjection configures the host-side paths used when wrapping
@@ -275,16 +278,18 @@ func withKukeonGroupGIDSpecOpt(gid uint32) oci.SpecOpts {
 }
 
 // WithSecretRunPath carries the daemon's RunPath into CreateContainerFromSpec
-// so a ContainerSecret with a secretRef can be resolved from the referenced
-// scope's secrets tree (<RunPath>/data/<scope>/secrets/<name>, issue #619).
-// Has no effect on BuildContainerSpec itself — the value is consumed by
-// resolveSecrets before the OCI spec is built. An empty argument is a no-op so
-// callers can pass it unconditionally; specs that declare no secretRef never
-// touch the path. Issue #623.
+// so scoped references can be resolved off disk before the OCI spec is built: a
+// ContainerSecret with a secretRef from the referenced scope's secrets tree
+// (<RunPath>/data/<scope>/secrets/<name>, issue #619) and a kind: volume
+// VolumeMount from its scope's volumes tree (issue #1016). Has no effect on
+// BuildContainerSpec itself — the value is consumed by resolveSecrets and
+// resolveVolumeMounts. An empty argument is a no-op so callers can pass it
+// unconditionally; specs that declare no scoped reference never touch the path.
+// Issue #623.
 func WithSecretRunPath(runPath string) BuildOption {
 	return func(o *buildOpts) {
 		if runPath != "" {
-			o.secretRunPath = runPath
+			o.runPath = runPath
 		}
 	}
 }
@@ -679,9 +684,12 @@ func cellCgroupsPath(cellCgroupPath, containerdID string) string {
 // VolumeMount.Kind discriminator selects the emitted mount type: empty or
 // VolumeKindBind produces a host bind mount (Source → Target), VolumeKindTmpfs
 // produces an in-memory tmpfs mount at Target with the runtime's standard
-// tmpfs Source. Entries are expected to be already validated (absolute paths
-// for the bind kind; absolute Target for the tmpfs kind). Unknown kinds are
-// skipped silently — validation belongs upstream.
+// tmpfs Source, and VolumeKindVolume — once resolveVolumeMounts has rewritten
+// its Source to the referenced Volume's on-disk directory — emits the same host
+// bind mount as the bind kind (the daemon-managed Volume directory bound
+// read-write at Target). Entries are expected to be already validated and (for
+// the volume kind) already resolved. Unknown kinds are skipped silently —
+// validation belongs upstream.
 func buildVolumeMounts(volumes []intmodel.VolumeMount) []runtimespec.Mount {
 	if len(volumes) == 0 {
 		return nil
@@ -693,7 +701,7 @@ func buildVolumeMounts(volumes []intmodel.VolumeMount) []runtimespec.Mount {
 			if m, ok := tmpfsVolumeMount(v); ok {
 				mounts = append(mounts, m)
 			}
-		case "", intmodel.VolumeKindBind:
+		case "", intmodel.VolumeKindBind, intmodel.VolumeKindVolume:
 			if m, ok := bindVolumeMount(v); ok {
 				mounts = append(mounts, m)
 			}

--- a/internal/ctr/volume_ref.go
+++ b/internal/ctr/volume_ref.go
@@ -1,0 +1,167 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package ctr
+
+import (
+	"errors"
+	"fmt"
+	"os"
+
+	internalerrdefs "github.com/eminwux/kukeon/internal/errdefs"
+	intmodel "github.com/eminwux/kukeon/internal/modelhub"
+	"github.com/eminwux/kukeon/internal/util/fs"
+)
+
+// VolumeScope is the realm/space/stack scope a container resolves a same-scope
+// (bare-source) kind: volume mount against. The scope walk starts at the
+// deepest set coordinate and falls back to shallower ones, so the most-specific
+// Volume of a given name wins — mirroring secret-scope lookup. Step 4 (#1016).
+type VolumeScope struct {
+	Realm string
+	Space string
+	Stack string
+}
+
+// ResolvedVolume is the outcome of resolving a kind: volume VolumeMount: the
+// host directory to bind-mount and the scope coordinates the reference resolved
+// to. The coordinates let the `kuke delete volume` gate match a live mount
+// against the Volume being deleted without re-walking the scope. Step 4 (#1016).
+type ResolvedVolume struct {
+	HostPath string
+	Realm    string
+	Space    string
+	Stack    string
+	Name     string
+}
+
+// ResolveVolumeMount resolves a kind: volume VolumeMount to the on-disk Volume
+// directory under runPath. A bare Source names a Volume in the container's own
+// scope, walked most-specific-first (stack → space → realm); a VolumeRef names
+// one cross-scope by explicit coordinates. The referenced Volume must already
+// exist — there is no auto-create (an unknown name is a hard error, not a
+// silent provision), so a typo'd reference fails fast at container create. A
+// non-volume Kind is not this resolver's concern and yields an error so callers
+// never mis-route a bind/tmpfs mount here. Step 4 (#1016).
+func ResolveVolumeMount(runPath string, scope VolumeScope, mount intmodel.VolumeMount) (ResolvedVolume, error) {
+	if mount.Kind != intmodel.VolumeKindVolume {
+		return ResolvedVolume{}, fmt.Errorf("%w: not a volume-kind mount", internalerrdefs.ErrVolumeKindUnknown)
+	}
+	if runPath == "" {
+		return ResolvedVolume{}, errors.New("cannot resolve volume reference: daemon RunPath is unset")
+	}
+
+	if mount.VolumeRef != nil {
+		ref := mount.VolumeRef
+		path := fs.VolumePath(runPath, ref.Realm, ref.Space, ref.Stack, ref.Name)
+		if !volumeDirExists(path) {
+			return ResolvedVolume{}, fmt.Errorf(
+				"%w: volumeRef %q (realm=%q space=%q stack=%q)",
+				internalerrdefs.ErrVolumeNotFound, ref.Name, ref.Realm, ref.Space, ref.Stack,
+			)
+		}
+		return ResolvedVolume{
+			HostPath: path,
+			Realm:    ref.Realm,
+			Space:    ref.Space,
+			Stack:    ref.Stack,
+			Name:     ref.Name,
+		}, nil
+	}
+
+	// Same-scope name: walk the container's scope most-specific-first.
+	name := mount.Source
+	for _, cand := range volumeScopeCandidates(scope) {
+		path := fs.VolumePath(runPath, cand.Realm, cand.Space, cand.Stack, name)
+		if volumeDirExists(path) {
+			return ResolvedVolume{
+				HostPath: path,
+				Realm:    cand.Realm,
+				Space:    cand.Space,
+				Stack:    cand.Stack,
+				Name:     name,
+			}, nil
+		}
+	}
+	return ResolvedVolume{}, fmt.Errorf(
+		"%w: volume %q not found in scope realm=%q space=%q stack=%q (or any parent scope)",
+		internalerrdefs.ErrVolumeNotFound, name, scope.Realm, scope.Space, scope.Stack,
+	)
+}
+
+// volumeScopeCandidates returns the scope coordinates to probe for a same-scope
+// volume name, deepest first: the container's full (realm, space, stack), then
+// the space scope, then the realm scope. Levels whose required parent
+// coordinate is empty are skipped (a stack coordinate with no space is not a
+// valid scope), so a realm-scoped container probes only the realm.
+func volumeScopeCandidates(scope VolumeScope) []VolumeScope {
+	var out []VolumeScope
+	if scope.Realm != "" && scope.Space != "" && scope.Stack != "" {
+		out = append(out, VolumeScope{Realm: scope.Realm, Space: scope.Space, Stack: scope.Stack})
+	}
+	if scope.Realm != "" && scope.Space != "" {
+		out = append(out, VolumeScope{Realm: scope.Realm, Space: scope.Space})
+	}
+	if scope.Realm != "" {
+		out = append(out, VolumeScope{Realm: scope.Realm})
+	}
+	return out
+}
+
+// volumeDirExists reports whether path is an existing directory — the on-disk
+// shape WriteVolume provisions. A non-directory squatting on the path is not a
+// volume, so it reads as absent.
+func volumeDirExists(path string) bool {
+	info, err := os.Stat(path)
+	return err == nil && info.IsDir()
+}
+
+// resolveVolumeMounts returns a copy of mounts with every kind: volume entry's
+// Source rewritten to its resolved on-disk Volume directory, so the downstream
+// OCI bind-mount emitter needs no Volume awareness. Non-volume mounts pass
+// through untouched. The input slice is never mutated. When no kind: volume
+// entry is present the original slice is returned and runPath is never consulted
+// — a spec that declares no volume reference pays no resolution cost and is
+// unaffected by an unset RunPath. Step 4 (#1016).
+func resolveVolumeMounts(runPath string, scope VolumeScope, mounts []intmodel.VolumeMount) ([]intmodel.VolumeMount, error) {
+	hasVolumeKind := false
+	for i := range mounts {
+		if mounts[i].Kind == intmodel.VolumeKindVolume {
+			hasVolumeKind = true
+			break
+		}
+	}
+	if !hasVolumeKind {
+		return mounts, nil
+	}
+
+	out := make([]intmodel.VolumeMount, len(mounts))
+	copy(out, mounts)
+	for i := range out {
+		if out[i].Kind != intmodel.VolumeKindVolume {
+			continue
+		}
+		resolved, err := ResolveVolumeMount(runPath, scope, out[i])
+		if err != nil {
+			return nil, err
+		}
+		out[i].Source = resolved.HostPath
+		// VolumeRef has served its purpose; clear it so the rewritten mount is a
+		// plain resolved bind reference and never re-resolved downstream.
+		out[i].VolumeRef = nil
+	}
+	return out, nil
+}

--- a/internal/ctr/volume_ref_test.go
+++ b/internal/ctr/volume_ref_test.go
@@ -1,0 +1,250 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package ctr
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+
+	internalerrdefs "github.com/eminwux/kukeon/internal/errdefs"
+	intmodel "github.com/eminwux/kukeon/internal/modelhub"
+	"github.com/eminwux/kukeon/internal/util/fs"
+)
+
+// provisionVolume creates the on-disk directory WriteVolume would, so the
+// resolver's stat-based lookup finds it.
+func provisionVolume(t *testing.T, runPath, realm, space, stack, name string) string {
+	t.Helper()
+	path := fs.VolumePath(runPath, realm, space, stack, name)
+	if err := os.MkdirAll(path, 0o770); err != nil {
+		t.Fatalf("provision volume %q: %v", path, err)
+	}
+	return path
+}
+
+func TestResolveVolumeMount_SameScopeWalk_MostSpecificWins(t *testing.T) {
+	runPath := t.TempDir()
+	scope := VolumeScope{Realm: "default", Space: "app", Stack: "web"}
+
+	// Only a realm-scoped volume exists → the walk falls back to it.
+	realmPath := provisionVolume(t, runPath, "default", "", "", "data")
+	got, err := ResolveVolumeMount(runPath, scope, intmodel.VolumeMount{
+		Kind: intmodel.VolumeKindVolume, Source: "data", Target: "/data",
+	})
+	if err != nil {
+		t.Fatalf("resolve realm-scoped: %v", err)
+	}
+	if got.HostPath != realmPath {
+		t.Errorf("HostPath = %q, want realm-scoped %q", got.HostPath, realmPath)
+	}
+	if got.Realm != "default" || got.Space != "" || got.Stack != "" || got.Name != "data" {
+		t.Errorf("coords = %+v, want realm-scoped data", got)
+	}
+
+	// Now a stack-scoped volume of the same name appears → most-specific wins.
+	stackPath := provisionVolume(t, runPath, "default", "app", "web", "data")
+	got, err = ResolveVolumeMount(runPath, scope, intmodel.VolumeMount{
+		Kind: intmodel.VolumeKindVolume, Source: "data", Target: "/data",
+	})
+	if err != nil {
+		t.Fatalf("resolve stack-scoped: %v", err)
+	}
+	if got.HostPath != stackPath {
+		t.Errorf("HostPath = %q, want stack-scoped %q", got.HostPath, stackPath)
+	}
+	if got.Stack != "web" {
+		t.Errorf("coords stack = %q, want web (most-specific)", got.Stack)
+	}
+}
+
+func TestResolveVolumeMount_CrossScopeRef(t *testing.T) {
+	runPath := t.TempDir()
+	// A volume owned by a different realm than the resolving container's scope.
+	refPath := provisionVolume(t, runPath, "shared", "", "", "cache")
+
+	got, err := ResolveVolumeMount(runPath, VolumeScope{Realm: "default", Space: "app", Stack: "web"},
+		intmodel.VolumeMount{
+			Kind:      intmodel.VolumeKindVolume,
+			Target:    "/cache",
+			VolumeRef: &intmodel.VolumeRef{Name: "cache", Realm: "shared"},
+		})
+	if err != nil {
+		t.Fatalf("resolve cross-scope ref: %v", err)
+	}
+	if got.HostPath != refPath {
+		t.Errorf("HostPath = %q, want %q", got.HostPath, refPath)
+	}
+	if got.Realm != "shared" || got.Name != "cache" {
+		t.Errorf("coords = %+v, want shared/cache", got)
+	}
+}
+
+func TestResolveVolumeMount_NotFound(t *testing.T) {
+	runPath := t.TempDir()
+	scope := VolumeScope{Realm: "default"}
+
+	if _, err := ResolveVolumeMount(runPath, scope, intmodel.VolumeMount{
+		Kind: intmodel.VolumeKindVolume, Source: "missing", Target: "/x",
+	}); !errors.Is(err, internalerrdefs.ErrVolumeNotFound) {
+		t.Errorf("same-scope miss err = %v, want ErrVolumeNotFound", err)
+	}
+
+	if _, err := ResolveVolumeMount(runPath, scope, intmodel.VolumeMount{
+		Kind:      intmodel.VolumeKindVolume,
+		Target:    "/x",
+		VolumeRef: &intmodel.VolumeRef{Name: "missing", Realm: "default"},
+	}); !errors.Is(err, internalerrdefs.ErrVolumeNotFound) {
+		t.Errorf("cross-scope miss err = %v, want ErrVolumeNotFound", err)
+	}
+}
+
+func TestResolveVolumeMount_RejectsNonVolumeKind(t *testing.T) {
+	if _, err := ResolveVolumeMount(t.TempDir(), VolumeScope{Realm: "default"},
+		intmodel.VolumeMount{Kind: intmodel.VolumeKindBind, Source: "/a", Target: "/b"}); err == nil {
+		t.Error("resolve of a bind-kind mount should error, got nil")
+	}
+}
+
+func TestResolveVolumeMount_FileSquatIsNotAVolume(t *testing.T) {
+	runPath := t.TempDir()
+	// A file (not a directory) on the volume path must read as absent.
+	p := fs.VolumePath(runPath, "default", "", "", "data")
+	if err := os.MkdirAll(filepath.Dir(p), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(p, []byte("x"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := ResolveVolumeMount(runPath, VolumeScope{Realm: "default"}, intmodel.VolumeMount{
+		Kind: intmodel.VolumeKindVolume, Source: "data", Target: "/data",
+	}); !errors.Is(err, internalerrdefs.ErrVolumeNotFound) {
+		t.Errorf("file-squat err = %v, want ErrVolumeNotFound", err)
+	}
+}
+
+func TestResolveVolumeMounts_RewritesVolumeKeepsOthers(t *testing.T) {
+	runPath := t.TempDir()
+	volPath := provisionVolume(t, runPath, "default", "", "", "data")
+	scope := VolumeScope{Realm: "default"}
+
+	in := []intmodel.VolumeMount{
+		{Kind: intmodel.VolumeKindBind, Source: "/host/a", Target: "/a"},
+		{Kind: intmodel.VolumeKindVolume, Source: "data", Target: "/data", ReadOnly: true},
+		{Kind: intmodel.VolumeKindTmpfs, Target: "/tmp"},
+	}
+	out, err := resolveVolumeMounts(runPath, scope, in)
+	if err != nil {
+		t.Fatalf("resolveVolumeMounts: %v", err)
+	}
+	// Bind + tmpfs untouched.
+	if out[0] != in[0] {
+		t.Errorf("bind mount mutated: %+v", out[0])
+	}
+	if out[2] != in[2] {
+		t.Errorf("tmpfs mount mutated: %+v", out[2])
+	}
+	// Volume rewritten: Source becomes the resolved host dir, ReadOnly kept,
+	// Kind unchanged so buildVolumeMounts emits it via the bind path.
+	if out[1].Source != volPath {
+		t.Errorf("volume Source = %q, want resolved %q", out[1].Source, volPath)
+	}
+	if !out[1].ReadOnly {
+		t.Errorf("volume ReadOnly flag dropped during resolution")
+	}
+	if out[1].VolumeRef != nil {
+		t.Errorf("VolumeRef should be cleared after resolution, got %+v", out[1].VolumeRef)
+	}
+	// Input slice never mutated.
+	if in[1].Source != "data" {
+		t.Errorf("input slice mutated: in[1].Source = %q", in[1].Source)
+	}
+}
+
+func TestResolveVolumeMounts_NoVolumeKind_PassThrough(t *testing.T) {
+	in := []intmodel.VolumeMount{{Kind: intmodel.VolumeKindBind, Source: "/a", Target: "/a"}}
+	// Empty runPath must be tolerated when no volume-kind entry is present.
+	out, err := resolveVolumeMounts("", VolumeScope{}, in)
+	if err != nil {
+		t.Fatalf("pass-through resolve: %v", err)
+	}
+	if !reflect.DeepEqual(out, in) {
+		t.Errorf("pass-through mutated slice: %+v", out)
+	}
+}
+
+// TestVolume_SurvivesContainerRecreate pins AC #6: a sentinel written into a
+// referenced Volume survives a container recreate. The Volume directory lives
+// in the daemon's persistent volumes/ tree, not the container's writable
+// layer, so a recreate simply re-resolves the same reference to the same dir —
+// the resolver returns the identical HostPath and the sentinel is intact.
+func TestVolume_SurvivesContainerRecreate(t *testing.T) {
+	runPath := t.TempDir()
+	scope := VolumeScope{Realm: "default", Space: "app", Stack: "web"}
+	mount := intmodel.VolumeMount{Kind: intmodel.VolumeKindVolume, Source: "data", Target: "/data"}
+
+	volPath := provisionVolume(t, runPath, "default", "app", "web", "data")
+
+	// First create: resolve and write a sentinel into the resolved dir.
+	first, err := ResolveVolumeMount(runPath, scope, mount)
+	if err != nil {
+		t.Fatalf("first resolve: %v", err)
+	}
+	sentinel := filepath.Join(first.HostPath, "sentinel")
+	if err := os.WriteFile(sentinel, []byte("survived"), 0o600); err != nil {
+		t.Fatalf("write sentinel: %v", err)
+	}
+
+	// Recreate: a new container spec re-resolves the same reference. The volume
+	// dir is untouched by the (simulated) rootfs teardown.
+	second, err := ResolveVolumeMount(runPath, scope, mount)
+	if err != nil {
+		t.Fatalf("re-resolve after recreate: %v", err)
+	}
+	if second.HostPath != first.HostPath || second.HostPath != volPath {
+		t.Errorf("recreate resolved to %q, want stable %q", second.HostPath, volPath)
+	}
+	got, err := os.ReadFile(filepath.Join(second.HostPath, "sentinel"))
+	if err != nil {
+		t.Fatalf("read sentinel after recreate: %v", err)
+	}
+	if string(got) != "survived" {
+		t.Errorf("sentinel = %q, want %q", got, "survived")
+	}
+}
+
+// TestBuildVolumeMounts_VolumeKindEmitsBind pins AC #4 + the byte-identical
+// emission: a resolved volume-kind mount (Source already the on-disk dir)
+// produces the exact same OCI bind mount as the equivalent bind-kind entry.
+func TestBuildVolumeMounts_VolumeKindEmitsBind(t *testing.T) {
+	resolvedDir := "/run/kukeon/data/default/volumes/data"
+	volume := buildVolumeMounts([]intmodel.VolumeMount{
+		{Kind: intmodel.VolumeKindVolume, Source: resolvedDir, Target: "/data"},
+	})
+	bind := buildVolumeMounts([]intmodel.VolumeMount{
+		{Kind: intmodel.VolumeKindBind, Source: resolvedDir, Target: "/data"},
+	})
+	if !reflect.DeepEqual(volume, bind) {
+		t.Errorf("volume-kind emission %+v != bind-kind emission %+v", volume, bind)
+	}
+	if len(volume) != 1 || volume[0].Type != "bind" || volume[0].Source != resolvedDir ||
+		volume[0].Destination != "/data" {
+		t.Errorf("unexpected volume-kind mount: %+v", volume)
+	}
+}

--- a/internal/errdefs/errdefs.go
+++ b/internal/errdefs/errdefs.go
@@ -189,15 +189,32 @@ var (
 	ErrVolumeSourceNotAbsolute = errors.New("volume source must be an absolute host path")
 	ErrVolumeTargetNotAbsolute = errors.New("volume target must be an absolute container path")
 	ErrVolumeSourceNotFound    = errors.New("volume source does not exist on the host")
-	ErrVolumeNamedNotSupported = errors.New(
-		"named or managed volumes are not supported; use an absolute host path as source",
-	)
-	ErrVolumeKindUnknown = errors.New(
-		"volume kind is not recognized; expected \"\", \"bind\", or \"tmpfs\"",
+	ErrVolumeKindUnknown       = errors.New(
+		"volume kind is not recognized; expected \"\", \"bind\", \"tmpfs\", or \"volume\"",
 	)
 	ErrVolumeTmpfsSourceForbidden = errors.New(
 		"tmpfs volume must not set a source; tmpfs is in-memory and has no host backing",
 	)
+	// Volume-reference (kind: volume) mount errors — step 4 (#1016).
+	ErrVolumeRefSourceExclusive = errors.New(
+		"volume mount must set exactly one of source (same-scope name) or volumeRef (cross-scope)",
+	)
+	ErrVolumeRefSourceMissing = errors.New(
+		"volume mount must set either source (same-scope name) or volumeRef (cross-scope)",
+	)
+	ErrVolumeSourceNotName = errors.New(
+		"volume mount source must be a Volume name, not an absolute path",
+	)
+	ErrVolumeRefNameRequired    = errors.New("volumeRef.name is required")
+	ErrVolumeRefRealmRequired   = errors.New("volumeRef.realm is required")
+	ErrVolumeRefScopeIncomplete = errors.New(
+		"volumeRef scope is incomplete; a deeper coordinate requires every shallower one",
+	)
+	// ErrVolumeInUse gates `kuke delete volume` against a live mount: a Volume
+	// referenced by a volume-kind mount on a running cell cannot be deleted out
+	// from under it. The wrapping message names the mounting cell. Step 4
+	// (#1016).
+	ErrVolumeInUse = errors.New("volume is in use by a running cell")
 
 	// CNI-related errors.
 

--- a/internal/modelhub/container.go
+++ b/internal/modelhub/container.go
@@ -191,17 +191,33 @@ const (
 	// Source is implicit ("tmpfs"). SizeBytes and Mode tune the standard
 	// tmpfs size= and mode= options when non-zero.
 	VolumeKindTmpfs VolumeKind = "tmpfs"
+	// VolumeKindVolume references a daemon-managed kind: Volume (issue #1018) by
+	// name (Source, same-scope) or by VolumeRef (cross-scope) and bind-mounts
+	// its resolved on-disk directory at Target. Resolved at container-create
+	// time; the referenced Volume's directory survives container recreation and
+	// the mounting cell's deletion. Step 4 (#1016).
+	VolumeKindVolume VolumeKind = "volume"
 )
 
 // VolumeMount is a mount entry attached to a container. The Kind discriminator
 // selects the OCI mount type the runtime emits: bind (host path → container
-// path) or tmpfs (in-memory directory). Empty Kind means bind for back-compat
-// with call sites that predate the discriminator.
+// path), tmpfs (in-memory directory), or volume (a reference to a kind: Volume
+// resolved to its on-disk directory and bind-mounted). Empty Kind means bind
+// for back-compat with call sites that predate the discriminator.
 type VolumeMount struct {
-	Kind     VolumeKind
-	Source   string
-	Target   string
-	ReadOnly bool
+	Kind VolumeKind
+	// Source is the host path for a bind mount, or — when Kind is
+	// VolumeKindVolume — the name of a same-scope Volume (mutually exclusive
+	// with VolumeRef). Empty for tmpfs. The volume-reference resolver rewrites
+	// Source to the resolved Volume directory at container-create time so the
+	// downstream bind-mount emitter needs no Volume awareness.
+	Source string
+	Target string
+	// VolumeRef references a kind: Volume in another scope. Only honored when
+	// Kind == VolumeKindVolume and mutually exclusive with a same-scope Source.
+	// Step 4 (#1016).
+	VolumeRef *VolumeRef
+	ReadOnly  bool
 	// SizeBytes is the tmpfs size= option in bytes. Only honored when
 	// Kind == VolumeKindTmpfs; zero leaves the kernel default.
 	SizeBytes int64
@@ -209,6 +225,17 @@ type VolumeMount struct {
 	// Only honored when Kind == VolumeKindTmpfs; zero leaves the kernel
 	// default (01777).
 	Mode uint32
+}
+
+// VolumeRef mirrors the v1beta1 VolumeRef payload — a name + scope pointing at
+// a daemon-managed kind: Volume (issue #1018). Unlike ContainerSecretRef there
+// is no Cell coordinate; a Volume is never cell-scoped. See the v1beta1 type
+// for the scope-coordinate contract. Step 4 (#1016).
+type VolumeRef struct {
+	Name  string
+	Realm string
+	Space string
+	Stack string
 }
 
 // ContainerRepo mirrors the v1beta1 ContainerRepo payload — a git repository

--- a/pkg/api/model/v1beta1/container.go
+++ b/pkg/api/model/v1beta1/container.go
@@ -302,19 +302,58 @@ const (
 	// Source must be empty. SizeBytes and Mode tune the standard tmpfs
 	// size= and mode= options when non-zero.
 	VolumeKindTmpfs VolumeKind = "tmpfs"
+	// VolumeKindVolume references a daemon-managed kind: Volume (issue #1018)
+	// by name and bind-mounts its on-disk directory read-write at Target. The
+	// reference is resolved at container-create time: a bare `source: <name>`
+	// names a Volume in the container's own scope (resolved by walking
+	// realm/space/stack, most-specific first); a `volumeRef:` block names one
+	// cross-scope. The referenced Volume's directory survives both container
+	// recreation and the mounting cell's deletion — the cell references the
+	// Volume, it does not own it. Step 4 of the volumes epic (#1016).
+	VolumeKindVolume VolumeKind = "volume"
 )
 
 // VolumeMount is a mount entry attached to a container. The Kind discriminator
 // selects the OCI mount type the runtime emits: bind (host path → container
-// path) or tmpfs (in-memory directory). Empty Kind means bind for back-compat
-// with YAML authored before the discriminator existed.
+// path), tmpfs (in-memory directory), or volume (a reference to a daemon-
+// managed kind: Volume resolved to its on-disk directory and bind-mounted).
+// Empty Kind means bind for back-compat with YAML authored before the
+// discriminator existed.
 type VolumeMount struct {
-	Kind      VolumeKind `json:"kind,omitempty"      yaml:"kind,omitempty"`
-	Source    string     `json:"source,omitempty"    yaml:"source,omitempty"`
-	Target    string     `json:"target"              yaml:"target"`
+	Kind VolumeKind `json:"kind,omitempty"      yaml:"kind,omitempty"`
+	// Source is the host path for a bind mount, or — when Kind is volume — the
+	// name of a Volume in the container's own scope (mutually exclusive with
+	// VolumeRef). Empty for tmpfs.
+	Source string `json:"source,omitempty"    yaml:"source,omitempty"`
+	Target string `json:"target"              yaml:"target"`
+	// VolumeRef references a kind: Volume in another scope by name + scope
+	// coordinates (mirrors ContainerSecretRef, minus the cell coordinate a
+	// Volume can never carry). Only honored when Kind is volume, and mutually
+	// exclusive with Source. Step 4 (#1016).
+	VolumeRef *VolumeRef `json:"volumeRef,omitempty" yaml:"volumeRef,omitempty"`
 	ReadOnly  bool       `json:"readOnly,omitempty"  yaml:"readOnly,omitempty"`
 	SizeBytes int64      `json:"sizeBytes,omitempty" yaml:"sizeBytes,omitempty"`
 	Mode      uint32     `json:"mode,omitempty"      yaml:"mode,omitempty"`
+}
+
+// VolumeRef points at a daemon-managed kind: Volume (issue #1018) by name and
+// scope, the cross-scope companion to a bare `source: <name>` on a volume-kind
+// VolumeMount. The scope follows the Volume coordinate contract: Realm is
+// always required and a deeper coordinate may only be set when every shallower
+// one is. Unlike ContainerSecretRef there is no Cell coordinate — a Volume is
+// never cell-scoped. The reference resolves to the same on-disk directory the
+// Volume was provisioned at, so a container in one scope may mount a Volume
+// owned by another (e.g. a workload reading a realm-scoped shared volume).
+// Step 4 (#1016).
+type VolumeRef struct {
+	// Name is the referenced Volume's name within its scope. Required.
+	Name string `json:"name"            yaml:"name"`
+	// Realm is the always-required top-level scope coordinate.
+	Realm string `json:"realm"           yaml:"realm"`
+	// Space, when set, scopes the reference to a space within Realm.
+	Space string `json:"space,omitempty" yaml:"space,omitempty"`
+	// Stack, when set, scopes the reference to a stack within Space.
+	Stack string `json:"stack,omitempty" yaml:"stack,omitempty"`
 }
 
 // ContainerRepo declares a git repository the container depends on. kuketty
@@ -653,6 +692,14 @@ func cloneVolumeMounts(in []VolumeMount) []VolumeMount {
 
 	out := make([]VolumeMount, len(in))
 	copy(out, in)
+	// copy() is shallow: deep-copy the VolumeRef pointer so a clone never
+	// shares the referent struct with the original (mirrors cloneSecrets).
+	for i := range out {
+		if in[i].VolumeRef != nil {
+			ref := *in[i].VolumeRef
+			out[i].VolumeRef = &ref
+		}
+	}
 	return out
 }
 

--- a/pkg/api/model/v1beta1/container_test.go
+++ b/pkg/api/model/v1beta1/container_test.go
@@ -71,3 +71,36 @@ func TestContainerSpec_HostPIDDefault(t *testing.T) {
 		}
 	})
 }
+
+// TestNewContainerDoc_DeepCopiesVolumeRef pins the step-4 (#1016) clone
+// contract: cloneVolumeMounts deep-copies each VolumeMount's VolumeRef pointer
+// so a cloned ContainerDoc never shares the referent struct with its source —
+// the same guarantee cloneSecrets gives ContainerSecretRef. Mutating the
+// clone's VolumeRef must not bleed back into the original.
+func TestNewContainerDoc_DeepCopiesVolumeRef(t *testing.T) {
+	in := &ContainerDoc{
+		Spec: ContainerSpec{
+			Volumes: []VolumeMount{
+				{
+					Kind:      VolumeKindVolume,
+					Target:    "/cache",
+					VolumeRef: &VolumeRef{Name: "cache", Realm: "shared"},
+				},
+			},
+		},
+	}
+	out := NewContainerDoc(in)
+
+	if out.Spec.Volumes[0].VolumeRef == in.Spec.Volumes[0].VolumeRef {
+		t.Fatal("clone shares the VolumeRef pointer with the source")
+	}
+	if *out.Spec.Volumes[0].VolumeRef != *in.Spec.Volumes[0].VolumeRef {
+		t.Fatalf("clone VolumeRef = %+v, want equal value to source",
+			out.Spec.Volumes[0].VolumeRef)
+	}
+	out.Spec.Volumes[0].VolumeRef.Realm = "mutated"
+	if in.Spec.Volumes[0].VolumeRef.Realm != "shared" {
+		t.Errorf("mutating clone VolumeRef bled into source: realm = %q",
+			in.Spec.Volumes[0].VolumeRef.Realm)
+	}
+}


### PR DESCRIPTION
## Summary

Wires the container side of the standalone `Volume` (#1018): a new `VolumeKindVolume = "volume"` mount kind that **references** a daemon-managed Volume by name and bind-mounts its on-disk directory read-write. A bare `source: <name>` resolves a Volume in the container's own scope (walking realm/space/stack, most-specific first); a `volumeRef: {name, realm, space, stack}` resolves one cross-scope. The referenced Volume survives both container recreation and the mounting cell's deletion — the cell references the Volume, it does not own it. Closes #1016 (step 4 of volumes epic #1015).

Key why-bullets:
- **Resolution mirrors secrets.** Volume-kind mounts are resolved to their on-disk dir in `CreateContainerFromSpec` (alongside `resolveSecrets`), threading the daemon RunPath through the existing `WithSecretRunPath` option. The persisted `ContainerDoc` keeps the *reference* (`kind: volume` + name); only the OCI runtime spec carries the resolved path. After resolution `buildVolumeMounts` emits a `volume`-kind entry through the exact same bind path as `bind`, so an all-bind OCI list stays byte-identical.
- **Delete gate at the single choke point.** `controller.DeleteVolume` (the one path both `kuke delete volume` CLI and the daemon RPC traverse) now refuses with `ErrVolumeInUse` naming the mounting cell when a **running** cell mounts the Volume. The new `runner.VolumeMountedByLiveCell` enumerates cells across all realms and matches each live cell's volume-kind mounts (resolved to coordinates) against the target.

## Decisions / deviations (for reviewer scrutiny)

- **Cited paths had drifted (premise partially rotted, intent clear).** The issue cites `validateVolumes` at `internal/controller/create_container.go:284` and `buildVolumeMounts` at `internal/ctr/spec.go:661`. `create_container.go` no longer exists and there was **no** `validateVolumes` (the `ErrVolumeSource*`/`ErrVolumeKindUnknown` sentinels were defined but unwired). I introduced `validateContainerVolumes` in `internal/apischeme/scheme.go` — the container-conversion choke point both `apply -f` and imperative create traverse — and wired it into `ConvertContainerDocToInternal` + the cell-container loop. `buildVolumeMounts` is now at `spec.go:685`.
- **No auto-create.** The AC left "auto-create the Volume at stack scope when the name doesn't exist" as a PR call. I chose the lower-blast-radius reading: an unresolved reference is a **hard error** at container create (no surprise directory provisioning), matching the AC's "must resolve" branch. A typo'd reference fails fast rather than silently materializing an empty volume. Documented so the reviewer can push back if Docker `-v name:/path` auto-create is wanted.
- **Gate keys on running cell state.** `VolumeMountedByLiveCell` treats a cell as a live mounter only when its last-reconciled `Status.State == CellStateReady`. A Volume referenced solely by stopped/exited cells deletes cleanly (you only need to stop the cells, not delete them). This honors the AC's "running container" wording; a broader "any referencing cell" gate would refuse more aggressively.
- **Removed `ErrVolumeNamedNotSupported`.** That sentinel ("named or managed volumes are not supported; use an absolute host path") is now false and was unused — removed rather than left contradicting the feature.
- **Root-container boundary (verified).** Volume refs resolve only on the workload-container create path (`CreateContainerFromSpec`), not `BuildRootContainerSpec` — the *exact same boundary* `secretRef` already has (`resolveSecrets` and `resolveVolumeMounts` are both called only at `container.go:559`/`:587`; `BuildRootContainerSpec` calls neither). Root containers are kukeon infra (kukepause) with no user references, so this is consistent, not a new gap.

## Deferred (follow-up filed)

- The step-1 comment in `runner/volume.go` notes step 4 would also wire the *mounting container's uid* into the volume dir via a post-create chown. That is **not** in this issue's AC checklist; the existing setgid `root:kukeon` 0o770 dir already grants write to kukeon-group containers. Deferred to a separate follow-up so the per-uid ownership is scoped on its own.

## Test plan

- [x] `make test` (full CI target, GOWORK=off) — all packages pass
- [x] `make dev-init` smoke — daemon boots, two-realm parity tail identical between daemon and `--no-daemon` views (both realms Ready), kuketty attach smoke clean. (Required a one-time reclaim of orphan build snapshots from the 4G `/var/lib/containerd` tmpfs before the image rebuild fit.)
- [x] `go vet` + `gofmt` on all changed files

## Acceptance criteria

- [x] `VolumeKindVolume = "volume"` in v1beta1 + internal model; empty Kind still defaults to `bind` (no behavior change for existing specs)
- [x] `volume` case in `validateContainerVolumes`: `source` is a Volume name (or a `volumeRef` block) — not an absolute host path; `Target` absolute; the referenced Volume must resolve (no auto-create)
- [x] `volumeRef` shape (name + realm/space/stack) plumbed through v1beta1 ↔ apischeme ↔ validator ↔ clone (deep-copy mirrors `cloneSecrets`)
- [x] `buildVolumeMounts` emits `{Destination: Target, Source: <resolved Volume dir>, Type:"bind", Options:["rbind","rw"]}` (`readOnly` → `ro`)
- [x] **Survives cell delete** — `TestVolume_SurvivesCellDelete` (volume dir lives outside any cell metadata subtree; sentinel persists; new cell re-resolves)
- [x] **Survives container recreate** — `TestVolume_SurvivesContainerRecreate` (recreate re-resolves the same persistent dir; sentinel intact)
- [x] **Delete gate** — `TestDeleteVolume_InUseRefused` (controller) + `TestVolumeMountedByLiveCell_*` (runner): refused while a running cell mounts it; error names the mounting cell; stopped cells / different volumes do not gate
- [x] Tests: OCI emission byte-identical (`TestBuildVolumeMounts_VolumeKindEmitsBind`), same-scope + cross-scope resolution, survives-cell-delete, survives-recreate, delete-gate

Closes #1016