### PR TITLE
feat: per-cell volume identity for 1:N bindings (step 5)

### DIFF
--- a/internal/apischeme/scheme.go
+++ b/internal/apischeme/scheme.go
@@ -1434,6 +1434,7 @@ func volumeMountsToInternal(in []ext.VolumeMount) []intmodel.VolumeMount {
 			ReadOnly:  v.ReadOnly,
 			SizeBytes: v.SizeBytes,
 			Mode:      v.Mode,
+			Ensure:    v.Ensure,
 		}
 	}
 	return out
@@ -1453,6 +1454,7 @@ func volumeMountsToExternal(in []intmodel.VolumeMount) []ext.VolumeMount {
 			ReadOnly:  v.ReadOnly,
 			SizeBytes: v.SizeBytes,
 			Mode:      v.Mode,
+			Ensure:    v.Ensure,
 		}
 	}
 	return out

--- a/internal/cellblueprint/cellblueprint.go
+++ b/internal/cellblueprint/cellblueprint.go
@@ -222,6 +222,11 @@ func MaterializeWithName(
 		)
 	}
 
+	// Resolve the per-cell ${CELL_NAME} volume template now that the cell name
+	// exists, so a 1:N binding mints a distinct private Volume per stamped cell
+	// (#1017).
+	ExpandPerCellVolumes(cellName, containers)
+
 	return v1beta1.CellDoc{
 		APIVersion: v1beta1.APIVersionV1Beta1,
 		Kind:       v1beta1.KindCell,

--- a/internal/cellblueprint/percell.go
+++ b/internal/cellblueprint/percell.go
@@ -1,0 +1,87 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package cellblueprint
+
+import (
+	"strings"
+
+	v1beta1 "github.com/eminwux/kukeon/pkg/api/model/v1beta1"
+)
+
+// CellNameVar is the reserved per-cell template variable a binding embeds in a
+// kind: volume mount source (e.g. `source: mem-${CELL_NAME}`) to mint a
+// distinct, private Volume per stamped cell (step 5 of the volumes epic,
+// #1017). Unlike the scalar `${KEY}` parameters substituted at Resolve time
+// (params.go), ${CELL_NAME} is resolved later — at MaterializeWithName, once
+// the cell's name exists — because a 1:N binding's cell name is generated per
+// invocation, not supplied as a parameter. CELL_NAME is therefore reserved: a
+// blueprint should not declare a parameter named CELL_NAME, since Resolve
+// substitutes declared `${KEY}` parameters first and the value would consume
+// the token before this per-cell expansion ever runs.
+const CellNameVar = "${CELL_NAME}"
+
+// ExpandPerCellVolumes rewrites the ${CELL_NAME} template variable to cellName
+// in every kind: volume mount of every container, and marks each rewritten
+// mount Ensure=true so the daemon auto-provisions the now cell-specific Volume
+// at create/start (a per-cell Volume cannot be pre-created for a not-yet-named
+// cell). This is the naming + provisioning half of the per-cell volume claim:
+// materializing N cells from one binding yields N distinct Volume names
+// (`mem-<cellA>`, `mem-<cellB>`, …), so isolation comes from the name, not the
+// scope (umbrella #1015).
+//
+// Idempotency falls out of determinism: re-materializing a cell with the same
+// identity re-expands to the same Volume name, so reconcile and recreate
+// re-bind the existing Volume rather than minting a fresh one (#1017 AC4). A
+// mount with no ${CELL_NAME} is left untouched — Ensure stays as authored, so a
+// statically-named volume keeps step 4's "missing is a hard error" default.
+//
+// Each container's Volumes slice is cloned before mutation and reassigned, so
+// a blueprint document whose Volumes backing array is shared across
+// materializations (materializeContainer copies the slice header, not its
+// elements) is never aliased — without the clone, expanding ${CELL_NAME} for
+// one stamped cell would overwrite the template and collapse the next cell's
+// name onto the first. A VolumeRef is likewise cloned before its Name is
+// rewritten.
+func ExpandPerCellVolumes(cellName string, containers []v1beta1.ContainerSpec) {
+	for ci := range containers {
+		if len(containers[ci].Volumes) == 0 {
+			continue
+		}
+		vols := make([]v1beta1.VolumeMount, len(containers[ci].Volumes))
+		copy(vols, containers[ci].Volumes)
+		containers[ci].Volumes = vols
+		for vi := range vols {
+			if vols[vi].Kind != v1beta1.VolumeKindVolume {
+				continue
+			}
+			expanded := false
+			if strings.Contains(vols[vi].Source, CellNameVar) {
+				vols[vi].Source = strings.ReplaceAll(vols[vi].Source, CellNameVar, cellName)
+				expanded = true
+			}
+			if ref := vols[vi].VolumeRef; ref != nil && strings.Contains(ref.Name, CellNameVar) {
+				clone := *ref
+				clone.Name = strings.ReplaceAll(ref.Name, CellNameVar, cellName)
+				vols[vi].VolumeRef = &clone
+				expanded = true
+			}
+			if expanded {
+				vols[vi].Ensure = true
+			}
+		}
+	}
+}

--- a/internal/cellblueprint/percell_test.go
+++ b/internal/cellblueprint/percell_test.go
@@ -1,0 +1,200 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package cellblueprint_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/eminwux/kukeon/internal/cellblueprint"
+	v1beta1 "github.com/eminwux/kukeon/pkg/api/model/v1beta1"
+)
+
+// TestExpandPerCellVolumes_ExpandsSourceAndMarksEnsure pins the per-cell
+// naming + provisioning contract: a kind: volume mount whose source embeds
+// ${CELL_NAME} is rewritten to the cell's name and marked Ensure so the daemon
+// auto-provisions it (#1017 AC1/AC4).
+func TestExpandPerCellVolumes_ExpandsSourceAndMarksEnsure(t *testing.T) {
+	containers := []v1beta1.ContainerSpec{{
+		ID: "app",
+		Volumes: []v1beta1.VolumeMount{{
+			Kind:   v1beta1.VolumeKindVolume,
+			Source: "mem-${CELL_NAME}",
+			Target: "/memory",
+		}},
+	}}
+
+	cellblueprint.ExpandPerCellVolumes("agent-a1b2c3", containers)
+
+	got := containers[0].Volumes[0]
+	if got.Source != "mem-agent-a1b2c3" {
+		t.Errorf("Source = %q, want mem-agent-a1b2c3", got.Source)
+	}
+	if !got.Ensure {
+		t.Errorf("Ensure = false, want true on an expanded per-cell mount")
+	}
+}
+
+// TestExpandPerCellVolumes_DistinctPerCell is the isolation guarantee: two
+// cells materialized from the same templated source get two distinct Volume
+// names, so neither shares the other's directory (#1017 AC1).
+func TestExpandPerCellVolumes_DistinctPerCell(t *testing.T) {
+	tmpl := func() []v1beta1.ContainerSpec {
+		return []v1beta1.ContainerSpec{{
+			ID:      "app",
+			Volumes: []v1beta1.VolumeMount{{Kind: v1beta1.VolumeKindVolume, Source: "mem-${CELL_NAME}", Target: "/m"}},
+		}}
+	}
+
+	a := tmpl()
+	b := tmpl()
+	cellblueprint.ExpandPerCellVolumes("cellA", a)
+	cellblueprint.ExpandPerCellVolumes("cellB", b)
+
+	if a[0].Volumes[0].Source == b[0].Volumes[0].Source {
+		t.Fatalf("two cells share volume source %q, want distinct", a[0].Volumes[0].Source)
+	}
+	if a[0].Volumes[0].Source != "mem-cellA" || b[0].Volumes[0].Source != "mem-cellB" {
+		t.Errorf("sources = %q, %q; want mem-cellA, mem-cellB", a[0].Volumes[0].Source, b[0].Volumes[0].Source)
+	}
+}
+
+// TestExpandPerCellVolumes_Deterministic underpins the successor-inherits and
+// reconcile-preserve ACs: expanding the same templated source against the same
+// cell name yields the same Volume name, so re-materializing a cell with the
+// same identity re-binds the same Volume rather than minting a fresh one
+// (#1017 AC2/AC4).
+func TestExpandPerCellVolumes_Deterministic(t *testing.T) {
+	mk := func() []v1beta1.ContainerSpec {
+		return []v1beta1.ContainerSpec{{
+			ID:      "app",
+			Volumes: []v1beta1.VolumeMount{{Kind: v1beta1.VolumeKindVolume, Source: "mem-${CELL_NAME}", Target: "/m"}},
+		}}
+	}
+	first := mk()
+	second := mk()
+	cellblueprint.ExpandPerCellVolumes("agent-deadbe", first)
+	cellblueprint.ExpandPerCellVolumes("agent-deadbe", second)
+
+	if first[0].Volumes[0].Source != second[0].Volumes[0].Source {
+		t.Errorf("non-deterministic expansion: %q vs %q",
+			first[0].Volumes[0].Source, second[0].Volumes[0].Source)
+	}
+}
+
+// TestExpandPerCellVolumes_ClonesVolumeRef confirms a cross-scope per-cell ref
+// is expanded on a clone, so the caller's (potentially shared) VolumeRef is
+// never aliased/mutated, and the rewritten mount is marked Ensure.
+func TestExpandPerCellVolumes_ClonesVolumeRef(t *testing.T) {
+	ref := &v1beta1.VolumeRef{Name: "mem-${CELL_NAME}", Realm: "default", Space: "agents"}
+	containers := []v1beta1.ContainerSpec{{
+		ID:      "app",
+		Volumes: []v1beta1.VolumeMount{{Kind: v1beta1.VolumeKindVolume, VolumeRef: ref, Target: "/m"}},
+	}}
+
+	cellblueprint.ExpandPerCellVolumes("cellX", containers)
+
+	if ref.Name != "mem-${CELL_NAME}" {
+		t.Errorf("input VolumeRef mutated: Name = %q, want template preserved", ref.Name)
+	}
+	got := containers[0].Volumes[0]
+	if got.VolumeRef == ref {
+		t.Errorf("VolumeRef not cloned (still points at input)")
+	}
+	if got.VolumeRef.Name != "mem-cellX" {
+		t.Errorf("clone Name = %q, want mem-cellX", got.VolumeRef.Name)
+	}
+	if !got.Ensure {
+		t.Errorf("Ensure = false, want true on an expanded per-cell ref")
+	}
+}
+
+// TestExpandPerCellVolumes_LeavesUntemplatedAlone confirms a statically-named
+// volume keeps step 4's "missing is a hard error" default — no ${CELL_NAME}
+// means no rewrite and no Ensure flip — and non-volume kinds are never touched.
+func TestExpandPerCellVolumes_LeavesUntemplatedAlone(t *testing.T) {
+	containers := []v1beta1.ContainerSpec{{
+		ID: "app",
+		Volumes: []v1beta1.VolumeMount{
+			{Kind: v1beta1.VolumeKindVolume, Source: "shared-cache", Target: "/cache"},
+			{Kind: v1beta1.VolumeKindBind, Source: "/host/${CELL_NAME}", Target: "/b"},
+			{Kind: v1beta1.VolumeKindTmpfs, Target: "/t"},
+		},
+	}}
+
+	cellblueprint.ExpandPerCellVolumes("cellZ", containers)
+
+	if v := containers[0].Volumes[0]; v.Source != "shared-cache" || v.Ensure {
+		t.Errorf("static volume mount changed: %+v", v)
+	}
+	if v := containers[0].Volumes[1]; v.Source != "/host/${CELL_NAME}" || v.Ensure {
+		t.Errorf("bind mount touched: %+v (only kind: volume sources expand)", v)
+	}
+}
+
+// TestMaterializeWithName_PerCellVolumeFanout exercises the full blueprint
+// path: each materialization (a fresh <prefix>-<6hex> cell) yields a distinct
+// per-cell Volume name, each marked Ensure — the 1:N fan-out isolation
+// guarantee (#1017 AC1).
+func TestMaterializeWithName_PerCellVolumeFanout(t *testing.T) {
+	doc := v1beta1.CellBlueprintDoc{
+		APIVersion: v1beta1.APIVersionV1Beta1,
+		Kind:       v1beta1.KindCellBlueprint,
+		Metadata:   v1beta1.CellBlueprintMetadata{Name: "agent", Realm: "default", Space: "agents", Stack: "team"},
+		Spec: v1beta1.CellBlueprintSpec{
+			Cell: v1beta1.BlueprintCellSpec{
+				Containers: []v1beta1.BlueprintContainer{{
+					ID:    "app",
+					Image: "img",
+					Volumes: []v1beta1.VolumeMount{{
+						Kind:   v1beta1.VolumeKindVolume,
+						Source: "mem-${CELL_NAME}",
+						Target: "/memory",
+					}},
+				}},
+			},
+		},
+	}
+
+	cellA, err := cellblueprint.MaterializeWithName(doc, "", nil)
+	if err != nil {
+		t.Fatalf("MaterializeWithName(A) error = %v", err)
+	}
+	cellB, err := cellblueprint.MaterializeWithName(doc, "", nil)
+	if err != nil {
+		t.Fatalf("MaterializeWithName(B) error = %v", err)
+	}
+
+	srcA := cellA.Spec.Containers[0].Volumes[0].Source
+	srcB := cellB.Spec.Containers[0].Volumes[0].Source
+
+	if srcA == srcB {
+		t.Fatalf("fan-out shares volume source %q, want distinct per cell", srcA)
+	}
+	for _, c := range []v1beta1.CellDoc{cellA, cellB} {
+		v := c.Spec.Containers[0].Volumes[0]
+		if !strings.HasPrefix(v.Source, "mem-") || strings.Contains(v.Source, "${") {
+			t.Errorf("source %q not expanded to mem-<cell>", v.Source)
+		}
+		if !v.Ensure {
+			t.Errorf("cell %q volume not marked Ensure", c.Metadata.Name)
+		}
+		if v.Source != "mem-"+c.Metadata.Name {
+			t.Errorf("source %q != mem-%s", v.Source, c.Metadata.Name)
+		}
+	}
+}

