### PR TITLE
feat(install): auto-add invoking user to kukeon group + surface re-login (step 3)

### DIFF
--- a/docs/site/install.sh
+++ b/docs/site/install.sh
@@ -405,6 +405,7 @@ do_install() {
     fi
 
     install_systemd_unit
+    grant_group_membership
 }
 
 # --- Running-daemon version gate ---------------------------------------------
@@ -442,6 +443,50 @@ handle_running_daemon() {
     printf '      %ssudo kuke daemon recreate --kukeond-image ghcr.io/%s:%s%s\n\n' "$C_BOLD" "$KUKE_REPO" "$KUKE_VERSION" "$C_RESET" >&2
     printf '    To keep an intentionally pinned older daemon, re-run with KUKE_SKIP_DAEMON_UPGRADE=1.\n' >&2
     return 0
+}
+
+# --- kukeon group membership -------------------------------------------------
+# `kuke init` creates the `kukeon` group and lands the daemon socket
+# root:kukeon 0o660, so dialing it requires membership in that group. Init
+# never touches the invoking user's groups, so the operator who just drove the
+# install — the obvious first client — would hit `dial kukeond ... permission
+# denied` on the very next command. Grant it here while we still hold root.
+#
+# Scoped to a non-root $SUDO_USER: a direct-root install has no invoking user to
+# grant, and we never silently add other accounts (group membership confers
+# daemon access — a real privilege grant, intended only for the operator).
+# Idempotent: an already-member user is a clean no-op, not an error.
+#
+# Group changes only take effect in a NEW login session; KUKE_GROUP_GRANT
+# records the outcome so print_next_steps can tell the operator to start one
+# (newgrp / re-login) before the first client command.
+KUKE_GROUP="kukeon"
+KUKE_GROUP_GRANT="skipped" # skipped | added | already
+
+grant_group_membership() {
+    # No invoking user to grant when run directly as root (no sudo wrapper).
+    if [ -z "${SUDO_USER:-}" ] || [ "$SUDO_USER" = "root" ]; then
+        return 0
+    fi
+    # The group is created by `kuke init`. If it is somehow absent (init was
+    # skipped via KUKE_SKIP_INIT, or a partial bootstrap), skip rather than
+    # fail the whole install — there is nothing to join yet.
+    if ! getent group "$KUKE_GROUP" >/dev/null 2>&1; then
+        return 0
+    fi
+    step "Granting ${SUDO_USER} access to the ${KUKE_GROUP} group"
+    if id -nG "$SUDO_USER" 2>/dev/null | tr ' ' '\n' | grep -qxF "$KUKE_GROUP"; then
+        KUKE_GROUP_GRANT="already"
+        ok "${SUDO_USER} is already a member of the ${KUKE_GROUP} group"
+        return 0
+    fi
+    if $SUDO usermod -aG "$KUKE_GROUP" "$SUDO_USER"; then
+        KUKE_GROUP_GRANT="added"
+        ok "added ${SUDO_USER} to the ${KUKE_GROUP} group"
+    else
+        warn "could not add ${SUDO_USER} to the ${KUKE_GROUP} group — add it manually:"
+        printf '      sudo usermod -aG %s %s\n' "$KUKE_GROUP" "$SUDO_USER" >&2
+    fi
 }
 
 # --- systemd unit ------------------------------------------------------------
@@ -511,7 +556,40 @@ EOF
 }
 
 # --- Next steps --------------------------------------------------------------
