### PR TITLE
feat: auto-ensure team-rendered own-scope volume mounts

### DIFF
--- a/internal/teamrender/teamrender.go
+++ b/internal/teamrender/teamrender.go
@@ -434,7 +434,43 @@ func RenderBlueprint(
 		bp.Metadata.Labels = map[string]string{}
 	}
 	bp.Metadata.Labels[v1beta1.LabelTeam] = project
+	ensureTeamVolumeMounts(&bp)
 	return &bp, nil
+}
+
+// ensureTeamVolumeMounts marks every own-scope kind: volume mount in the
+// rendered blueprint Ensure=true, so the daemon auto-provisions the referenced
+// Volume at the cell's own realm/space/stack on first `kuke run --from-config`
+// instead of hard-erroring on a missing reference (step 4's default, #1290).
+// This closes the team-init half of the volume auto-create gap (#1301, Option
+// B): `kuke team init` renders the (project, role) state-volume *reference* but
+// provisions no Volume, so the very first run of a freshly-rendered config used
+// to fail until the operator hand-ran `kuke create volume`. Flipping Ensure
+// here reuses the already-shipped opt-in primitive (the VolumeMount.Ensure
+// field + controller.ensurePerCellVolumes, #1294/#1017) rather than eagerly
+// minting kind: Volume documents into the apply bundle — the daemon's ensure
+// path is idempotent (an already-bound cell re-binds its existing Volume), so a
+// re-init re-renders the same Ensure mount with no duplicate or error, and the
+// state volumes stay outside the per-team prune lifecycle (#1029) so removing a
+// role from the roster never deletes the operator's persisted state.
+//
+// Only own-scope (`source:`) mounts are flipped. A cross-scope `volumeRef`
+// mount is left as authored — you can't implicitly create a Volume in another
+// scope, so a missing cross-scope reference stays the hard error step 4 makes
+// it (mirrors the issue's auto-create caution). Hand-written blueprints applied
+// outside team init are likewise untouched: this flip lives only on the
+// team-render path, so a typo'd volume name in a `kuke run -f` config still
+// fails fast.
+func ensureTeamVolumeMounts(bp *v1beta1.CellBlueprintDoc) {
+	for ci := range bp.Spec.Cell.Containers {
+		vols := bp.Spec.Cell.Containers[ci].Volumes
+		for vi := range vols {
+			if vols[vi].Kind != v1beta1.VolumeKindVolume || vols[vi].VolumeRef != nil {
+				continue
+			}
+			vols[vi].Ensure = true
+		}
+	}
 }
 
 // scopeToProject prefixes name with `<project>-` so the rendered

--- a/internal/teamrender/teamrender_test.go
+++ b/internal/teamrender/teamrender_test.go
@@ -299,6 +299,77 @@ func TestRenderBlueprintSubstitutesAndStampsTeamLabel(t *testing.T) {
 	}
 }
 
+// TestRenderBlueprintMarksOwnScopeVolumesEnsure pins the team-init auto-create
+// fix (#1301, Option B): a rendered blueprint's own-scope kind: volume mounts
+// are flipped Ensure=true so the daemon auto-provisions the (project, role)
+// state Volume on first `kuke run --from-config`, while a cross-scope volumeRef
+// mount and a bind mount are left exactly as authored.
+func TestRenderBlueprintMarksOwnScopeVolumesEnsure(t *testing.T) {
+	t.Parallel()
+	cacheDir := t.TempDir()
+	body := `apiVersion: v1beta1
+kind: CellBlueprint
+metadata:
+  name: {{ .role.name }}-{{ .harness }}
+spec:
+  cell:
+    containers:
+      - id: {{ .role.name }}
+        image: {{ .image }}
+        volumes:
+          - kind: volume
+            source: {{ .project.NAME }}-{{ .role.name }}
+            target: /home/agent/.claude
+          - kind: volume
+            target: /shared
+            volumeRef:
+              name: shared
+              realm: default
+          - kind: bind
+            source: /host/path
+            target: /mnt
+`
+	writeHarnessFile(t, cacheDir, "claude", "blueprint.tmpl.yaml", body)
+	r := minimalRole()
+	h := &model.Harness{
+		APIVersion: model.APIVersionV1,
+		Kind:       model.KindHarness,
+		Metadata:   model.Metadata{Name: "claude"},
+		Spec:       model.HarnessSpec{Template: "blueprint.tmpl.yaml"},
+	}
+	image := &model.ImageCatalogEntry{
+		Ref:     "claude-base",
+		Harness: "claude",
+		Image:   "registry.local/claude:latest",
+	}
+	bp, err := RenderBlueprint(
+		cacheDir, h, r, "claude", "dev", nil, image, nil,
+		teamsource.Source{}, Inputs{}, "kukeon", "default", "default", "default",
+	)
+	if err != nil {
+		t.Fatalf("RenderBlueprint: %v", err)
+	}
+	if len(bp.Spec.Cell.Containers) == 0 {
+		t.Fatalf("no containers in rendered blueprint")
+	}
+	vols := bp.Spec.Cell.Containers[0].Volumes
+	if len(vols) != 3 {
+		t.Fatalf("got %d volume mounts, want 3", len(vols))
+	}
+	// Own-scope kind: volume → auto-provisioned.
+	if own := vols[0]; own.Source != "kukeon-dev" || !own.Ensure {
+		t.Errorf("own-scope volume: source=%q ensure=%v, want source=kukeon-dev ensure=true", own.Source, own.Ensure)
+	}
+	// Cross-scope volumeRef → left a hard error (Ensure stays false).
+	if ref := vols[1]; ref.VolumeRef == nil || ref.Ensure {
+		t.Errorf("cross-scope volumeRef: ensure=%v, want false (must not implicitly create in another scope)", ref.Ensure)
+	}
+	// Non-volume kind → untouched.
+	if bind := vols[2]; bind.Kind != v1beta1.VolumeKindBind || bind.Ensure {
+		t.Errorf("bind mount: kind=%q ensure=%v, want kind=bind ensure=false", bind.Kind, bind.Ensure)
+	}
+}
+
 // TestRenderBlueprintRangesPerHarnessSecrets pins the agents#750 fix: a
 // blueprint ranging `(index .harnesses .harness).secrets` renders a secret
 // slot for each per-harness secret name. Before this change harnessesView


