### PR TITLE
feat: chown referenced Volume dir to the mounting container uid at mount time (volumes step 4 follow-up)

### DIFF
--- a/internal/controller/runner/provision.go
+++ b/internal/controller/runner/provision.go
@@ -1612,6 +1612,11 @@ func (r *Exec) createCellContainers(cell *intmodel.Cell) (containerd.Container, 
 					"failed to chown attachable tty dir for %s: %w", containerdID, chownErr,
 				)
 			}
+			if volErr := r.volumePostCreateChown(namespace, containerSpec); volErr != nil {
+				return nil, fmt.Errorf(
+					"failed to chown volume dir for %s: %w", containerdID, volErr,
+				)
+			}
 		}
 	}
 
@@ -2109,6 +2114,11 @@ func (r *Exec) ensureCellContainers(cell *intmodel.Cell) (containerd.Container, 
 				if chownErr := r.attachablePostCreateChown(internalRealm.Spec.Namespace, containerSpec); chownErr != nil {
 					return nil, fmt.Errorf(
 						"failed to chown attachable tty dir for %s: %w", containerdID, chownErr,
+					)
+				}
+				if volErr := r.volumePostCreateChown(internalRealm.Spec.Namespace, containerSpec); volErr != nil {
+					return nil, fmt.Errorf(
+						"failed to chown volume dir for %s: %w", containerdID, volErr,
 					)
 				}
 			}

--- a/internal/controller/runner/start.go
+++ b/internal/controller/runner/start.go
@@ -1150,6 +1150,11 @@ func (r *Exec) startCellLocked(cell intmodel.Cell) (_ intmodel.Cell, retErr erro
 				"failed to chown attachable tty dir for %s: %w", ctrContainerID, attachErr,
 			)
 		}