+# Surface the kukeon-group requirement before the first client command. After
+# grant_group_membership, $SUDO_USER is in the group on disk, but the current
+# shell still carries the old group set — so the next `kuke` command would hit
+# `dial kukeond ... permission denied`. Tell the operator to start a fresh
+# session (newgrp / re-login) first, and state whether we just added them or
+# they were already a member so the message stays honest on a re-run.
+print_group_note() {
+    case "$KUKE_GROUP_GRANT" in
+        added)
+            cat <<EOF
+
+${C_BOLD}Added ${SUDO_USER} to the ${KUKE_GROUP} group${C_RESET} — this grants access to the kukeon
+daemon socket. Group membership only takes effect in a new login session, so
+start one before the commands below (log out and back in), or use the no-logout
+shortcut:
+  ${C_BOLD}newgrp ${KUKE_GROUP}${C_RESET}
+EOF
+            ;;
+        already)
+            cat <<EOF
+
+${SUDO_USER} is already in the ${KUKE_GROUP} group. If the commands below fail with
+${C_BOLD}dial kukeond ... permission denied${C_RESET}, your shell predates the group grant —
+start a new login session or run ${C_BOLD}newgrp ${KUKE_GROUP}${C_RESET} first.
+EOF
+            ;;
+        *)
+            : # direct-root install or group not yet created — nothing to surface.
+            ;;
+    esac
+}
+
 print_next_steps() {
+    print_group_note
     cat <<EOF
 
 ${C_GREEN}${C_BOLD}✓ kukeon installed and initialized${C_RESET}

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -405,6 +405,7 @@ do_install() {
     fi
 
     install_systemd_unit
+    grant_group_membership
 }
 
 # --- Running-daemon version gate ---------------------------------------------
@@ -442,6 +443,50 @@ handle_running_daemon() {
     printf '      %ssudo kuke daemon recreate --kukeond-image ghcr.io/%s:%s%s\n\n' "$C_BOLD" "$KUKE_REPO" "$KUKE_VERSION" "$C_RESET" >&2
     printf '    To keep an intentionally pinned older daemon, re-run with KUKE_SKIP_DAEMON_UPGRADE=1.\n' >&2
     return 0
+}
+
+# --- kukeon group membership -------------------------------------------------
+# `kuke init` creates the `kukeon` group and lands the daemon socket
+# root:kukeon 0o660, so dialing it requires membership in that group. Init
+# never touches the invoking user's groups, so the operator who just drove the
+# install — the obvious first client — would hit `dial kukeond ... permission
+# denied` on the very next command. Grant it here while we still hold root.
+#
+# Scoped to a non-root $SUDO_USER: a direct-root install has no invoking user to
+# grant, and we never silently add other accounts (group membership confers
+# daemon access — a real privilege grant, intended only for the operator).
+# Idempotent: an already-member user is a clean no-op, not an error.
+#
+# Group changes only take effect in a NEW login session; KUKE_GROUP_GRANT
+# records the outcome so print_next_steps can tell the operator to start one
+# (newgrp / re-login) before the first client command.
+KUKE_GROUP="kukeon"
+KUKE_GROUP_GRANT="skipped" # skipped | added | already
+
+grant_group_membership() {
+    # No invoking user to grant when run directly as root (no sudo wrapper).
+    if [ -z "${SUDO_USER:-}" ] || [ "$SUDO_USER" = "root" ]; then
+        return 0
+    fi
+    # The group is created by `kuke init`. If it is somehow absent (init was
+    # skipped via KUKE_SKIP_INIT, or a partial bootstrap), skip rather than
+    # fail the whole install — there is nothing to join yet.
+    if ! getent group "$KUKE_GROUP" >/dev/null 2>&1; then
+        return 0
+    fi
+    step "Granting ${SUDO_USER} access to the ${KUKE_GROUP} group"
+    if id -nG "$SUDO_USER" 2>/dev/null | tr ' ' '\n' | grep -qxF "$KUKE_GROUP"; then
+        KUKE_GROUP_GRANT="already"
+        ok "${SUDO_USER} is already a member of the ${KUKE_GROUP} group"
+        return 0
+    fi
+    if $SUDO usermod -aG "$KUKE_GROUP" "$SUDO_USER"; then
+        KUKE_GROUP_GRANT="added"
+        ok "added ${SUDO_USER} to the ${KUKE_GROUP} group"
+    else
+        warn "could not add ${SUDO_USER} to the ${KUKE_GROUP} group — add it manually:"
+        printf '      sudo usermod -aG %s %s\n' "$KUKE_GROUP" "$SUDO_USER" >&2
+    fi
 }
 
 # --- systemd unit ------------------------------------------------------------
@@ -511,7 +556,40 @@ EOF
 }
 
 # --- Next steps --------------------------------------------------------------
