### PR TITLE
fix: guard ListVolumes filter segments against path traversal

### DIFF
--- a/internal/controller/volume.go
+++ b/internal/controller/volume.go
@@ -194,7 +194,12 @@ func validateVolumeSegment(value string) error {
 // validateVolumeScopeFilter enforces the scope contract for a list filter:
 // realm is optional (an empty realm lists across all realms), but a set deeper
 // coordinate still requires every shallower one. A Volume is never cell-scoped,
-// so the filter bottoms out at stack.
+// so the filter bottoms out at stack. Each set coordinate is also screened for
+// unsafe path segments (issue #1293): ListVolumes passes the raw segments to
+// the runner's childScopeNames, which filepath.Joins them onto the scope dir,
+// so an unscreened "space=.." would stat/enumerate a parent scope — the same
+// `..`/separator traversal class validateVolumeSegment closes for single-volume
+// lookups. An empty segment is allowed (it means "unset", not unsafe).
 func validateVolumeScopeFilter(realm, space, stack string) error {
 	realm = strings.TrimSpace(realm)
 	space = strings.TrimSpace(space)
@@ -205,6 +210,15 @@ func validateVolumeScopeFilter(realm, space, stack string) error {
 	}
 	if stack != "" && space == "" {
 		return fmt.Errorf("%w (stack set without space)", errdefs.ErrVolumeScopeIncomplete)
+	}
+	for _, seg := range []struct{ field, value string }{
+		{"realm", realm},
+		{"space", space},
+		{"stack", stack},
+	} {
+		if err := validateVolumeSegment(seg.value); err != nil {
+			return fmt.Errorf("%w (%s)", err, seg.field)
+		}
 	}
 	return nil
 }

--- a/internal/controller/volume_test.go
+++ b/internal/controller/volume_test.go
@@ -236,6 +236,18 @@ func TestListVolumes_FilterGuard(t *testing.T) {
 	}
 }
 
+// TestListVolumes_UnsafeFilterSegment confirms an unsafe filter segment (a
+// path-traversal "..") is rejected before the runner is touched, closing the
+// info-disclosure surface where childScopeNames would filepath.Join the raw
+// segment onto a parent scope dir (issue #1293).
+func TestListVolumes_UnsafeFilterSegment(t *testing.T) {
+	ctrl := setupTestController(t, &fakeRunner{})
+	_, err := ctrl.ListVolumes("default", "..", "")
+	if !errors.Is(err, errdefs.ErrVolumeCoordUnsafe) {
+		t.Errorf("ListVolumes(unsafe space) = %v, want ErrVolumeCoordUnsafe", err)
+	}
+}
+
 // TestListVolumes_PassesThrough confirms a valid filter reaches the runner and
 // returns its result.
 func TestListVolumes_PassesThrough(t *testing.T) {


### PR DESCRIPTION
## Summary
- Follow-up nit from PR #1288's 2nd-reviewer pass. The single-volume lookup ops (create/get/delete) reject unsafe path segments via `validateVolumeLookup`/`validateVolumeSegment`, but `ListVolumes` was unguarded.
- `validateVolumeScopeFilter` validated only coordinate contiguity and passed raw segments to the runner. In `internal/controller/runner/scope_children.go:67`, `childScopeNames` does `filepath.Join(dir, want)` + `os.Stat`, so a filter like `space=".."` would stat/enumerate a parent scope — a read-only, bounded path-traversal / info-disclosure surface (the same `..`/separator class PR #1288 closed for single-volume ops).
- Fix runs each set filter coordinate (realm/space/stack) through the existing `validateVolumeSegment` (empty allowed) inside `validateVolumeScopeFilter` — the controller-level guard placement matches how `validateVolumeLookup` already screens single-volume ops, so the runner's `childScopeNames` is unchanged.

## Test plan
- [x] `GOWORK=off go build ./internal/controller/...` and `go vet` pass
- [x] `GOWORK=off go test ./internal/controller/ -run Volume -v` — new `TestListVolumes_UnsafeFilterSegment` passes alongside existing filter-guard/pass-through tests
- [x] `make test` (full CI target, `GOWORK=off` per Makefile) — exit 0, no FAIL

Closes #1293