+		if volErr := r.volumePostCreateChown(namespace, containerSpec); volErr != nil {
+			return intmodel.Cell{}, fmt.Errorf(
+				"failed to chown volume dir for %s: %w", ctrContainerID, volErr,
+			)
+		}
 
 		// Use container name with UUID for containerd operations
 		specWithNamespaces := ctr.JoinContainerNamespaces(
@@ -1450,6 +1455,11 @@ func (r *Exec) StartContainer(cell intmodel.Cell, containerID string) (_ intmode
 	if attachErr = r.attachablePostCreateChown(namespace, *foundContainerSpec); attachErr != nil {
 		return intmodel.Cell{}, fmt.Errorf(
 			"failed to chown attachable tty dir for %s: %w", containerdID, attachErr,
+		)
+	}
+	if volErr := r.volumePostCreateChown(namespace, *foundContainerSpec); volErr != nil {
+		return intmodel.Cell{}, fmt.Errorf(
+			"failed to chown volume dir for %s: %w", containerdID, volErr,
 		)
 	}
 

--- a/internal/controller/runner/volume.go
+++ b/internal/controller/runner/volume.go
@@ -41,8 +41,9 @@ const volumesDirMode os.FileMode = 0o755
 // inside inherit the kukeon group, mirroring attachableTTYDirRootMode's
 // model — the directory is owned root:kukeon so the daemon and kuke-group
 // operators can manage it without exposing volume contents world-wide. The
-// mounting container's own uid is wired in at mount time in step 4 (#1016),
-// the same two-phase shape as attachablePostCreateChown.
+// mounting container's own uid is wired in as the directory owner at container
+// create by volumePostCreateChown, the same two-phase shape as
+// attachablePostCreateChown (step 4 follow-up, #1291).
 const volumeDirRootMode os.FileMode = os.ModeSetgid | 0o0770
 
 // volumeDirFallbackMode is the mode used when no kukeon group GID is
@@ -70,6 +71,22 @@ func volumeDirInitialPerms(kukeonGroupGID int) (os.FileMode, int) {
 // MkdirAll is idempotent, so re-applying an existing volume re-asserts the
 // mode/owner and reports created=false. The caller (ReconcileVolume) is
 // responsible for having verified the scope exists.
+//
+// Cross-uid sharing contract. At container create the mounting container's
+// resolved process uid is granted *owner* write on the resolved directory by
+// volumePostCreateChown, so a non-root workload can write into the Volume even
+// without kukeon-group membership. Only the owner is reset — the setgid
+// root:kukeon group is preserved — so two cells that mount the same Volume as
+// different non-root uids each re-own it at their own create and the last
+// writer wins the owner bit. Cross-uid *shared* write therefore relies on the
+// kukeon group (setgid group-write), not the owner chown. Two consequences of
+// the WriteVolume re-apply make this durable rather than racy: when the kukeon
+// group is configured a reconcile re-apply chowns the owner back to root, but
+// group-write persists; in the no-group fallback WriteVolume issues no chown at
+// all, so the mount-time owner grant survives reconcile. Per-cell volume
+// identity (step 5, #1294 — ${CELL_NAME} claims) gives each cell its own Volume
+// directory and is the supported pattern when distinct uids each need exclusive
+// owner-write. Step 4 follow-up (#1291).
 func (r *Exec) WriteVolume(volume intmodel.Volume) (bool, error) {
 	md := volume.Metadata
 	dir := fs.VolumesDir(r.opts.RunPath, md.Realm, md.Space, md.Stack)
@@ -132,6 +149,99 @@ func (r *Exec) WriteVolume(volume intmodel.Volume) (bool, error) {
 		"reclaimPolicy", string(volume.Spec.ReclaimPolicy),
 	)
 	return created, nil
+}
+
+// volumePostCreateChown grants the mounting container's resolved process uid
+// owner write on every writable kind: volume directory the container mounts,
+// mirroring attachablePostCreateChown's two-phase shape: containerd resolves
+// the image USER (and any container.user override) only when the runtime spec
+// is built during container create, so the uid is unknowable before
+// CreateContainerFromSpec. Without this a non-root workload that carries
+// neither uid 0 nor the kukeon group GID cannot write into a Volume it mounts
+// on a host where no kukeon group is configured (the fallback dir is root:root
+// 0o770).
+//
+// A no-op when the container declares no kind: volume mount (the common case
+// pays no containerd round-trip) and when the resolved uid is 0 (a root
+// container already owns the root-owned dir). Read-only mounts are skipped —
+// the container cannot write through them, so re-owning the directory away from
+// another mounter would be pointless. The mount references are re-resolved from
+// the stored spec via the same ResolveVolumeMount walk the create path uses;
+// CreateContainerFromSpec rewrites only its own by-value copy of the spec, so
+// the runner's spec still carries the kind: volume reference here.
+//
+// Multi-mounter contract: only the *owner* is reset, so cross-uid shared write
+// relies on the kukeon group (setgid group-write), not this chown — see the
+// WriteVolume godoc for the full cross-uid sharing contract. Step 4 follow-up
+// (#1291).
+func (r *Exec) volumePostCreateChown(namespace string, spec intmodel.ContainerSpec) error {
+	scope := ctr.VolumeScope{
+		Realm: spec.RealmName,
+		Space: spec.SpaceName,
+		Stack: spec.StackName,
+	}
+	var targets []string
+	for i := range spec.Volumes {
+		m := spec.Volumes[i]
+		if m.Kind != intmodel.VolumeKindVolume || m.ReadOnly {
+			continue
+		}
+		resolved, err := ctr.ResolveVolumeMount(r.opts.RunPath, scope, m)
+		if err != nil {
+			// The mount already resolved when the container was created, so a
+			// miss here is unexpected — surface it rather than silently leaving
+			// a directory the workload expects to be writable owned by root.
+			return fmt.Errorf("resolve volume mount for target %q: %w", m.Target, err)
+		}
+		targets = append(targets, resolved.HostPath)
+	}
+	if len(targets) == 0 {
+		return nil
+	}
+
+	containerdID := spec.ContainerdID
+	if containerdID == "" {
+		containerdID = spec.ID
+	}
+	container, err := r.ctrClient.GetContainer(namespace, containerdID)
+	if err != nil {
+		return fmt.Errorf("get container %q: %w", containerdID, err)
+	}
+	uid, err := r.ctrClient.ContainerProcessUID(namespace, container)
+	if err != nil {
+		return fmt.Errorf("resolve process uid for %q: %w", containerdID, err)
+	}
+	if uid == 0 {
+		// Root container: it already owns the root-owned volume dir, and a
+		// reconcile re-apply would chown it back to root anyway. Nothing to grant.
+		return nil
+	}
+
+	for _, path := range targets {
+		if chownErr := r.chownVolumeDirToUID(path, int(uid)); chownErr != nil {
+			return chownErr
+		}
+	}
+	return nil
+}
+
+// chownVolumeDirToUID resets a provisioned Volume directory's owner to uid while
+// preserving the group and the setgid + 0o770 contract WriteVolume established.
+// The gid is left untouched (Chown -1) so the kukeon group survives the owner
+// flip and the kukeon-group-write path is never regressed; the mode is then
+// re-asserted from volumeDirInitialPerms so the setgid bit is explicitly
+// guaranteed (root's chown preserves it via CAP_FSETID, but the re-chmod makes
+// the group-inheritance guarantee independent of that, matching WriteVolume's
+// "assert the contract unconditionally" stance).
+func (r *Exec) chownVolumeDirToUID(path string, uid int) error {
+	if err := os.Chown(path, uid, -1); err != nil {
+		return fmt.Errorf("%w: chown volume dir %q to uid %d: %w", errdefs.ErrWriteVolume, path, uid, err)
+	}
+	mode, _ := volumeDirInitialPerms(r.opts.KukeonGroupGID)
+	if err := os.Chmod(path, mode); err != nil {
+		return fmt.Errorf("%w: chmod volume dir %q: %w", errdefs.ErrWriteVolume, path, err)
+	}
+	return nil
 }
 
 // GetVolume reports whether a single named, scoped Volume exists on disk and

--- a/internal/controller/runner/volume_test.go
+++ b/internal/controller/runner/volume_test.go
@@ -20,13 +20,18 @@
 package runner
 
 import (
+	"context"
 	"errors"
+	"io"
+	"log/slog"
 	"os"
 	"sort"
 	"strings"
 	"testing"
 	"time"
 
+	containerd "github.com/containerd/containerd/v2/client"
+	"github.com/eminwux/kukeon/internal/ctr"
 	"github.com/eminwux/kukeon/internal/errdefs"
 	intmodel "github.com/eminwux/kukeon/internal/modelhub"
 	"github.com/eminwux/kukeon/internal/util/fs"
@@ -344,4 +349,182 @@ func TestVolume_NotMistakenForChildScope(t *testing.T) {
 	if !equalStrings(got, want) {
 		t.Errorf("ListBlueprints(all) = %v, want %v (volumes/ subdir must be ignored, not traversed as a phantom space)", got, want)
 	}
+}
+
+// volumeChownFakeClient makes ContainerProcessUID configurable on top of the
+// near-empty specHashFakeClient so volumePostCreateChown's uid-resolution hop
+// can be driven without a real containerd container. getContainerFn (set by the
+// caller) returns a nil Container — the fake's ContainerProcessUID ignores the
+// container argument, so a nil value is sufficient.
+type volumeChownFakeClient struct {
+	*specHashFakeClient
+
+	uid uint32
+}
+
+func (c *volumeChownFakeClient) ContainerProcessUID(string, containerd.Container) (uint32, error) {
+	return c.uid, nil
+}
+
+var _ ctr.Client = (*volumeChownFakeClient)(nil)
+
+func newVolumeChownExec(runPath string, kukeonGID int, uid uint32) *Exec {
+	return &Exec{
+		ctx:    context.Background(),
+		logger: slog.New(slog.NewTextHandler(io.Discard, nil)),
+		opts:   Options{RunPath: runPath, KukeonGroupGID: kukeonGID},
+		ctrClient: &volumeChownFakeClient{
+			specHashFakeClient: &specHashFakeClient{
+				getContainerFn: func(string, string) (containerd.Container, error) {
+					return nil, nil
+				},
+			},
+			uid: uid,
+		},
+	}
+}
+
+// TestVolumePostCreateChown_GrantsOwnerWriteToNonRootUID locks AC #1/#4 (#1291):
+// a kind: volume mount's resolved directory is chowned to the mounting
+// container's resolved process uid at container create, so a non-root workload
+// with no kukeon-group membership owns — and can write into — the Volume. Runs
+// in the no-kukeon-group fallback (0o770) the test Exec uses so it needs no
+// privilege: when the suite runs as root the chown to a non-root uid is
+// observable; otherwise it self-chowns and the uid assertion is skipped (the
+// path still exercises end-to-end), mirroring the attachable chown tests.
+func TestVolumePostCreateChown_GrantsOwnerWriteToNonRootUID(t *testing.T) {
+	runPath := t.TempDir()
+
+	// Provision the volume dir owned by the current user; WriteVolume's
+	// chown-to-root path is gid-gated and a no-op in this fallback config.
+	seed := newMetadataTestExec(t, runPath, time.Now())
+	if _, err := seed.WriteVolume(intmodel.Volume{
+		Metadata: intmodel.VolumeMetadata{Name: "data", Realm: "default"},
+	}); err != nil {
+		t.Fatalf("WriteVolume() error = %v", err)
+	}
+	volPath := fs.VolumePath(runPath, "default", "", "", "data")
+
+	root := os.Geteuid() == 0
+	targetUID := os.Geteuid()
+	if root {
+		targetUID = 1000
+	}
+
+	exec := newVolumeChownExec(runPath, 0, uint32(targetUID))
+	spec := intmodel.ContainerSpec{
+		ID:        "c1",
+		RealmName: "default",
+		Volumes: []intmodel.VolumeMount{
+			{Kind: intmodel.VolumeKindVolume, Source: "data", Target: "/data"},
+		},
+	}
+	if err := exec.volumePostCreateChown("default.kukeon.io", spec); err != nil {
+		t.Fatalf("volumePostCreateChown() error = %v", err)
+	}
+
+	// Owner is the mounting container's uid (observable only as root); the
+	// directory stays group-writable 0o770 so the owner-write grant is real.
+	assertOwnedBy(t, volPath, targetUID, root)
+	info, err := os.Stat(volPath)
+	if err != nil {
+		t.Fatalf("stat volume dir: %v", err)
+	}
+	if perm := info.Mode().Perm(); perm != 0o770 {
+		t.Errorf("volume dir mode = %o, want 770 (owner+group writable)", perm)
+	}
+}
+
+// TestVolumePostCreateChown_PreservesKukeonGroupWrite locks AC #2 (#1291): the
+// owner flip must not regress the kukeon-group-write path — the setgid bit and
+// the kukeon group survive the chown, so attachable cells (and any other
+// kukeon-group member) keep group-write on a shared Volume. Requires root to
+// provision a setgid root:<gid> dir and to chown across uids.
+func TestVolumePostCreateChown_PreservesKukeonGroupWrite(t *testing.T) {
+	if os.Geteuid() != 0 {
+		t.Skip("requires root to provision a setgid root:kukeon volume dir and chown across uids")
+	}
+	const kukeonGID = 1000
+	const targetUID = 1001
+	runPath := t.TempDir()
+
+	r := newVolumeChownExec(runPath, kukeonGID, targetUID)
+	if _, err := r.WriteVolume(intmodel.Volume{
+		Metadata: intmodel.VolumeMetadata{Name: "data", Realm: "default"},
+	}); err != nil {
+		t.Fatalf("WriteVolume() error = %v", err)
+	}
+	volPath := fs.VolumePath(runPath, "default", "", "", "data")
+
+	if err := r.chownVolumeDirToUID(volPath, targetUID); err != nil {
+		t.Fatalf("chownVolumeDirToUID() error = %v", err)
+	}
+
+	stat := statSys(t, volPath)
+	if int(stat.Uid) != targetUID {
+		t.Errorf("owner uid = %d, want %d", stat.Uid, targetUID)
+	}
+	if int(stat.Gid) != kukeonGID {
+		t.Errorf("group gid = %d, want %d (kukeon group must survive the owner flip)", stat.Gid, kukeonGID)
+	}
+	info, err := os.Stat(volPath)
+	if err != nil {
+		t.Fatalf("stat volume dir: %v", err)
+	}
+	if info.Mode()&os.ModeSetgid == 0 {
+		t.Errorf("setgid bit lost after owner chown: %v (group inheritance regressed)", info.Mode())
+	}
+	if perm := info.Mode().Perm(); perm != 0o770 {
+		t.Errorf("volume dir mode = %o, want 770 (group-write preserved)", perm)
+	}
+}
+
+// TestVolumePostCreateChown_Skips locks the two no-op branches (#1291): a spec
+// with no kind: volume mount never reaches containerd (so a failing GetContainer
+// would be a bug surfacing as an error), and a root-uid container leaves the
+// root-owned dir untouched — the early return means chownVolumeDirToUID(path, 0)
+// (which a non-root daemon could not even perform) never runs.
+func TestVolumePostCreateChown_Skips(t *testing.T) {
+	runPath := t.TempDir()
+	seed := newMetadataTestExec(t, runPath, time.Now())
+	if _, err := seed.WriteVolume(intmodel.Volume{
+		Metadata: intmodel.VolumeMetadata{Name: "data", Realm: "default"},
+	}); err != nil {
+		t.Fatalf("WriteVolume() error = %v", err)
+	}
+
+	t.Run("no volume mount: no containerd round-trip", func(t *testing.T) {
+		// GetContainer is left at the specHashFakeClient default (NotFound); if
+		// the function reached it the call would error.
+		exec := &Exec{
+			ctx:       context.Background(),
+			logger:    slog.New(slog.NewTextHandler(io.Discard, nil)),
+			opts:      Options{RunPath: runPath},
+			ctrClient: &volumeChownFakeClient{specHashFakeClient: &specHashFakeClient{}, uid: 1000},
+		}
+		spec := intmodel.ContainerSpec{
+			ID:        "c1",
+			RealmName: "default",
+			Volumes: []intmodel.VolumeMount{
+				{Kind: intmodel.VolumeKindBind, Source: "/host", Target: "/in"},
+			},
+		}
+		if err := exec.volumePostCreateChown("default.kukeon.io", spec); err != nil {
+			t.Errorf("want nil (no kind: volume mount, ctrClient untouched), got %v", err)
+		}
+	})
+
+	t.Run("root container uid: dir left root-owned", func(t *testing.T) {
+		exec := newVolumeChownExec(runPath, 0, 0)
+		spec := intmodel.ContainerSpec{
+			ID:        "c1",
+			RealmName: "default",
+			Volumes: []intmodel.VolumeMount{
+				{Kind: intmodel.VolumeKindVolume, Source: "data", Target: "/data"},
+			},
+		}
+		if err := exec.volumePostCreateChown("default.kukeon.io", spec); err != nil {
+			t.Errorf("want nil (root uid short-circuits the chown), got %v", err)
+		}
+	})
 }

--- a/internal/modelhub/container.go
+++ b/internal/modelhub/container.go
@@ -195,7 +195,14 @@ const (
 	// name (Source, same-scope) or by VolumeRef (cross-scope) and bind-mounts
 	// its resolved on-disk directory at Target. Resolved at container-create
 	// time; the referenced Volume's directory survives container recreation and
-	// the mounting cell's deletion. Step 4 (#1016).
+	// the mounting cell's deletion. At create the resolved directory's owner is
+	// chowned to the mounting container's process uid so a non-root workload can
+	// write into it even without kukeon-group membership; only the owner is
+	// reset, so cross-uid sharing of one Volume by cells running as different
+	// uids relies on the kukeon group (setgid group-write), and per-cell volume
+	// identity (${CELL_NAME}, step 5 #1294) is the pattern for distinct
+	// owner-write. See runner.WriteVolume's "Cross-uid sharing contract" godoc.
+	// Step 4 (#1016), owner chown #1291.
 	VolumeKindVolume VolumeKind = "volume"
 )
 


### PR DESCRIPTION
## Summary

- Wires the step-1 note in `internal/controller/runner/volume.go` that step 4 deferred: at container create the resolved `kind: volume` directory's **owner** is chowned to the mounting container's resolved process uid, so a non-root workload can write into a Volume it mounts even on a host with no kukeon group configured (the fallback dir is `root:root 0o770`, previously unwritable by a non-root non-group uid).
- New `volumePostCreateChown` mirrors `attachablePostCreateChown`'s two-phase shape — the uid is unknowable before `CreateContainerFromSpec` because containerd resolves the image `USER` (and any `container.user` override) only when the runtime spec is built. It is called at all four container-create sites (`start.go` x2, `provision.go` x2), right after `attachablePostCreateChown`.
- Re-resolves each mount via the same `ctr.ResolveVolumeMount` walk the create path used (`CreateContainerFromSpec` rewrites only its own by-value copy of the spec, so the runner's stored spec still carries the `kind: volume` reference). Because the create path already proved that exact `spec.Volumes` set resolves, the re-resolve is guaranteed to succeed.

### Design calls (documented for reviewer push-back)

- **Owner-only chown, group preserved (AC #2).** `chownVolumeDirToUID` uses `Chown(path, uid, -1)` so the setgid `root:kukeon` group survives the owner flip, then re-asserts the mode from `volumeDirInitialPerms`. The kukeon-group-write path (attachable cells, any kukeon-group member) is therefore never regressed; in the no-group fallback the group stays `root` and `0o770` is preserved.
- **Multi-mounter / cross-uid contract (AC #3).** Only the owner is reset, so two cells mounting one Volume as different uids each re-own it at their own create — last writer wins the owner bit. Cross-uid **shared** write relies on the kukeon group (setgid group-write); **per-cell volume identity** (`${CELL_NAME}`, step 5 #1294) is the supported pattern when distinct uids each need exclusive owner-write. This is made durable by the `WriteVolume` re-apply behavior: with a kukeon group, a reconcile re-apply chowns the owner back to root but group-write persists; in the fallback `WriteVolume` issues no chown, so the mount-time owner grant survives reconcile. Documented in both the `WriteVolume` ("Cross-uid sharing contract") and `VolumeMount`/`VolumeKindVolume` godoc.
- **Skips:** read-only mounts (container can't write through them), root-uid containers (already own the root-owned dir), and specs with no `kind: volume` mount (no containerd round-trip).
- **Premise note:** the issue cited the step-1 note as "wired in at mount time in step 4 (#1016)"; step 4 (PR #1290) deliberately scoped it out, so the note was aspirational. Implemented here as the follow-up; updated the stale note to point at `volumePostCreateChown`.

## Test plan

- [x] `make test` (full root + kukebuild suites) — pass
- [x] `GOWORK=off go build ./...` / `go vet` on affected packages — pass
- [x] New unit tests in `volume_test.go` (run as **root**, so cross-uid chown to uid 1000/1001 and group-write preservation actually executed):
  - `TestVolumePostCreateChown_GrantsOwnerWriteToNonRootUID` — AC #1/#4: resolved dir owned by the mounting container's uid, dir stays `0o770` (owner+group writable)
  - `TestVolumePostCreateChown_PreservesKukeonGroupWrite` — AC #2: setgid bit + kukeon group survive the owner flip (root-gated)
  - `TestVolumePostCreateChown_Skips` — no-volume and root-uid short-circuits
- [x] `make dev-init` smoke (daemon-touching change) — exit 0; daemon-parity tail shows `default`/`kuke-system` both `Ready` with identical daemon vs `--no-daemon` views; `kuke attach` smoke against a kuketty-wrapped cell exited cleanly (exercises the container-create path that now calls `volumePostCreateChown`). Ran in the host's live default profile (nested-without-`KUKEON_PROFILE=dev`); the script prints the plain `kuke get realms` shape accordingly.

## Acceptance criteria

- [x] A `kind: volume` mount's resolved directory is chowned to the mounting container's uid at container create, mirroring `attachablePostCreateChown`'s two-phase shape
- [x] Behavior is gated so it does not regress the kukeon-group-write path (attachable cells) or the no-kukeon-group fallback
- [x] The multi-mounter / cross-uid sharing contract is decided and documented in the `VolumeMount` / `WriteVolume` godoc
- [x] Unit test: a workload container running as a non-root uid can write into a mounted Volume

Closes #1291