+# Surface the kukeon-group requirement before the first client command. After
+# grant_group_membership, $SUDO_USER is in the group on disk, but the current
+# shell still carries the old group set — so the next `kuke` command would hit
+# `dial kukeond ... permission denied`. Tell the operator to start a fresh
+# session (newgrp / re-login) first, and state whether we just added them or
+# they were already a member so the message stays honest on a re-run.
+print_group_note() {
+    case "$KUKE_GROUP_GRANT" in
+        added)
+            cat <<EOF
+
+${C_BOLD}Added ${SUDO_USER} to the ${KUKE_GROUP} group${C_RESET} — this grants access to the kukeon
+daemon socket. Group membership only takes effect in a new login session, so
+start one before the commands below (log out and back in), or use the no-logout
+shortcut:
+  ${C_BOLD}newgrp ${KUKE_GROUP}${C_RESET}
+EOF
+            ;;
+        already)
+            cat <<EOF
+
+${SUDO_USER} is already in the ${KUKE_GROUP} group. If the commands below fail with
+${C_BOLD}dial kukeond ... permission denied${C_RESET}, your shell predates the group grant —
+start a new login session or run ${C_BOLD}newgrp ${KUKE_GROUP}${C_RESET} first.
+EOF
+            ;;
+        *)
+            : # direct-root install or group not yet created — nothing to surface.
+            ;;
+    esac
+}
+
 print_next_steps() {
+    print_group_note
     cat <<EOF
 
 ${C_GREEN}${C_BOLD}✓ kukeon installed and initialized${C_RESET}


### PR DESCRIPTION
## Summary

- `kuke init` creates the `kukeon` group and lands the daemon socket `root:kukeon 0o660`, but never adds the invoking operator to the group — so the very first `kuke` client command the install banner suggests hits `dial kukeond ... permission denied`. This wires the installer to close that gap automatically while it still holds root.
- New `grant_group_membership` (runs after init, inside `do_install`): when a non-root `$SUDO_USER` is present, `usermod -aG kukeon "$SUDO_USER"`. Idempotent — an already-member user is a clean no-op via an `id -nG | grep -qxF` membership check, never an error. Skipped cleanly when run directly as root (no `$SUDO_USER`, or `$SUDO_USER=root`) and when the group doesn't exist yet (e.g. `KUKE_SKIP_INIT=1`). This is a real privilege grant, so it is scoped strictly to the interactive installer's `$SUDO_USER` — never silently to other accounts.
- New `print_group_note` (called from `print_next_steps`): surfaces the re-login requirement before the first client command, with `newgrp kukeon` as the no-logout shortcut. States explicitly whether the user was **just added** vs **already a member** (`KUKE_GROUP_GRANT` records the outcome); prints nothing on a direct-root install.
- Regenerated the `docs/site/install.sh` mirror via `make install.sh` (the `installer.yaml` CI sync check is satisfied).

Coordinates with merged step 2 (#1245), which also edits `print_next_steps` — different lines (step 2 fixed the advertised commands; this adds the group/re-login note ahead of them). Per the issue's Notes, standalone `kuke init` auto-add is explicitly out of scope (a separate follow-up question); this covers the `curl … | install.sh` onboarding path only.

## Test plan

- [x] `bash -n scripts/install.sh` — syntax OK (script is `set -euo pipefail`).
- [x] `make install.sh` + `diff scripts/install.sh docs/site/install.sh` — mirror byte-identical (the `installer.yaml` sync-check job).
- [x] `bash scripts/install.sh --check` — exits 0, prereq path unaffected (the `installer.yaml` --check job).
- [x] Isolated branch tests of `grant_group_membership` (stubbed `getent`/`id`/`usermod`): direct-root → `skipped` (no `usermod`); `$SUDO_USER=root` → `skipped`; non-member → `added` (`usermod -aG kukeon` invoked); already-member → `already` (no `usermod`). Confirmed the membership detector uses whole-line fixed-string match (`grep -qxF`) so `kukeon` can't match a `kukeon-*` group.
- [x] Isolated render of `print_group_note` for all three `KUKE_GROUP_GRANT` states — `added`/`already` print the correct guidance, `skipped` prints nothing.
- [ ] AC item 5 — full hand-verification (fresh `sudo` install → `newgrp kukeon` → first `kuke get …` succeeds without EACCES) — **not run on the dev host**: it mutates a real account's group membership and runs `kuke init` against live containerd/cgroups, which would clobber unrelated host state. The constituent logic (each grant branch + the note for each state) is verified above in isolation; the end-to-end smoke is best run by the reviewer on a clean host.

Note on the named CI test target: the Go suite (`make test`, `.github/workflows/test.yaml`) is path-filtered to `**/*.go` / `go.mod` / `go.sum` and does **not** trigger on this shell-only diff. The CI surface that gates this change is `.github/workflows/installer.yaml` (sync check + `--check`), both green locally above.

## Acceptance criteria

- [x] On a fresh `sudo`-driven install, `$SUDO_USER` is added to the `kukeon` group automatically; re-running is idempotent (already-member is a no-op).
- [x] Skipped cleanly when there is no non-root `$SUDO_USER` (direct-root install).
- [x] The success message states the group was granted and tells the operator to `newgrp kukeon` (or re-login) before the first client command, with explicit just-added vs already-member wording.
- [x] The `docs/site/` install-script mirror matches.
- [ ] Verified by hand end-to-end — deferred to a clean host (destructive: mutates a real user's groups + runs `kuke init`); logic verified in isolation instead. See test plan.

Closes #1246