--- a/internal/cellconfig/materialize.go
+++ b/internal/cellconfig/materialize.go
@@ -85,6 +85,11 @@ func MaterializeWithName(
 	}
 
 	cellName := strings.TrimSpace(name)
+	// Resolve the per-cell ${CELL_NAME} volume template against the cell's name
+	// so a Config 1:N binding mints a distinct private Volume per stamped cell
+	// (#1017). Shares cellblueprint's expansion so blueprint and config bindings
+	// behave identically.
+	cellblueprint.ExpandPerCellVolumes(cellName, containers)
 	return v1beta1.CellDoc{
 		APIVersion: v1beta1.APIVersionV1Beta1,
 		Kind:       v1beta1.KindCell,

--- a/internal/cellconfig/percell_test.go
+++ b/internal/cellconfig/percell_test.go
@@ -1,0 +1,82 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package cellconfig
+
+import (
+	"testing"
+
+	v1beta1 "github.com/eminwux/kukeon/pkg/api/model/v1beta1"
+)
+
+// TestMaterialize_ExpandsPerCellVolume confirms the Config 1:N binding path
+// resolves the ${CELL_NAME} per-cell volume template against the caller-
+// supplied cell name and marks the mount Ensure, identically to the blueprint
+// path (shared cellblueprint.ExpandPerCellVolumes). Two cells stamped from the
+// same Config get distinct, private Volume names (#1017 AC1).
+func TestMaterialize_ExpandsPerCellVolume(t *testing.T) {
+	bp := v1beta1.CellBlueprintDoc{
+		APIVersion: v1beta1.APIVersionV1Beta1,
+		Kind:       v1beta1.KindCellBlueprint,
+		Metadata:   v1beta1.CellBlueprintMetadata{Name: "agent", Realm: "bp-realm"},
+		Spec: v1beta1.CellBlueprintSpec{
+			Cell: v1beta1.BlueprintCellSpec{
+				Containers: []v1beta1.BlueprintContainer{{
+					ID:    "main",
+					Image: "img",
+					Volumes: []v1beta1.VolumeMount{{
+						Kind:   v1beta1.VolumeKindVolume,
+						Source: "mem-${CELL_NAME}",
+						Target: "/memory",
+					}},
+				}},
+			},
+		},
+	}
+	cfg := v1beta1.CellConfigDoc{
+		APIVersion: v1beta1.APIVersionV1Beta1,
+		Kind:       v1beta1.KindCellConfig,
+		Metadata:   v1beta1.CellConfigMetadata{Name: "prod", Realm: "cfg-realm"},
+		Spec: v1beta1.CellConfigSpec{
+			Blueprint: v1beta1.CellConfigBlueprintRef{Name: "agent", Realm: "bp-realm"},
+		},
+	}
+
+	cellA, err := MaterializeWithName(cfg, bp, "agent-aaa111")
+	if err != nil {
+		t.Fatalf("MaterializeWithName(A) error = %v", err)
+	}
+	cellB, err := MaterializeWithName(cfg, bp, "agent-bbb222")
+	if err != nil {
+		t.Fatalf("MaterializeWithName(B) error = %v", err)
+	}
+
+	volA := cellA.Spec.Containers[0].Volumes[0]
+	volB := cellB.Spec.Containers[0].Volumes[0]
+
+	if volA.Source != "mem-agent-aaa111" {
+		t.Errorf("cellA source = %q, want mem-agent-aaa111", volA.Source)
+	}
+	if volB.Source != "mem-agent-bbb222" {
+		t.Errorf("cellB source = %q, want mem-agent-bbb222", volB.Source)
+	}
+	if volA.Source == volB.Source {
+		t.Errorf("two Config-stamped cells share volume source %q, want distinct", volA.Source)
+	}
+	if !volA.Ensure || !volB.Ensure {
+		t.Errorf("per-cell volume not marked Ensure (A=%v B=%v)", volA.Ensure, volB.Ensure)
+	}
+}

--- a/internal/controller/create_cell.go
+++ b/internal/controller/create_cell.go
@@ -226,6 +226,13 @@ func (b *Exec) createCellInternal(cell intmodel.Cell, startAfterCreate bool) (Cr
 		return res, err
 	}
 
+	// Auto-provision per-cell (ensure) volumes before any container spec is
+	// built, so the volume-reference resolver finds the on-disk directory at
+	// container-create time (#1017).
+	if err = b.ensurePerCellVolumes(cell); err != nil {
+		return res, err
+	}
+
 	preContainerExists := make(map[string]bool)
 
 	// Build minimal internal cell for GetCell lookup

--- a/internal/controller/percell_volume.go
+++ b/internal/controller/percell_volume.go
@@ -1,0 +1,83 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package controller
+
+import (
+	"fmt"
+
+	applypkg "github.com/eminwux/kukeon/internal/controller/apply"
+	"github.com/eminwux/kukeon/internal/errdefs"
+	intmodel "github.com/eminwux/kukeon/internal/modelhub"
+)
+
+// ensurePerCellVolumes auto-provisions every kind: volume mount marked
+// Ensure=true on the cell's containers before its containers are created or
+// started, the daemon-side provisioning half of the per-cell volume claim (step
+// 5, #1017). Materialization sets Ensure on per-cell (${CELL_NAME}) volume
+// mounts, whose Volume cannot be pre-created for a not-yet-named cell; an
+// operator may also set ensure: true directly for Docker-style "create on first
+// reference". Provisioning reuses ReconcileVolume, so it is idempotent (an
+// already-bound cell re-binds its existing Volume rather than minting a fresh
+// one — #1017 AC4) and inherits the scope-existence check, perms, and reclaim
+// handling of `kuke create volume`.
+//
+// A bare-source mount provisions a Volume at the cell's own realm/space/stack;
+// a volumeRef mount provisions at the ref's explicit coordinates. Mounts
+// without Ensure are left to step 4's resolver, which still hard-errors on a
+// missing reference so a typo fails fast.
+func (b *Exec) ensurePerCellVolumes(cell intmodel.Cell) error {
+	for ci := range cell.Spec.Containers {
+		for _, m := range cell.Spec.Containers[ci].Volumes {
+			if m.Kind != intmodel.VolumeKindVolume || !m.Ensure {
+				continue
+			}
+			vol := volumeForEnsureMount(cell, m)
+			if _, err := applypkg.ReconcileVolume(b.runner, vol); err != nil {
+				return fmt.Errorf(
+					"%w: ensure volume %q for cell %q: %w",
+					errdefs.ErrWriteVolume, vol.Metadata.Name, cell.Metadata.Name, err,
+				)
+			}
+		}
+	}
+	return nil
+}
+
+// volumeForEnsureMount builds the Volume an Ensure mount provisions: a volumeRef
+// mount names its Volume by the ref's explicit scope coordinates; a bare-source
+// mount names it in the cell's own scope (where step 4's same-scope resolver
+// finds it most-specific-first).
+func volumeForEnsureMount(cell intmodel.Cell, m intmodel.VolumeMount) intmodel.Volume {
+	if m.VolumeRef != nil {
+		return intmodel.Volume{
+			Metadata: intmodel.VolumeMetadata{
+				Name:  m.VolumeRef.Name,
+				Realm: m.VolumeRef.Realm,
+				Space: m.VolumeRef.Space,
+				Stack: m.VolumeRef.Stack,
+			},
+		}
+	}
+	return intmodel.Volume{
+		Metadata: intmodel.VolumeMetadata{
+			Name:  m.Source,
+			Realm: cell.Spec.RealmName,
+			Space: cell.Spec.SpaceName,
+			Stack: cell.Spec.StackName,
+		},
+	}
+}

--- a/internal/controller/percell_volume_test.go
+++ b/internal/controller/percell_volume_test.go
@@ -1,0 +1,195 @@
+//go:build !integration
+
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+//nolint:testpackage // white-box: exercises the unexported ensurePerCellVolumes path
+package controller
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/eminwux/kukeon/internal/controller/runner"
+	"github.com/eminwux/kukeon/internal/errdefs"
+	intmodel "github.com/eminwux/kukeon/internal/modelhub"
+)
+
+// ensureStubRunner satisfies runner.Runner (via the embedded interface) but
+// implements only the scope-lookup + WriteVolume methods ReconcileVolume
+// touches, recording every provisioned Volume. Any other method panics, which
+// is the assertion that ensurePerCellVolumes provisions through the canonical
+// reconcile path and nothing else.
+type ensureStubRunner struct {
+	runner.Runner
+	writes   []intmodel.Volume
+	writeErr error
+	created  bool
+}
+
+func (s *ensureStubRunner) GetRealm(r intmodel.Realm) (intmodel.Realm, error)  { return r, nil }
+func (s *ensureStubRunner) GetSpace(sp intmodel.Space) (intmodel.Space, error) { return sp, nil }
+func (s *ensureStubRunner) GetStack(st intmodel.Stack) (intmodel.Stack, error) { return st, nil }
+func (s *ensureStubRunner) WriteVolume(v intmodel.Volume) (bool, error) {
+	s.writes = append(s.writes, v)
+	return s.created, s.writeErr
+}
+
+func cellWith(scope [3]string, vols ...intmodel.VolumeMount) intmodel.Cell {
+	return intmodel.Cell{
+		Metadata: intmodel.CellMetadata{Name: "agent-a1b2c3"},
+		Spec: intmodel.CellSpec{
+			RealmName: scope[0],
+			SpaceName: scope[1],
+			StackName: scope[2],
+			Containers: []intmodel.ContainerSpec{{
+				ID:      "app",
+				Volumes: vols,
+			}},
+		},
+	}
+}
+
+// TestEnsurePerCellVolumes_ProvisionsAtCellScope confirms a bare-source ensure
+// mount provisions a Volume named by the source at the cell's own
+// realm/space/stack — where step 4's same-scope resolver finds it (#1017).
+func TestEnsurePerCellVolumes_ProvisionsAtCellScope(t *testing.T) {
+	stub := &ensureStubRunner{created: true}
+	b := &Exec{runner: stub}
+
+	cell := cellWith([3]string{"default", "agents", "team"}, intmodel.VolumeMount{
+		Kind:   intmodel.VolumeKindVolume,
+		Source: "mem-agent-a1b2c3",
+		Target: "/memory",
+		Ensure: true,
+	})
+
+	if err := b.ensurePerCellVolumes(cell); err != nil {
+		t.Fatalf("ensurePerCellVolumes() error = %v", err)
+	}
+	if len(stub.writes) != 1 {
+		t.Fatalf("WriteVolume calls = %d, want 1", len(stub.writes))
+	}
+	got := stub.writes[0].Metadata
+	want := intmodel.VolumeMetadata{Name: "mem-agent-a1b2c3", Realm: "default", Space: "agents", Stack: "team"}
+	if got != want {
+		t.Errorf("provisioned volume = %+v, want %+v", got, want)
+	}
+}
+
+// TestEnsurePerCellVolumes_VolumeRefScopeHonored confirms a cross-scope ensure
+// mount provisions at the ref's explicit coordinates, not the cell's scope.
+func TestEnsurePerCellVolumes_VolumeRefScopeHonored(t *testing.T) {
+	stub := &ensureStubRunner{created: true}
+	b := &Exec{runner: stub}
+
+	cell := cellWith([3]string{"cell-realm", "cell-space", "cell-stack"}, intmodel.VolumeMount{
+		Kind:   intmodel.VolumeKindVolume,
+		Target: "/memory",
+		Ensure: true,
+		VolumeRef: &intmodel.VolumeRef{
+			Name:  "mem-agent-a1b2c3",
+			Realm: "shared-realm",
+			Space: "shared-space",
+		},
+	})
+
+	if err := b.ensurePerCellVolumes(cell); err != nil {
+		t.Fatalf("ensurePerCellVolumes() error = %v", err)
+	}
+	if len(stub.writes) != 1 {
+		t.Fatalf("WriteVolume calls = %d, want 1", len(stub.writes))
+	}
+	got := stub.writes[0].Metadata
+	want := intmodel.VolumeMetadata{Name: "mem-agent-a1b2c3", Realm: "shared-realm", Space: "shared-space"}
+	if got != want {
+		t.Errorf("provisioned volume = %+v, want %+v (ref scope, not cell scope)", got, want)
+	}
+}
+
+// TestEnsurePerCellVolumes_SkipsNonEnsureAndNonVolume confirms the provisioning
+// step is opt-in: a kind: volume mount without Ensure (step 4's default
+// hard-error-on-missing) and bind/tmpfs mounts are never provisioned.
+func TestEnsurePerCellVolumes_SkipsNonEnsureAndNonVolume(t *testing.T) {
+	stub := &ensureStubRunner{created: true}
+	b := &Exec{runner: stub}
+
+	cell := cellWith([3]string{"default", "", ""},
+		intmodel.VolumeMount{Kind: intmodel.VolumeKindVolume, Source: "shared", Target: "/s"}, // no Ensure
+		intmodel.VolumeMount{Kind: intmodel.VolumeKindBind, Source: "/host", Target: "/b", Ensure: true},
+		intmodel.VolumeMount{Kind: intmodel.VolumeKindTmpfs, Target: "/t", Ensure: true},
+	)
+
+	if err := b.ensurePerCellVolumes(cell); err != nil {
+		t.Fatalf("ensurePerCellVolumes() error = %v", err)
+	}
+	if len(stub.writes) != 0 {
+		t.Errorf("WriteVolume calls = %d, want 0 (only ensure kind: volume mounts provision)", len(stub.writes))
+	}
+}
+
+// TestEnsurePerCellVolumes_Idempotent confirms re-running against a cell whose
+// Volume already exists (WriteVolume reports created=false) is a no-op error-
+// wise and re-targets the same deterministic name — never minting a fresh
+// Volume for an already-bound cell (#1017 AC4).
+func TestEnsurePerCellVolumes_Idempotent(t *testing.T) {
+	stub := &ensureStubRunner{created: false} // models an already-provisioned volume
+	b := &Exec{runner: stub}
+
+	cell := cellWith([3]string{"default", "", ""}, intmodel.VolumeMount{
+		Kind:   intmodel.VolumeKindVolume,
+		Source: "mem-agent-a1b2c3",
+		Target: "/memory",
+		Ensure: true,
+	})
+
+	for i := 0; i < 2; i++ {
+		if err := b.ensurePerCellVolumes(cell); err != nil {
+			t.Fatalf("ensurePerCellVolumes() pass %d error = %v", i, err)
+		}
+	}
+	if len(stub.writes) != 2 {
+		t.Fatalf("WriteVolume calls = %d, want 2", len(stub.writes))
+	}
+	if stub.writes[0].Metadata.Name != stub.writes[1].Metadata.Name {
+		t.Errorf("re-provision targeted different names %q vs %q (should be deterministic)",
+			stub.writes[0].Metadata.Name, stub.writes[1].Metadata.Name)
+	}
+}
+
+// TestEnsurePerCellVolumes_PropagatesError confirms a provisioning failure is
+// surfaced (wrapped as ErrWriteVolume) so cell create/start fails fast rather
+// than starting a container whose Volume mount cannot resolve.
+func TestEnsurePerCellVolumes_PropagatesError(t *testing.T) {
+	sentinel := errors.New("disk full")
+	stub := &ensureStubRunner{writeErr: sentinel}
+	b := &Exec{runner: stub}
+
+	cell := cellWith([3]string{"default", "", ""}, intmodel.VolumeMount{
+		Kind:   intmodel.VolumeKindVolume,
+		Source: "mem-agent-a1b2c3",
+		Target: "/memory",
+		Ensure: true,
+	})
+
+	err := b.ensurePerCellVolumes(cell)
+	if !errors.Is(err, errdefs.ErrWriteVolume) {
+		t.Errorf("error = %v, want wrapped ErrWriteVolume", err)
+	}
+	if !errors.Is(err, sentinel) {
+		t.Errorf("error = %v, want to wrap the underlying cause", err)
+	}
+}

