### PR TITLE
fix: guard volume list filter coordinates against path traversal

### DIFF
--- a/internal/controller/volume.go
+++ b/internal/controller/volume.go
@@ -194,7 +194,10 @@ func validateVolumeSegment(value string) error {
 // validateVolumeScopeFilter enforces the scope contract for a list filter:
 // realm is optional (an empty realm lists across all realms), but a set deeper
 // coordinate still requires every shallower one. A Volume is never cell-scoped,
-// so the filter bottoms out at stack.
+// so the filter bottoms out at stack. Each set coordinate is also segment-guarded
+// (issue #1289) so a `..` filter can't traverse out of the scope dir downstream
+// in childScopeNames/resolveRealmDirs; empty coordinates are legal and skipped
+// by validateVolumeSegment, bringing the list path to parity with the lookup path.
 func validateVolumeScopeFilter(realm, space, stack string) error {
 	realm = strings.TrimSpace(realm)
 	space = strings.TrimSpace(space)
@@ -205,6 +208,15 @@ func validateVolumeScopeFilter(realm, space, stack string) error {
 	}
 	if stack != "" && space == "" {
 		return fmt.Errorf("%w (stack set without space)", errdefs.ErrVolumeScopeIncomplete)
+	}
+	for _, seg := range []struct{ field, value string }{
+		{"realm", realm},
+		{"space", space},
+		{"stack", stack},
+	} {
+		if err := validateVolumeSegment(seg.value); err != nil {
+			return fmt.Errorf("%w (%s)", err, seg.field)
+		}
 	}
 	return nil
 }

--- a/internal/controller/volume_test.go
+++ b/internal/controller/volume_test.go
@@ -236,6 +236,17 @@ func TestListVolumes_FilterGuard(t *testing.T) {
 	}
 }
 
+// TestListVolumes_RejectsUnsafeFilterSegment confirms a `..` filter coordinate
+// is rejected before the runner is touched (issue #1289), bringing the list
+// path to parity with the single-volume lookup path.
+func TestListVolumes_RejectsUnsafeFilterSegment(t *testing.T) {
+	ctrl := setupTestController(t, &fakeRunner{})
+	_, err := ctrl.ListVolumes("default", "..", "")
+	if !errors.Is(err, errdefs.ErrVolumeCoordUnsafe) {
+		t.Errorf("ListVolumes(unsafe space) = %v, want ErrVolumeCoordUnsafe", err)
+	}
+}
+
 // TestListVolumes_PassesThrough confirms a valid filter reaches the runner and
 // returns its result.
 func TestListVolumes_PassesThrough(t *testing.T) {


### PR DESCRIPTION
## Summary
- `ListVolumes` routed through `validateVolumeScopeFilter`, which (unlike `validateVolumeLookup`) applied no segment guard, so a `..` filter coordinate would traverse out of the scope dir downstream — `childScopeNames` does `filepath.Join(dir, want)` + `os.Stat` (`internal/controller/runner/scope_children.go:67`) and `resolveRealmDirs` has the same shape (`internal/controller/runner/get.go:210`), enabling read-only enumeration of volume names in an adjacent scope.
- Extend the existing `validateVolumeSegment` guard to each set filter coordinate (realm/space/stack). Empty coordinates remain legal for a list filter — `validateVolumeSegment` returns `nil` on empty — so the cross-realm/all-scopes list semantics are preserved while bringing the list path to parity with the single-volume lookup path PR #1288 fixed.

## Test plan
- [x] `make test` (test-root + test-kukebuild) — all green
- [x] `go test ./internal/controller/ -run TestListVolumes -v` — `TestListVolumes_RejectsUnsafeFilterSegment` (new) plus `_FilterGuard` and `_PassesThrough` pass
- [x] `go vet ./internal/controller/`

Closes #1289