### PR TITLE
fix: normalize bare image references before pull

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/containerd/typeurl/v2 v2.2.3
 	github.com/containernetworking/cni v1.3.0
 	github.com/creack/pty v1.1.24
+	github.com/distribution/reference v0.6.0
 	github.com/eminwux/sbsh v0.13.1
 	github.com/opencontainers/go-digest v1.0.0
 	github.com/opencontainers/image-spec v1.1.1
@@ -37,7 +38,6 @@ require (
 	github.com/coreos/go-systemd/v22 v22.6.0 // indirect
 	github.com/cyphar/filepath-securejoin v0.6.0 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
-	github.com/distribution/reference v0.6.0 // indirect
 	github.com/felixge/httpsnoop v1.0.4 // indirect
 	github.com/fsnotify/fsnotify v1.9.0 // indirect
 	github.com/go-logr/logr v1.4.3 // indirect

--- a/internal/ctr/container_utils.go
+++ b/internal/ctr/container_utils.go
@@ -20,6 +20,7 @@ import (
 	"strings"
 
 	"github.com/containerd/containerd/v2/pkg/oci"
+	"github.com/distribution/reference"
 	intmodel "github.com/eminwux/kukeon/internal/modelhub"
 	runtimespec "github.com/opencontainers/runtime-spec/specs-go"
 )
@@ -292,40 +293,41 @@ func copyLabels(src map[string]string) map[string]string {
 	return dst
 }
 
-// NormalizeImageReference normalizes an image reference to a fully qualified format.
+// NormalizeImageReference canonicalizes an image reference to the fully
+// qualified docker.io/library form containerd's resolver requires, the same way
+// `docker` and kukebuild's -t normalization do (see normalizeImageName in
+// cmd/kukebuild/build.go). Bare references that omit the registry, the
+// docker.io/library namespace, or the tag would otherwise reach the resolver as
+// `dummy://busybox:latest` and fail to parse, so every pull path runs the ref
+// through here first.
+//
 // Examples:
-//   - "debian:latest" -> "docker.io/library/debian:latest"
-//   - "alpine" -> "docker.io/library/alpine:latest"
-//   - "user/image:tag" -> "docker.io/user/image:tag"
-//   - "docker.io/library/debian:latest" -> "docker.io/library/debian:latest" (unchanged)
-//   - "registry.example.com/image:tag" -> "registry.example.com/image:tag" (unchanged)
+//   - "debian:latest"                    -> "docker.io/library/debian:latest"
+//   - "alpine"                           -> "docker.io/library/alpine:latest"
+//   - "busybox"                          -> "docker.io/library/busybox:latest"
+//   - "docker.io/busybox:latest"         -> "docker.io/library/busybox:latest"
+//   - "user/image"                       -> "docker.io/user/image:latest"
+//   - "docker.io/library/debian:latest"  -> "docker.io/library/debian:latest" (unchanged)
+//   - "registry.example.com/image:tag"   -> "registry.example.com/image:tag" (unchanged)
+//   - "kukeon.internal/kukeond:v0.0.0"   -> "kukeon.internal/kukeond:v0.0.0" (unchanged)
+//
+// A reference that cannot be parsed (genuinely malformed) is returned unchanged
+// so the downstream containerd resolver surfaces the error, preserving prior
+// behavior for invalid input.
 func NormalizeImageReference(image string) string {
 	if image == "" {
 		return image
 	}
 
-	// If it already contains a registry (has "://" or starts with a known registry), return as-is
+	// References carrying an explicit URL scheme are not containerd image refs
+	// (distribution/reference rejects them); leave them untouched.
 	if strings.Contains(image, "://") {
 		return image
 	}
 
-	// Check if it starts with a known registry (contains a dot before the first slash, or is a known registry)
-	firstSlash := strings.Index(image, "/")
-	if firstSlash > 0 {
-		// Check if the part before the first slash looks like a registry (contains a dot or is a known registry)
-		registryPart := image[:firstSlash]
-		if strings.Contains(registryPart, ".") || strings.Contains(registryPart, ":") {
-			// Already has a registry, return as-is
-			return image
-		}
-		// No registry, add docker.io prefix
-		return "docker.io/" + image
+	named, err := reference.ParseNormalizedNamed(image)
+	if err != nil {
+		return image
 	}
-
-	// No slash means it's a library image
-	// Add default tag if not present
-	if !strings.Contains(image, ":") {
-		image += ":latest"
-	}
-	return "docker.io/library/" + image
+	return reference.TagNameOnly(named).String()
 }

--- a/internal/ctr/container_utils_test.go
+++ b/internal/ctr/container_utils_test.go
@@ -353,7 +353,22 @@ func TestNormalizeImageReference(t *testing.T) {
 		{
 			name:  "user image without tag",
 			image: "user/image",
-			want:  "docker.io/user/image",
+			want:  "docker.io/user/image:latest",
+		},
+		{
+			name:  "bare library image with tag",
+			image: "busybox:latest",
+			want:  "docker.io/library/busybox:latest",
+		},
+		{
+			name:  "docker.io single-name needs library namespace",
+			image: "docker.io/busybox:latest",
+			want:  "docker.io/library/busybox:latest",
+		},
+		{
+			name:  "internal registry ref unchanged",
+			image: "kukeon.internal/kukeond:v0.0.0-dev",
+			want:  "kukeon.internal/kukeond:v0.0.0-dev",
 		},
 		{
 			name:  "already fully qualified docker.io",

--- a/internal/ctr/image.go
+++ b/internal/ctr/image.go
@@ -107,6 +107,14 @@ func (c *client) pullImage(namespace string, imageRef string, creds []RegistryCr
 	nsCtx := c.namespaceCtx(namespace)
 	cc := c.conn()
 
+	// Canonicalize bare references (e.g. "busybox:latest",
+	// "docker.io/busybox:latest") to the fully qualified docker.io/library form
+	// before either the local lookup or the network pull — containerd's resolver
+	// parses the raw ref as a URL and rejects "dummy://busybox:latest" otherwise.
+	// kukebuild stores images under this same normalized name, so the local
+	// GetImage hit below stays consistent with built/loaded images.
+	imageRef = NormalizeImageReference(imageRef)
+
 	// Try to get the image locally first
 	image, err := cc.GetImage(nsCtx, imageRef)
 	if err == nil {


### PR DESCRIPTION
## Summary

- `kuke run --image busybox:latest` (and any cell spec carrying a bare image ref) failed at pull time with `failed to resolve reference "dummy://busybox:latest": invalid port ":latest" after host`. containerd's resolver requires a fully qualified `docker.io/library/...` reference and parses a bare ref as a URL; nothing in the create/pull path normalized it first.
- Root cause: `internal/ctr.NormalizeImageReference` existed and was unit-tested but was **never called** in production — dead code. It was also hand-rolled and buggy: `docker.io/busybox:latest` (single-name under an explicit `docker.io`) was returned unchanged instead of getting the `library/` namespace, which is the second failure the report showed (`pull access denied, repository does not exist`).
- Fix: rewrite `NormalizeImageReference` to use the canonical `github.com/distribution/reference` (`ParseNormalizedNamed` + `TagNameOnly`), the same normalization `cmd/kukebuild/build.go:normalizeImageName` already applies to `-t` tags so built images and pulled images resolve to the same stored name. Then call it at the top of `(*client).pullImage` so it runs before both the local `GetImage` hit and the network pull.

This is a shared-pull-path defect surfaced by the new `--image` quick-start in #1287 (epic:first-run) — the headline onboarding command `kuke run --image busybox` is broken without it — but the fix lives below that feature and benefits every pull path (`kuke run --image`, `kuke create cell -f`, etc.), so it ships as its own focused change rather than amending #1287's branch.

## Behavior change note

Switching from the hand-rolled logic to the canonical library changes two cases (both toward the correct, docker-matching behavior):
- Untagged slashed refs now get `:latest` (`user/image` → `docker.io/user/image:latest`, previously `docker.io/user/image`). This matches `TagNameOnly` / `kukebuild` and keeps the local `GetImage` lookup consistent with how kukebuild stores images (always tagged).
- `docker.io/<single-name>` now gets the `library/` namespace inserted (the reported bug). `kukeon.internal/...` and registries-with-a-dot are unchanged, so `IsInternalImageRef` and custom-registry refs are unaffected.

Scope is the create/pull path only; the read-side `kuke get image <ref>` lookups are intentionally left untouched here.

## Test plan

- [x] `GOWORK=off go build ./...`
- [x] `GOWORK=off go vet ./internal/ctr/...`
- [x] `make test` (full CI target: `test-root` + `test-kukebuild`; EXIT=0)
- [x] `NormalizeImageReference` table tests updated: added bare `busybox:latest`, `docker.io/busybox:latest` → `docker.io/library/busybox:latest`, and `kukeon.internal/...`-unchanged cases; adjusted the untagged-slashed-ref expectation to the canonical `:latest` form.
- [ ] End-to-end `kuke run --image busybox:latest` against a live daemon — not run on this host (requires a running kukeond + containerd + network registry access). The fix is a deterministic reference transform verified at the unit layer; the downstream pull is containerd's once handed a valid ref. The user reproduced the original failure on `kukeon-test`.