--- a/internal/controller/percell_volume_test.go
+++ b/internal/controller/percell_volume_test.go
@@ -20,13 +20,27 @@
 package controller
 
 import (
+	"context"
 	"errors"
+	"io"
+	"log/slog"
 	"testing"
 
 	"github.com/eminwux/kukeon/internal/controller/runner"
 	"github.com/eminwux/kukeon/internal/errdefs"
 	intmodel "github.com/eminwux/kukeon/internal/modelhub"
 )
+
+// newReapplyTestExec builds an *Exec with a discard logger + context for the
+// reapply-helper tests, whose success paths log via b.logger/b.ctx (the
+// ensure-only tests above use a bare &Exec{runner: stub} because they never log).
+func newReapplyTestExec(r runner.Runner) *Exec {
+	return &Exec{
+		ctx:    context.Background(),
+		logger: slog.New(slog.NewTextHandler(io.Discard, nil)),
+		runner: r,
+	}
+}
 
 // ensureStubRunner satisfies runner.Runner (via the embedded interface) but
 // implements only the scope-lookup + WriteVolume methods ReconcileVolume
@@ -191,5 +205,99 @@ func TestEnsurePerCellVolumes_PropagatesError(t *testing.T) {
 	}
 	if !errors.Is(err, sentinel) {
 		t.Errorf("error = %v, want to wrap the underlying cause", err)
+	}
+}
+
+// reapplyStubRunner records the order of the runner calls the reapply helpers
+// make — WriteVolume (via ReconcileVolume), RecreateCell, StartCell, UpdateCell —
+// so the per-cell-volume tests can assert provisioning precedes the container
+// rebuild. Scope getters return their input (the scope exists); the embedded
+// runner.Runner panics on any other method, asserting nothing else is touched.
+type reapplyStubRunner struct {
+	runner.Runner
+	order *[]string
+	out   intmodel.Cell
+}
+
+func (s *reapplyStubRunner) GetRealm(r intmodel.Realm) (intmodel.Realm, error)  { return r, nil }
+func (s *reapplyStubRunner) GetSpace(sp intmodel.Space) (intmodel.Space, error) { return sp, nil }
+func (s *reapplyStubRunner) GetStack(st intmodel.Stack) (intmodel.Stack, error) { return st, nil }
+
+func (s *reapplyStubRunner) WriteVolume(v intmodel.Volume) (bool, error) {
+	*s.order = append(*s.order, "WriteVolume:"+v.Metadata.Name)
+	return true, nil
+}
+
+func (s *reapplyStubRunner) RecreateCell(_ intmodel.Cell) (intmodel.Cell, error) {
+	*s.order = append(*s.order, "RecreateCell")
+	return s.out, nil
+}
+
+func (s *reapplyStubRunner) StartCell(_ intmodel.Cell) (intmodel.Cell, error) {
+	*s.order = append(*s.order, "StartCell")
+	return s.out, nil
+}
+
+func (s *reapplyStubRunner) UpdateCell(_ intmodel.Cell) (intmodel.Cell, error) {
+	*s.order = append(*s.order, "UpdateCell")
+	return s.out, nil
+}
+
+// desiredWithEnsureMount builds a re-materialised `desired` cell carrying a
+// single bare-source ensure mount — the shape ExpandPerCellVolumes stamps when a
+// Config edit adds a ${CELL_NAME} mount.
+func desiredWithEnsureMount() intmodel.Cell {
+	return cellWith([3]string{"default", "agents", "team"}, intmodel.VolumeMount{
+		Kind:   intmodel.VolumeKindVolume,
+		Source: "mem-agent-a1b2c3",
+		Target: "/memory",
+		Ensure: true,
+	})
+}
+
+// TestReapplyBreaking_ProvisionsDesiredBeforeRecreate is the #1294 reconcile-gap
+// regression: an OutOfSync breaking reapply re-materialises a `desired` spec that
+// may add a new per-cell ${CELL_NAME} mount the StartCell-level ensure pass (run
+// against the on-disk spec) never saw. reapplyBreaking must provision `desired`'s
+// ensure volumes *before* RecreateCell rebuilds containers against it, or step
+// 4's resolver hard-errors on the unprovisioned Volume and OutOfSync never
+// converges.
+func TestReapplyBreaking_ProvisionsDesiredBeforeRecreate(t *testing.T) {
+	var order []string
+	out := desiredWithEnsureMount()
+	out.Status.State = intmodel.CellStateReady
+	b := newReapplyTestExec(&reapplyStubRunner{order: &order, out: out})
+
+	cell := desiredWithEnsureMount()
+	_, started, ok := b.reapplyBreaking(cell, desiredWithEnsureMount(), "cfg")
+	if !ok || !started {
+		t.Fatalf("reapplyBreaking() = (_, started=%v, ok=%v), want both true", started, ok)
+	}
+	want := []string{"WriteVolume:mem-agent-a1b2c3", "RecreateCell"}
+	if len(order) != 2 || order[0] != want[0] || order[1] != want[1] {
+		t.Errorf("call order = %v, want %v (provision before recreate)", order, want)
+	}
+}
+
+// TestReapplyCompatibleInPlace_ProvisionsDesiredBeforeUpdate is the in-place
+// counterpart of the #1294 gap: a compatible/additive reapply that adds a new
+// per-cell mount must provision `desired`'s ensure volumes before UpdateCell
+// stop-removes-recreates the affected child against it. StartCell (on the on-disk
+// spec) runs first and needs no new Volume; the provision lands between StartCell
+// and UpdateCell.
+func TestReapplyCompatibleInPlace_ProvisionsDesiredBeforeUpdate(t *testing.T) {
+	var order []string
+	out := desiredWithEnsureMount()
+	out.Status.State = intmodel.CellStateReady
+	b := newReapplyTestExec(&reapplyStubRunner{order: &order, out: out})
+
+	cell := desiredWithEnsureMount()
+	_, started, ok := b.reapplyCompatibleInPlace(cell, desiredWithEnsureMount(), "cfg")
+	if !ok || !started {
+		t.Fatalf("reapplyCompatibleInPlace() = (_, started=%v, ok=%v), want both true", started, ok)
+	}
+	want := []string{"StartCell", "WriteVolume:mem-agent-a1b2c3", "UpdateCell"}
+	if len(order) != 3 || order[0] != want[0] || order[1] != want[1] || order[2] != want[2] {
+		t.Errorf("call order = %v, want %v (provision between start and update)", order, want)
 	}
 }