### PR DESCRIPTION
## Summary

Closes the team-init half of the volume auto-create gap (#1301, **Option B**): `kuke team init` rendered the `(project, role)` state-volume *reference* but provisioned no Volume, so the very first `kuke run --from-config <cfg>` failed with `volume not found` until the operator hand-ran `kuke create volume`.

`teamrender.RenderBlueprint` now marks every **own-scope** `kind: volume` mount in the rendered blueprint `Ensure=true`, so the daemon auto-provisions the referenced Volume at the cell's own realm/space/stack on first run. Cross-scope `volumeRef` mounts and `bind`/`tmpfs` mounts are left exactly as authored.

### Scope decision (premise partially rotted — documented per dev CLAUDE.md)

The issue offers two options. **Option A** (daemon-side opt-in `ensure: true` auto-create with a fail-closed default) is **already shipped** since the issue was filed — the `VolumeMount.Ensure` field + `controller.ensurePerCellVolumes` (#1294/#1017, documented in #1299/#1300). So A's AC is already satisfied on `origin/main`; this PR closes only the remaining **B** gap.

**Why Ensure-flip rather than eagerly minting `kind: Volume` docs into the apply bundle** (B's literal wording says "create … as part of apply"): this is the lower-blast-radius reading and reuses the already-shipped, tested primitive.

- **Reuses shipped infra** — the daemon's `ensure` path is idempotent (an already-bound cell re-binds its existing Volume, never minting a fresh one), so a re-`init` re-renders the same `Ensure` mount with no duplicate or error. Satisfies B's idempotency AC for free.
- **Avoids a state-loss footgun** — pre-provisioning `kind: Volume` documents into the team apply bundle would subject them to the per-team prune (#1029): removing a role from the roster would then *prune its state Volume*, deleting the operator's persisted `~/.claude`/`~/.codex`. Flipping `Ensure` keeps state volumes outside the prune lifecycle. (The issue itself flags this under "Delete-gate / GC interaction".)
- **Consistent with the codebase** — `cellblueprint.ExpandPerCellVolumes` already flips `Ensure` for `${CELL_NAME}` per-cell mounts; this extends the same idiom to team-rendered static mounts.
- **Stays fail-closed where B wants it** — only the team-render path flips `Ensure`. Hand-written `kuke run -f` configs are untouched, so a typo'd volume name there still hard-errors (B's "keeps the daemon fail-closed" property).

Cross-scope `volumeRef` mounts are deliberately **not** flipped — you can't implicitly create a Volume in another scope, so a missing cross-scope reference stays the hard error step 4 makes it (mirrors the issue's auto-create caution).

Reviewer: push back if you'd prefer the eager-apply-bundle reading of B despite the prune footgun.

## Test plan
- [x] `GOWORK=off go test ./internal/teamrender/...` — new `TestRenderBlueprintMarksOwnScopeVolumesEnsure` asserts own-scope `kind: volume` → `Ensure=true`, cross-scope `volumeRef` → `Ensure=false`, `bind` → untouched.
- [x] `make test` (full CI target, `GOWORK=off`) — exit 0.
- [x] `GOWORK=off go vet ./internal/teamrender/` — clean.
- [ ] `make dev-init` smoke — N/A: this change touches neither the build path, the daemon, nor `/opt/kukeon`; it only alters team-render output, and the `ensure` mechanism it leverages is already daemon-test-covered. The dev-init smoke exercises `kuke init`, not `kuke team init` volume rendering.

### Notes
- A pre-existing dependency build break (`containerd/cgroups` `pids.Limit` type error) reproduces on a clean `origin/main` checkout and is unrelated to this diff — it surfaces only when building through the `go.work` union. `make`/CI build per-module with `GOWORK=off`, which compiles and tests green (confirmed above).

Closes #1301