### PR TITLE
chore(controller): document RestartCount/RestartTime as intentionally-zero pending #1151

### DIFF
--- a/internal/controller/runner/helpers.go
+++ b/internal/controller/runner/helpers.go
@@ -853,16 +853,20 @@ func (r *Exec) populateCellContainerStatuses(cell *intmodel.Cell) error {
 			exitCode = obs.ExitCode
 		}
 
-		// RestartCount/RestartTime require restart bookkeeping the runner does
-		// not yet track; deferred to #1146 per issue #1137's "scope that part
-		// separately". They stay at their zero values for now.
+		// RestartCount/RestartTime require restart bookkeeping, but the runner has
+		// no reconciler-driven container restart-on-exit mechanism today
+		// (restartPolicy is reap-veto only, #1003) — nothing re-creates or
+		// re-starts an exited container task, so there is nothing to count from.
+		// The fields are therefore intentionally always-zero. Building the
+		// restart-on-exit mechanism and populating these counters is tracked by
+		// #1151.
 		status := intmodel.ContainerStatus{
 			Name:         containerSpec.ID,
 			ID:           containerSpec.ID,
 			CreatedAt:    createdAt,
 			State:        obs.State,
-			RestartCount: 0,           // TODO(#1146): restart bookkeeping
-			RestartTime:  time.Time{}, // TODO(#1146): restart bookkeeping
+			RestartCount: 0,           // intentionally zero — see comment above (#1151)
+			RestartTime:  time.Time{}, // intentionally zero — see comment above (#1151)
 			StartTime:    startTime,
 			FinishTime:   finishTime,
 			ExitCode:     exitCode,


### PR DESCRIPTION
## Summary
- Re-scoped per the issue's interim direction: the runner has no reconciler-driven container restart-on-exit mechanism today (`restartPolicy` is reap-veto only, #1003), so `RestartCount`/`RestartTime` have nothing to count from.
- Replaced the `TODO(#1146): restart bookkeeping` inline markers in `populateCellContainerStatuses` (`internal/controller/runner/helpers.go`) with a comment documenting the fields as **intentionally always-zero**, pointing at #1151 (the restart-on-exit umbrella) for eventual population.
- No behavior change — the fields already serialized as zero and continue to.

## Premise rot (documented per dev CLAUDE.md)
- The issue body (filed 2026-06-07) proposed editing simpler `TODO(#1146)` markers at `helpers.go:795-796`. Since then, #1137 (PR #1148) merged and landed a slightly different shape at `helpers.go:856-865`: a block comment deferring to #1146/#1137 **plus** the inline `TODO(#1146)` markers. Intent is unchanged — this PR rewrites both the block comment and the inline markers so nothing implies a restart counter is coming *here*, and both now reference #1151.

## Test plan
- [x] `GOWORK=off go build ./internal/controller/runner/` — clean (bare build fails on a pre-existing `containerd/cgroups` graph mismatch under the `go.work` workspace; per `go.work`'s own header, build/test each module with `GOWORK=off`, which is what make and CI do).
- [x] `GOWORK=off go test $(go list ./... | grep -v /e2e)` — full root suite passed (`TEST-EXIT=0`); `internal/controller/runner ok`.
- [x] `git grep 'TODO(#1146)'` — no markers remain in the tree.

## Acceptance criteria
- [x] The `TODO(#1146)` markers in `populateCellContainerStatuses` are replaced with a comment documenting the fields as intentionally-zero pending #1151 (no restart mechanism exists today).
- [x] No behavior change: `RestartCount`/`RestartTime` continue to serialize as their zero values.

Closes #1146