--- a/internal/controller/start_cell.go
+++ b/internal/controller/start_cell.go
@@ -56,6 +56,14 @@ func (b *Exec) StartCell(cell intmodel.Cell) (StartCellResult, error) {
 	// bare `kuke start <cell>` never sets RuntimeEnv).
 	internalCell.Spec.RuntimeEnv = cell.Spec.RuntimeEnv
 
+	// Auto-provision per-cell (ensure) volumes before any start/recreate path
+	// rebuilds a container OCI spec, so the volume-reference resolver finds the
+	// on-disk directory. Idempotent, so a restart re-binds the cell's existing
+	// Volume and preserves its contents (#1017).
+	if err = b.ensurePerCellVolumes(internalCell); err != nil {
+		return res, err
+	}
+
 	// Recovery routing for the terminal-by-derivation states, evaluated BEFORE
 	// the "already running" guard below. The ordering is load-bearing (#1274): a
 	// sticky Error/Failed cell keeps its root container alive — cell state is

--- a/internal/controller/start_cell.go
+++ b/internal/controller/start_cell.go
@@ -56,10 +56,14 @@ func (b *Exec) StartCell(cell intmodel.Cell) (StartCellResult, error) {
 	// bare `kuke start <cell>` never sets RuntimeEnv).
 	internalCell.Spec.RuntimeEnv = cell.Spec.RuntimeEnv
 
-	// Auto-provision per-cell (ensure) volumes before any start/recreate path
-	// rebuilds a container OCI spec, so the volume-reference resolver finds the
-	// on-disk directory. Idempotent, so a restart re-binds the cell's existing
-	// Volume and preserves its contents (#1017).
+	// Auto-provision the on-disk spec's per-cell (ensure) volumes before any
+	// start/recreate path rebuilds a container OCI spec, so the volume-reference
+	// resolver finds the on-disk directory. Idempotent, so a restart re-binds the
+	// cell's existing Volume and preserves its contents (#1017). The OutOfSync
+	// reapply below re-materialises a fresh `desired` spec whose newly-added
+	// ${CELL_NAME} mounts this pass cannot see; reapplyBreaking /
+	// reapplyCompatibleInPlace provision `desired` separately before handing it to
+	// the runner (#1294 review).
 	if err = b.ensurePerCellVolumes(internalCell); err != nil {
 		return res, err
 	}
@@ -286,6 +290,24 @@ func (b *Exec) reapplyOutOfSyncFromConfig(cell intmodel.Cell) (intmodel.Cell, bo
 // Ready. Mirrors the restart CLI's ApplyDocuments+StopCell+StartCell sequence
 // for a Stopped cell. On failure the caller falls back to the on-disk spec.
 func (b *Exec) reapplyBreaking(cell, desired intmodel.Cell, configName string) (intmodel.Cell, bool, bool) {
+	// Provision the re-materialised spec's per-cell (ensure) volumes before
+	// RecreateCell rebuilds containers against `desired`. The StartCell-level
+	// ensurePerCellVolumes pass ran against the pre-reapply on-disk spec, so a
+	// Config edit that *adds* a new ${CELL_NAME} mount has no provisioned Volume
+	// yet — RecreateCell would then build a container against a Volume step 4's
+	// resolver hard-errors on, and OutOfSync never converges (#1017, #1294
+	// review). Idempotent, so an already-bound cell re-binds in place. On
+	// failure, fall back to the on-disk spec like the RecreateCell path below.
+	if err := b.ensurePerCellVolumes(desired); err != nil {
+		b.logger.WarnContext(b.ctx,
+			"OutOfSync reapply ensure-volumes failed; falling back to on-disk spec",
+			"cell", cell.Metadata.Name,
+			"config", configName,
+			"error", err,
+		)
+		return intmodel.Cell{}, false, false
+	}
+
 	recreated, err := b.runner.RecreateCell(desired)
 	if err != nil {
 		b.logger.WarnContext(b.ctx,
@@ -328,6 +350,26 @@ func (b *Exec) reapplyCompatibleInPlace(
 			"error", err,
 		)
 		return intmodel.Cell{}, false, false
+	}
+
+	// Provision the re-materialised spec's per-cell (ensure) volumes before
+	// UpdateCell stop-removes-recreates any child whose spec changed against
+	// `desired`. The StartCell-level ensurePerCellVolumes pass ran against the
+	// pre-reapply on-disk spec, so a Config edit that *adds* a new ${CELL_NAME}
+	// mount has no provisioned Volume yet — UpdateCell would rebuild the affected
+	// child against a Volume step 4's resolver hard-errors on (#1017, #1294
+	// review). Idempotent, so an already-bound cell re-binds in place. StartCell
+	// above already restarted the root on its on-disk snapshot (no new mount), so
+	// a failure here mirrors the UpdateCell-failure path: the cell is Ready on the
+	// on-disk spec, OutOfSync stays set, and the next start retries.
+	if err := b.ensurePerCellVolumes(desired); err != nil {
+		b.logger.WarnContext(b.ctx,
+			"OutOfSync reapply ensure-volumes failed; cell started on the on-disk spec but not reconciled",
+			"cell", cell.Metadata.Name,
+			"config", configName,
+			"error", err,
+		)
+		return started, true, true
 	}
 
 	updated, err := b.runner.UpdateCell(desired)

--- a/internal/modelhub/container.go
+++ b/internal/modelhub/container.go
@@ -225,6 +225,11 @@ type VolumeMount struct {
 	// Only honored when Kind == VolumeKindTmpfs; zero leaves the kernel
 	// default (01777).
 	Mode uint32
+	// Ensure auto-provisions the referenced kind: Volume at cell create/start
+	// when absent (opt-in "create on first reference"). Set by materialization
+	// on per-cell (${CELL_NAME}) volume claims; idempotent so an already-bound
+	// cell re-binds its existing Volume. Step 5 (#1017).
+	Ensure bool
 }
 
 // VolumeRef mirrors the v1beta1 VolumeRef payload — a name + scope pointing at

--- a/pkg/api/model/v1beta1/container.go
+++ b/pkg/api/model/v1beta1/container.go
@@ -334,6 +334,18 @@ type VolumeMount struct {
 	ReadOnly  bool       `json:"readOnly,omitempty"  yaml:"readOnly,omitempty"`
 	SizeBytes int64      `json:"sizeBytes,omitempty" yaml:"sizeBytes,omitempty"`
 	Mode      uint32     `json:"mode,omitempty"      yaml:"mode,omitempty"`
+	// Ensure, when true on a kind: volume mount, auto-provisions the referenced
+	// Volume at cell create/start if it does not already exist — Docker's
+	// "create on first reference" semantics (umbrella #1015), the opt-in
+	// counterpart to step 4's default "missing volume is a hard error". It is
+	// the provisioning half of the per-cell volume claim: materialization sets
+	// Ensure on any volume mount whose source embeds the ${CELL_NAME} template
+	// (cellblueprint.ExpandPerCellVolumes), since a per-cell Volume cannot be
+	// pre-created for a not-yet-named cell. Auto-create is idempotent (an
+	// already-bound cell re-binds its existing Volume, never minting a fresh
+	// one) so reconcile and recreate preserve the Volume's contents. Step 5
+	// (#1017).
+	Ensure bool `json:"ensure,omitempty"    yaml:"ensure,omitempty"`
 }
 
 // VolumeRef points at a daemon-managed kind: Volume (issue #1018) by name and


### PR DESCRIPTION
## Summary

Step 5 of the volumes epic (umbrella #1015). A 1:N binding (CellBlueprint / CellConfig) that stamps N cells can now give each cell its **own private, durable Volume**, so per-agent memory isolates by name rather than by scope (which no longer auto-isolates after step 4).

- **Naming** — a binding embeds the reserved `${CELL_NAME}` template variable in a `kind: volume` mount source (e.g. `source: mem-${CELL_NAME}`). Materialization expands it against the cell's generated name *after* the name exists, so N stamped cells yield N distinct Volume names (`mem-<cellA>`, `mem-<cellB>`, …). Shared by both the blueprint and config materialize paths (`cellblueprint.ExpandPerCellVolumes`).
- **Provisioning** — expansion also flips a new `ensure` flag on the mount; at cell create/start the daemon auto-provisions each `ensure` Volume via the canonical `ReconcileVolume` (scope check + idempotent `WriteVolume`, correct perms/reclaim). This is the umbrella's "optional auto-create on first reference", made opt-in so step 4's default (a missing volume is a hard error → typos fail fast) is preserved for statically-named mounts.
- **Idempotency / inheritance** — names are deterministic from the cell name and provisioning is create-if-absent, so re-materialize/reconcile/recreate re-bind the *existing* Volume rather than minting a fresh one. Combined with step 1/4's standalone-Volume lifecycle (a Volume outlives its cell), a same-identity successor inherits the contents.

## Design decision (AC4): template variable, not a new claim-template schema

I chose the **`${CELL_NAME}` template variable + opt-in `ensure` auto-provision** over a new binding-level `volumeClaimTemplates` array. Rationale (lower blast radius): it reuses the existing `${KEY}` substitution surface and the existing `kind: volume` mount + `ReconcileVolume` provisioning, adding only one serialized bool and a post-name expansion pass — versus a new top-level schema kind and a separate mint pipeline. It also matches the AC's own example (`source: mem-${CELL_NAME}`). `CELL_NAME` is reserved (a blueprint should not declare a `${KEY}` parameter of that name; Resolve would consume the token first).

## How each AC is met

- **N-cell fan-out isolation** — `ExpandPerCellVolumes` rewrites to distinct names per cell; `ensurePerCellVolumes` provisions one Volume each at the cell's own scope (a `volumeRef` mount provisions at the ref's explicit scope). Covered by blueprint/config materialize fan-out tests + the controller provisioning test.
- **Standalone + survives delete + successor inherits** — provisioned Volumes are ordinary step-1 Volumes (cell delete never touches them); deterministic naming re-binds the same Volume for a same-name successor. Covered by the determinism test; the on-disk survival/recreate guarantee is step 4's `TestVolume_SurvivesContainerRecreate`.
- **Spec-change reconcile retains contents** — re-materialization yields the same Volume name + `ensure` (consistent both sides of `DiffCell`), and provisioning is create-if-absent, so a recreate re-binds the same directory. `ensurePerCellVolumes` is invoked on both the create and start/recreate paths.
- **No fresh mint for an already-bound cell** — deterministic name + create-if-absent; idempotency test asserts re-provision targets the same name.

## Notes for the reviewer

- **Aliasing fix:** `ExpandPerCellVolumes` clones each container's `Volumes` slice before mutating. `materializeContainer` copies the slice header (not elements), so without the clone, expanding one stamped cell would overwrite the shared template and collapse the next cell's name onto the first — caught by the fan-out test.
- **Out of scope (PM doc lane):** `docs/site/manifests/container.md`'s VolumeMount table is already stale from step 4 (still lists `kind: bind|tmpfs` and "managed volumes are not supported", omitting `kind: volume`/`volumeRef`). Documenting `ensure`/`${CELL_NAME}` there means first repairing step-4's omissions — a `documentation`-lane change owned by PM. AC4's "documented in the PR" is satisfied here + by the in-code godoc on `Ensure`, `CellNameVar`, and `ExpandPerCellVolumes`. Flagging for a PM doc follow-up.
- `ensure: true` on a non-`kind: volume` mount is silently ignored (matches the lenient bind/tmpfs handling); no new apischeme rejection added to keep blast radius minimal.
- **Reconcile-path provisioning (review fix-up, `cff9c13`):** the StartCell-level `ensurePerCellVolumes` pass runs against the *pre-reapply on-disk* spec, so an OutOfSync reapply that re-materialises a `desired` spec adding a new `${CELL_NAME}` mount had no provisioned Volume before `RecreateCell(desired)` / `UpdateCell(desired)` rebuilt containers against it — step 4's resolver would hard-error and OutOfSync never converge. `reapplyBreaking` and `reapplyCompatibleInPlace` now call `b.ensurePerCellVolumes(desired)` before the runner rebuild (idempotent; failure falls back to the on-disk spec like the adjacent runner-failure paths). This makes the "invoked on both create and start/recreate paths" claim above actually hold on the reconcile path.

## Test plan

- [x] `make test` (full CI suite, `GOWORK=off`) — passed
- [x] `GOWORK=off go vet ./internal/... ./pkg/...` on touched packages — clean
- [x] `gofmt -l` on all touched files — clean
- [x] New unit tests: `internal/cellblueprint` (expansion, clone-no-alias, determinism, fan-out distinct names + Ensure), `internal/cellconfig` (config-path expansion), `internal/controller` (provision at cell scope, volumeRef scope, skip non-ensure/non-volume, idempotent, error propagation, **reapply-path provision-before-recreate / provision-before-update ordering — review fix-up**)
- [ ] End-to-end on-device (real containers writing a sentinel into a per-cell Volume, surviving cell delete) — not run; covered conceptually by step 4's recreate-survival test + this PR's determinism/provisioning unit tests. The `make dev-init` smoke does not exercise volume claims.

Closes #1017
