### PR TITLE
feat(daemon): reconcile Space network state in the loop + Serve-startup re-assert (step 1)

### DIFF
--- a/internal/client/local/local.go
+++ b/internal/client/local/local.go
@@ -922,6 +922,14 @@ func (c *Client) ReconcileCells() (controller.ReconcileResult, error) {
 	return c.ctrl.ReconcileCells()
 }
 
+// ReconcileSpaceNetworks runs one pass of the daemon-side Space network
+// reconciliation loop (#1074): re-asserts each space's CNI conflist/bridge
+// and egress policy from space.Spec.Network. Daemon-internal: not surfaced
+// over the kukeonv1 wire.
+func (c *Client) ReconcileSpaceNetworks() (controller.SpaceNetReconcileResult, error) {
+	return c.ctrl.ReconcileSpaceNetworks()
+}
+
 // ---- Refresh ----
 
 func (c *Client) RefreshAll(_ context.Context) (kukeonv1.RefreshAllResult, error) {

--- a/internal/controller/reconcile.go
+++ b/internal/controller/reconcile.go
@@ -39,6 +39,62 @@ type ReconcileResult struct {
 	Errors       []string
 }
 
+// SpaceNetReconcileResult summarizes a single pass of the daemon's
+// background Space network reconciliation loop (#1074, foundation of the
+// #953 spacenet epic). Counts are scoped to spaces; per-pass errors are
+// collected so the loop can keep ticking.
+type SpaceNetReconcileResult struct {
+	SpacesScanned int
+	SpacesErrored int
+	Errors        []string
+}
+
+// ReconcileSpaceNetworks walks every realm/space and re-asserts each space's
+// network desired-state — the CNI conflist/bridge and the egress policy from
+// space.Spec.Network — via the idempotent EnsureSpace helper (which fans out
+// to ensureSpaceCNIConfig in provision.go and applySpaceEgressPolicy in
+// egress.go). It is the per-tick sibling of ReconcileCells: a reboot wipes
+// the host's iptables and CNI state, and without continuous re-assertion a
+// Default=deny space whose KUKEON-EGRESS chain went missing silently allows
+// all egress. The global KUKEON-FORWARD admission chain is re-asserted by the
+// daemon layer (one chain covers every bridge), not here.
+//
+// Errors at any level are recorded in Errors; the walk continues so a single
+// bad space does not silence the rest of the host. The returned error is
+// always nil — failures surface through Errors so the loop keeps ticking,
+// matching ReconcileCells.
+func (b *Exec) ReconcileSpaceNetworks() (SpaceNetReconcileResult, error) {
+	result := SpaceNetReconcileResult{Errors: []string{}}
+
+	realms, err := b.runner.ListRealms()
+	if err != nil {
+		result.Errors = append(result.Errors, fmt.Sprintf("list realms: %v", err))
+		return result, nil
+	}
+
+	for _, realm := range realms {
+		realmName := realm.Metadata.Name
+		spaces, listErr := b.runner.ListSpaces(realmName)
+		if listErr != nil {
+			result.Errors = append(result.Errors,
+				fmt.Sprintf("list spaces in realm %q: %v", realmName, listErr))
+			continue
+		}
+		for _, space := range spaces {
+			result.SpacesScanned++
+			if _, ensureErr := b.runner.EnsureSpace(space); ensureErr != nil {
+				result.SpacesErrored++
+				result.Errors = append(result.Errors,
+					fmt.Sprintf("reconcile space network %s/%s: %v",
+						realmName, space.Metadata.Name, ensureErr))
+				continue
+			}
+		}
+	}
+
+	return result, nil
+}
+
 // ReconcileCells walks every realm/space/stack and reconciles each cell's
 // status against observed container state. Errors at any level are logged
 // and recorded in Errors; the walk continues so a single bad cell does not

--- a/internal/controller/reconcile_spacenet_test.go
+++ b/internal/controller/reconcile_spacenet_test.go
@@ -1,0 +1,193 @@
+//go:build !integration
+
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package controller_test
+
+import (
+	"errors"
+	"sort"
+	"strings"
+	"sync"
+	"testing"
+
+	intmodel "github.com/eminwux/kukeon/internal/modelhub"
+)
+
+// TestReconcileSpaceNetworks_WalksEverySpaceAndEnsures is #1074 AC #1/#2: the
+// pass walks every realm/space and re-asserts each space's network
+// desired-state via the idempotent EnsureSpace helper (which fans out to the
+// CNI conflist/bridge + egress-policy apply helpers).
+func TestReconcileSpaceNetworks_WalksEverySpaceAndEnsures(t *testing.T) {
+	realmA := buildTestRealm("realm-a", "")
+	realmB := buildTestRealm("realm-b", "")
+	spaceA1 := buildTestSpace("space-a1", "realm-a")
+	spaceA2 := buildTestSpace("space-a2", "realm-a")
+	spaceB1 := buildTestSpace("space-b1", "realm-b")
+
+	var mu sync.Mutex
+	var ensured []string
+	mock := &fakeRunner{
+		ListRealmsFn: func() ([]intmodel.Realm, error) {
+			return []intmodel.Realm{realmA, realmB}, nil
+		},
+		ListSpacesFn: func(realm string) ([]intmodel.Space, error) {
+			switch realm {
+			case "realm-a":
+				return []intmodel.Space{spaceA1, spaceA2}, nil
+			case "realm-b":
+				return []intmodel.Space{spaceB1}, nil
+			}
+			return nil, nil
+		},
+		EnsureSpaceFn: func(space intmodel.Space) (intmodel.Space, error) {
+			mu.Lock()
+			ensured = append(ensured, space.Spec.RealmName+"/"+space.Metadata.Name)
+			mu.Unlock()
+			return space, nil
+		},
+	}
+
+	ctrl := setupTestController(t, mock)
+	res, err := ctrl.ReconcileSpaceNetworks()
+	if err != nil {
+		t.Fatalf("ReconcileSpaceNetworks() error = %v", err)
+	}
+	if res.SpacesScanned != 3 {
+		t.Errorf("SpacesScanned: got %d, want 3", res.SpacesScanned)
+	}
+	if res.SpacesErrored != 0 {
+		t.Errorf("SpacesErrored: got %d, want 0", res.SpacesErrored)
+	}
+	if len(res.Errors) != 0 {
+		t.Errorf("Errors: got %v, want empty", res.Errors)
+	}
+
+	sort.Strings(ensured)
+	want := []string{"realm-a/space-a1", "realm-a/space-a2", "realm-b/space-b1"}
+	if strings.Join(ensured, ",") != strings.Join(want, ",") {
+		t.Errorf("EnsureSpace called for: got %v, want %v", ensured, want)
+	}
+}
+
+// TestReconcileSpaceNetworks_PerSpaceErrorDoesNotAbortWalk confirms a single
+// space whose EnsureSpace fails is recorded but does not silence the rest of
+// the host — the loop must keep converging every other space (#1074).
+func TestReconcileSpaceNetworks_PerSpaceErrorDoesNotAbortWalk(t *testing.T) {
+	realm := buildTestRealm("realm-a", "")
+	good := buildTestSpace("good", "realm-a")
+	bad := buildTestSpace("bad", "realm-a")
+	alsoGood := buildTestSpace("also-good", "realm-a")
+
+	var ensuredCount int
+	mock := &fakeRunner{
+		ListRealmsFn: func() ([]intmodel.Realm, error) {
+			return []intmodel.Realm{realm}, nil
+		},
+		ListSpacesFn: func(_ string) ([]intmodel.Space, error) {
+			return []intmodel.Space{good, bad, alsoGood}, nil
+		},
+		EnsureSpaceFn: func(space intmodel.Space) (intmodel.Space, error) {
+			ensuredCount++
+			if space.Metadata.Name == "bad" {
+				return intmodel.Space{}, errors.New("synthetic egress apply failure")
+			}
+			return space, nil
+		},
+	}
+
+	ctrl := setupTestController(t, mock)
+	res, err := ctrl.ReconcileSpaceNetworks()
+	if err != nil {
+		t.Fatalf("ReconcileSpaceNetworks() error = %v", err)
+	}
+	if ensuredCount != 3 {
+		t.Errorf("EnsureSpace calls: got %d, want 3 (walk must continue past the bad space)", ensuredCount)
+	}
+	if res.SpacesScanned != 3 {
+		t.Errorf("SpacesScanned: got %d, want 3", res.SpacesScanned)
+	}
+	if res.SpacesErrored != 1 {
+		t.Errorf("SpacesErrored: got %d, want 1", res.SpacesErrored)
+	}
+	if len(res.Errors) != 1 || !strings.Contains(res.Errors[0], "realm-a/bad") {
+		t.Errorf("Errors: got %v, want one entry naming realm-a/bad", res.Errors)
+	}
+}
+
+// TestReconcileSpaceNetworks_ListRealmsErrorIsRecorded confirms a top-level
+// list failure is captured in Errors and returns a nil error so the daemon
+// loop keeps ticking (mirrors ReconcileCells).
+func TestReconcileSpaceNetworks_ListRealmsErrorIsRecorded(t *testing.T) {
+	mock := &fakeRunner{
+		ListRealmsFn: func() ([]intmodel.Realm, error) {
+			return nil, errors.New("containerd unavailable")
+		},
+	}
+
+	ctrl := setupTestController(t, mock)
+	res, err := ctrl.ReconcileSpaceNetworks()
+	if err != nil {
+		t.Fatalf("ReconcileSpaceNetworks() error = %v, want nil (errors surface via Errors)", err)
+	}
+	if res.SpacesScanned != 0 {
+		t.Errorf("SpacesScanned: got %d, want 0", res.SpacesScanned)
+	}
+	if len(res.Errors) != 1 || !strings.Contains(res.Errors[0], "list realms") {
+		t.Errorf("Errors: got %v, want one list-realms entry", res.Errors)
+	}
+}
+
+// TestReconcileSpaceNetworks_ListSpacesErrorSkipsRealm confirms a per-realm
+// ListSpaces failure is recorded and the walk continues into sibling realms.
+func TestReconcileSpaceNetworks_ListSpacesErrorSkipsRealm(t *testing.T) {
+	realmA := buildTestRealm("realm-a", "")
+	realmB := buildTestRealm("realm-b", "")
+	spaceB := buildTestSpace("space-b", "realm-b")
+
+	var ensured []string
+	mock := &fakeRunner{
+		ListRealmsFn: func() ([]intmodel.Realm, error) {
+			return []intmodel.Realm{realmA, realmB}, nil
+		},
+		ListSpacesFn: func(realm string) ([]intmodel.Space, error) {
+			if realm == "realm-a" {
+				return nil, errors.New("metadata dir unreadable")
+			}
+			return []intmodel.Space{spaceB}, nil
+		},
+		EnsureSpaceFn: func(space intmodel.Space) (intmodel.Space, error) {
+			ensured = append(ensured, space.Metadata.Name)
+			return space, nil
+		},
+	}
+
+	ctrl := setupTestController(t, mock)
+	res, err := ctrl.ReconcileSpaceNetworks()
+	if err != nil {
+		t.Fatalf("ReconcileSpaceNetworks() error = %v", err)
+	}
+	if res.SpacesScanned != 1 {
+		t.Errorf("SpacesScanned: got %d, want 1 (realm-b only)", res.SpacesScanned)
+	}
+	if len(ensured) != 1 || ensured[0] != "space-b" {
+		t.Errorf("EnsureSpace called for: got %v, want [space-b]", ensured)
+	}
+	if len(res.Errors) != 1 || !strings.Contains(res.Errors[0], "realm-a") {
+		t.Errorf("Errors: got %v, want one entry naming realm-a", res.Errors)
+	}
+}

--- a/internal/daemon/reconcile_spacenet_test.go
+++ b/internal/daemon/reconcile_spacenet_test.go
@@ -1,0 +1,228 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package daemon
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"path/filepath"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/eminwux/kukeon/internal/controller"
+	"github.com/eminwux/kukeon/internal/firewall"
+)
+
+// TestServer_SpaceNetworkReconcileLoopFires is #1074 AC #1/#4: the daemon
+// ticker drives a Space network reconcile pass — re-asserting FORWARD
+// admission and the per-space CNI/egress state — on every tick, sibling to
+// the cell pass. Continuous enforcement is what re-creates a removed
+// KUKEON-EGRESS chain on the next tick.
+func TestServer_SpaceNetworkReconcileLoopFires(t *testing.T) {
+	srv := newTestServer(t, 20*time.Millisecond)
+	var fwdCalls, spaceCalls atomic.Int32
+	srv.reconcileFn = func() (controller.ReconcileResult, error) {
+		return controller.ReconcileResult{}, nil
+	}
+	srv.forwardAdmissionFn = func() error {
+		fwdCalls.Add(1)
+		return nil
+	}
+	srv.spaceNetReconcileFn = func() (controller.SpaceNetReconcileResult, error) {
+		spaceCalls.Add(1)
+		return controller.SpaceNetReconcileResult{SpacesScanned: 2}, nil
+	}
+
+	startServer(t, srv)
+	waitForCalls(t, &spaceCalls, 2, 2*time.Second)
+	// FORWARD admission is re-asserted in the same pass, so it tracks the
+	// space pass tick-for-tick.
+	if got := fwdCalls.Load(); got < 2 {
+		t.Errorf("forwardAdmissionFn calls: got %d, want >=2", got)
+	}
+}
+
+// TestServer_SpaceNetworkReconcileRunsOnStartupBeforeLoop is #1074 AC #3: the
+// pass is invoked once on Serve startup before the loop begins. A large
+// reconcile interval is used so a call landing inside the short deadline can
+// only be the eager startup pass, not a ticker tick — this is the reboot-heal
+// path (#1074) that re-installs the wiped chains immediately.
+func TestServer_SpaceNetworkReconcileRunsOnStartupBeforeLoop(t *testing.T) {
+	srv := newTestServer(t, 10*time.Second)
+	var fwdCalls, spaceCalls atomic.Int32
+	srv.reconcileFn = func() (controller.ReconcileResult, error) {
+		return controller.ReconcileResult{}, nil
+	}
+	srv.forwardAdmissionFn = func() error {
+		fwdCalls.Add(1)
+		return nil
+	}
+	srv.spaceNetReconcileFn = func() (controller.SpaceNetReconcileResult, error) {
+		spaceCalls.Add(1)
+		return controller.SpaceNetReconcileResult{}, nil
+	}
+
+	startServer(t, srv)
+	// Far shorter than the 10s interval: a call here can only be the startup
+	// pass that runs before startReconcileLoop.
+	waitForCalls(t, &spaceCalls, 1, 1*time.Second)
+	if got := fwdCalls.Load(); got < 1 {
+		t.Errorf("forwardAdmissionFn calls on startup: got %d, want >=1", got)
+	}
+}
+
+// TestServer_SpaceNetworkReconcileContinuesOnError confirms a failing Space
+// network pass (or a failing FORWARD re-assert) is logged and the loop keeps
+// ticking — a transient iptables failure must never wedge the loop or take
+// the daemon down (#1074).
+func TestServer_SpaceNetworkReconcileContinuesOnError(t *testing.T) {
+	srv := newTestServer(t, 20*time.Millisecond)
+	var spaceCalls atomic.Int32
+	srv.reconcileFn = func() (controller.ReconcileResult, error) {
+		return controller.ReconcileResult{}, nil
+	}
+	srv.forwardAdmissionFn = func() error {
+		return context.DeadlineExceeded
+	}
+	srv.spaceNetReconcileFn = func() (controller.SpaceNetReconcileResult, error) {
+		spaceCalls.Add(1)
+		return controller.SpaceNetReconcileResult{
+			SpacesScanned: 1,
+			SpacesErrored: 1,
+			Errors:        []string{"synthetic egress failure"},
+		}, nil
+	}
+
+	startServer(t, srv)
+	waitForCalls(t, &spaceCalls, 3, 2*time.Second)
+}
+
+// recordingIptables is a firewall.CommandRunner that simulates a host whose
+// KUKEON-FORWARD chain has been wiped: every existence probe (-L / -C) fails,
+// forcing Install down its create path (-N / -A / -I). It records the
+// mutating invocations so a test can assert the chain was actually
+// re-installed.
+type recordingIptables struct {
+	mu   sync.Mutex
+	args [][]string
+}
+
+func (r *recordingIptables) Run(_ context.Context, args ...string) ([]byte, error) {
+	r.mu.Lock()
+	r.args = append(r.args, append([]string(nil), args...))
+	r.mu.Unlock()
+	// Read-only probes report "absent" so Install always takes the create
+	// path; mutating commands succeed.
+	switch args[0] {
+	case "-L", "-C", "-S":
+		return nil, context.Canceled // any non-nil error == "not present"
+	default:
+		return nil, nil
+	}
+}
+
+func (r *recordingIptables) ran(prefix ...string) bool {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	for _, got := range r.args {
+		if len(got) < len(prefix) {
+			continue
+		}
+		match := true
+		for i := range prefix {
+			if got[i] != prefix[i] {
+				match = false
+				break
+			}
+		}
+		if match {
+			return true
+		}
+	}
+	return false
+}
+
+// TestServer_SpaceNetworkReconcileReinstallsWipedForwardChain is #1074 AC #5:
+// simulate a wiped FORWARD admission chain and assert the reconcile pass
+// re-installs it. The pass drives a real firewall.Installer over a fake
+// iptables runner whose existence probes all report "absent" (the
+// post-reboot state); the test asserts the create path ran — the chain was
+// declared (-N KUKEON-FORWARD) and the FORWARD jump re-inserted.
+func TestServer_SpaceNetworkReconcileReinstallsWipedForwardChain(t *testing.T) {
+	dir := t.TempDir()
+	socketPath := filepath.Join(dir, "kukeond.sock")
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+
+	fake := &recordingIptables{}
+	installer := firewall.NewInstallerWithRunner(logger, fake)
+
+	srv := NewServer(context.Background(), logger, Options{
+		SocketPath:        socketPath,
+		SocketMode:        0o600,
+		ReconcileInterval: 10 * time.Second,
+	})
+	srv.reconcileFn = func() (controller.ReconcileResult, error) {
+		return controller.ReconcileResult{}, nil
+	}
+	srv.spaceNetReconcileFn = func() (controller.SpaceNetReconcileResult, error) {
+		return controller.SpaceNetReconcileResult{}, nil
+	}
+	// Wire the FORWARD re-assert to the real Installer over the fake runner so
+	// the startup pass exercises the genuine re-install code path.
+	srv.forwardAdmissionFn = func() error {
+		return installer.Install(context.Background())
+	}
+
+	startServer(t, srv)
+
+	// The startup pass runs before the loop; poll briefly for it to land.
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if fake.ran("-N", firewall.ForwardChainName) {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	if !fake.ran("-N", firewall.ForwardChainName) {
+		t.Errorf("wiped FORWARD chain not re-created: expected `-N %s` invocation, got %v",
+			firewall.ForwardChainName, fake.args)
+	}
+	if !fake.ran("-I", "FORWARD") {
+		t.Errorf("FORWARD jump not re-inserted: expected `-I FORWARD ...` invocation, got %v", fake.args)
+	}
+	// The admission rules carry the kukeon-forward comment tag; confirm at
+	// least one tagged rule was appended on the re-install.
+	if !ranContains(fake, "kukeon-forward") {
+		t.Errorf("admission rules not re-appended: no kukeon-forward-tagged rule in %v", fake.args)
+	}
+}
+
+func ranContains(r *recordingIptables, needle string) bool {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	for _, got := range r.args {
+		if strings.Contains(strings.Join(got, " "), needle) {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/daemon/reconcile_test.go
+++ b/internal/daemon/reconcile_test.go
@@ -158,11 +158,21 @@ func newTestServerWithCtx(t *testing.T, ctx context.Context, interval time.Durat
 	dir := t.TempDir()
 	socketPath := filepath.Join(dir, "kukeond.sock")
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
-	return NewServer(ctx, logger, Options{
+	srv := NewServer(ctx, logger, Options{
 		SocketPath:        socketPath,
 		SocketMode:        0o600,
 		ReconcileInterval: interval,
 	})
+	// The reconcile loop now drives a Space network pass (FORWARD admission +
+	// per-space CNI/egress) alongside the cell pass (#1074). Loop tests assert
+	// only on reconcileFn, so stub these hooks to keep the ticker hermetic —
+	// otherwise the default wiring would shell out to real iptables on every
+	// tick. Tests that exercise the Space network pass set them explicitly.
+	srv.forwardAdmissionFn = func() error { return nil }
+	srv.spaceNetReconcileFn = func() (controller.SpaceNetReconcileResult, error) {
+		return controller.SpaceNetReconcileResult{}, nil
+	}
+	return srv
 }
 
 func startServer(t *testing.T, srv *Server) {

--- a/internal/daemon/server.go
+++ b/internal/daemon/server.go
@@ -73,9 +73,17 @@ type Server struct {
 	// it before Serve so they exercise the ticker without a real controller.
 	reconcileFn func() (controller.ReconcileResult, error)
 
-	// forwardAdmissionFn re-asserts the host FORWARD admission chain once on
-	// Serve startup. Defaults to reassertForwardAdmission; tests overwrite it
-	// before Serve so they exercise the startup hook without touching iptables.
+	// spaceNetReconcileFn is the per-tick callable for the Space network
+	// reconciliation pass (#1074): it re-asserts each space's CNI
+	// conflist/bridge + egress policy from space.Spec.Network. Defaults to
+	// core.ReconcileSpaceNetworks; tests overwrite it before Serve so they
+	// exercise the ticker without a real controller.
+	spaceNetReconcileFn func() (controller.SpaceNetReconcileResult, error)
+
+	// forwardAdmissionFn re-asserts the host FORWARD admission chain on Serve
+	// startup and on every reconcile tick (folded into the Space network pass,
+	// #1074). Defaults to reassertForwardAdmission; tests overwrite it before
+	// Serve so they exercise the hook without touching iptables.
 	forwardAdmissionFn func() error
 
 	// stopCh is closed by Stop to terminate the reconcile loop independently
@@ -103,6 +111,7 @@ func NewServer(ctx context.Context, logger *slog.Logger, opts Options) *Server {
 		stopCh: make(chan struct{}),
 	}
 	srv.reconcileFn = srv.core.ReconcileCells
+	srv.spaceNetReconcileFn = srv.core.ReconcileSpaceNetworks
 	srv.forwardAdmissionFn = srv.reassertForwardAdmission
 	return srv
 }
@@ -153,16 +162,14 @@ func (s *Server) Serve() error {
 	}
 
 	s.logger.InfoContext(s.ctx, "kukeond listening", "socket", s.opts.SocketPath)
-	// NewServer always wires forwardAdmissionFn; call it unguarded to match the
-	// reconcileFn pattern (runReconcileOnce dereferences s.reconcileFn directly).
-	if err := s.forwardAdmissionFn(); err != nil {
-		// Best-effort: a flushed/unavailable FORWARD admission chain must
-		// not block the daemon from serving. The next reboot self-heals
-		// here; durable per-space egress + Docker-churn handling is #953.
-		s.logger.WarnContext(s.ctx,
-			"forward admission re-assert failed on startup; continuing",
-			"error", err)
-	}
+	// Re-assert the full host network desired-state once before the loop
+	// begins (#1074) so a reboot — which flushes iptables and strips the
+	// KUKEON-FORWARD/KUKEON-EGRESS chains — heals immediately rather than on
+	// the first tick. This folds in the FORWARD admission re-assert that
+	// previously ran standalone here and adds the per-space CNI/egress
+	// re-assert. Best-effort throughout: a flushed/unavailable chain or a
+	// single bad space must not block the daemon from serving.
+	s.runSpaceNetworkReconcileOnce()
 	s.startReconcileLoop()
 	s.acceptLoop(listener)
 	return nil
@@ -250,6 +257,7 @@ func (s *Server) runReconcileLoop(interval time.Duration) {
 			return
 		case <-ticker.C:
 			s.runReconcileOnce()
+			s.runSpaceNetworkReconcileOnce()
 		}
 	}
 }
@@ -283,6 +291,53 @@ func (s *Server) runReconcileOnce() {
 			"cells_scanned", res.CellsScanned,
 			"cells_updated", res.CellsUpdated,
 			"cells_deleted", res.CellsDeleted)
+	}
+}
+
+// runSpaceNetworkReconcileOnce re-asserts the host's network desired-state in
+// one pass (#1074): the global KUKEON-FORWARD admission chain (idempotent;
+// its k-+ iface match covers every kukeon bridge, so one re-assert per pass
+// suffices for all spaces) followed by the per-Space CNI conflist/bridge +
+// egress policy from space.Spec.Network. All underlying ops are idempotent,
+// so a healthy host sees no rule churn. Best-effort and panic-guarded like
+// runReconcileOnce: a failed FORWARD re-assert or a single bad space is
+// logged and the pass continues — nothing here may wedge the loop or take
+// the daemon down. Called once on Serve startup before the loop and on every
+// ticker tick.
+func (s *Server) runSpaceNetworkReconcileOnce() {
+	defer func() {
+		if r := recover(); r != nil {
+			s.logger.ErrorContext(s.ctx,
+				"space network reconcile pass panicked; loop continues",
+				"panic", r)
+		}
+	}()
+
+	if err := s.forwardAdmissionFn(); err != nil {
+		// Best-effort: a flushed/unavailable FORWARD admission chain must
+		// not block the per-space pass or the daemon. The next tick (or a
+		// reboot) self-heals here.
+		s.logger.WarnContext(s.ctx,
+			"forward admission re-assert failed; continuing",
+			"error", err)
+	}
+
+	res, err := s.spaceNetReconcileFn()
+	switch {
+	case err != nil:
+		s.logger.ErrorContext(s.ctx, "space network reconcile pass failed",
+			"error", err,
+			"spaces_scanned", res.SpacesScanned,
+			"spaces_errored", res.SpacesErrored,
+			"errors", res.Errors)
+	case len(res.Errors) > 0:
+		s.logger.WarnContext(s.ctx, "space network reconcile pass completed with errors",
+			"spaces_scanned", res.SpacesScanned,
+			"spaces_errored", res.SpacesErrored,
+			"errors", res.Errors)
+	default:
+		s.logger.InfoContext(s.ctx, "space network reconcile ok",
+			"spaces_scanned", res.SpacesScanned)
 	}
 }
 


### PR DESCRIPTION
## Summary

Step 1 of the spacenet epic (#953). Host firewall + CNI state was installed **once, imperatively, at `kuke init`** and never re-asserted; the daemon ticker reconciled cells only. A reboot wipes the iptables chains and CNI state → cell egress is silently dropped (and a `Default=deny` space whose `KUKEON-EGRESS` chain went missing fails open, silently allowing all egress).

This adds a periodic **Space network reconcile pass** sibling to `ReconcileCells`, plus a Serve-startup re-assert so a reboot heals immediately rather than on the next tick.

- New `controller.(*Exec).ReconcileSpaceNetworks()` walks every realm/space and re-asserts each space's CNI conflist/bridge + egress policy via the existing idempotent `Runner.EnsureSpace` (which fans out to `ensureSpaceCNIConfig` in `provision.go` and `applySpaceEgressPolicy` in `egress.go`). Errors are collected per-space; the walk continues so one bad space can't silence the host. Returns `nil` error like `ReconcileCells` so the loop keeps ticking.
- New daemon `runSpaceNetworkReconcileOnce()` runs the per-space pass **and** re-asserts the global `KUKEON-FORWARD` admission chain (`internal/firewall`). It's wired into the ticker (sibling to `runReconcileOnce`) and called once on `Serve` startup before the loop begins. Panic-guarded + best-effort, matching `runReconcileOnce`.
- `local.Client.ReconcileSpaceNetworks` delegates to the controller; `Server.spaceNetReconcileFn` is the injectable per-tick hook (defaults to it), mirroring `reconcileFn`.

### Design notes (for reviewer push-back)

- **FORWARD admission is global, not per-space.** The AC says "host FORWARD admission for that space's bridge", but `KUKEON-FORWARD`'s `-i/-o k-+` iface match covers *every* kukeon bridge — a single chain serves all spaces. So it's re-asserted once per pass at the daemon layer (where it already lived via `reassertForwardAdmission`), not once per space. The previous standalone startup `forwardAdmissionFn()` call in `Serve` is folded into the unified pass — identical startup behavior, now also re-asserted per tick.
- **Reused the exported `EnsureSpace` Runner method** rather than adding new interface surface. It re-asserts CNI conflist/bridge + egress (the AC's per-space items) and also re-ensures the space cgroup — an idempotent, harmless bonus aligned with the existing reboot cgroup-heal spirit. No new `Runner` method, no new fake stubs.
- **Lock claim:** issue carries `epic:spacenet`; `Depends on: none`, so no merge precondition.

## Test plan

- [x] `make test` (full CI target, `GOWORK=off`) — all packages pass, incl. `internal/daemon`, `internal/controller`, `internal/client/local`.
- [x] `go vet` (`GOWORK=off`) on touched packages — clean.
- [x] `pre-commit run --files <changed>` — gofmt, golangci-lint, addlicense, go-mod-tidy all pass.
- [x] New controller tests (`reconcile_spacenet_test.go`): walks every space and calls `EnsureSpace` (AC #1/#2); per-space error doesn't abort the walk; `ListRealms`/`ListSpaces` errors recorded with nil top-level error.
- [x] New daemon tests (`reconcile_spacenet_test.go`): pass fires on every tick (AC #1/#4); runs once on Serve startup before the loop (AC #3); continues past a failing pass; **AC #5** — `TestServer_SpaceNetworkReconcileReinstallsWipedForwardChain` drives a real `firewall.Installer` over a fake iptables runner whose existence probes all report "absent" (post-reboot state) and asserts the wiped chain is re-created (`-N KUKEON-FORWARD`, `-I FORWARD`, tagged admission rules re-appended).
- [ ] `make dev-init` end-to-end smoke — **not run here:** the host's containerd store is a 4.0G tmpfs at 97% (129M free), so the `kuke build` phase fails with `no space left on device` during the kukebuild Go-module download. This is a disk-infra constraint independent of the change (clearing it would require tearing down the running daemon/cell and still wouldn't fit the module closure). The daemon-startup path this change adds (`runSpaceNetworkReconcileOnce` on `Serve`) is covered by the new daemon tests above. Please run `make dev-init` on a disked host before merge.

### AC #5 EGRESS-chain coverage note
AC #5 names "FORWARD/EGRESS". The FORWARD re-install is asserted concretely (real `Installer` over a fake runner). The per-space EGRESS re-creation is driven through `EnsureSpace` → `applySpaceEgressPolicy`; the reconcile pass invoking `EnsureSpace` per space is asserted at the controller layer, and the underlying egress apply idempotency is already covered by `internal/netpolicy` tests. A daemon-level EGRESS re-install test would require a full controller+runner+netpolicy stack with a fake command runner — out of proportion for this step; flagged for reviewer judgment.

Closes #1074
