### PR TITLE
feat: self-assert and re-claim displaced FORWARD jump in reconcile self-assert (step 2)

### DIFF
--- a/internal/firewall/forward.go
+++ b/internal/firewall/forward.go
@@ -263,35 +263,69 @@ func (i *Installer) migrateUntaggedRules(ctx context.Context) error {
 	return flushErr
 }
 
-// ensureForwardJump idempotently inserts the FORWARD → KUKEON-FORWARD
-// jump. When KUKEON-EGRESS (netpolicy.MasterChainName) already lives in
-// FORWARD, the jump is placed at that position + 1 so per-space egress
-// DROP rules win over the blanket admission KUKEON-FORWARD provides.
-// Otherwise the jump goes to position 1; a later netpolicy.Apply() will
-// push it to position 2 by inserting KUKEON-EGRESS at 1.
+// ensureForwardJump idempotently self-asserts the FORWARD → KUKEON-FORWARD
+// jump and its ordering relative to the per-space egress dispatch chain
+// KUKEON-EGRESS (netpolicy.MasterChainName). It is the per-tick self-assert
+// the daemon's network reconcile pass drives via Install (#1074/#1075): a
+// reboot wipes the jump and Docker churn reorders it, and this re-claims it
+// on the next tick without ever touching a Docker-owned chain.
+//
+// Three states, mirroring AC #1 of #1075 ("re-insert when missing or
+// displaced; no churn on a healthy host"):
+//
+//   - Missing — the jump is absent (fresh host or post-reboot flush): insert
+//     it after KUKEON-EGRESS when that dispatch jump exists, else at
+//     position 1. A later netpolicy.Apply() that inserts KUKEON-EGRESS at 1
+//     pushes this jump to 2, preserving the invariant.
+//   - Displaced — the jump exists but sits at or ahead of KUKEON-EGRESS, so
+//     its blanket ACCEPT would shadow per-space egress DROP rules: delete the
+//     misplaced jump and re-insert it after KUKEON-EGRESS.
+//   - Healthy — the jump exists after KUKEON-EGRESS (or KUKEON-EGRESS is
+//     absent): no-op. Position relative to Docker's own chains is immaterial
+//     (KUKEON-FORWARD is ACCEPT-only and is reached before FORWARD's implicit
+//     policy DROP wherever it lands, because Docker's isolation chains RETURN
+//     for non-Docker interfaces), so only a precedence inversion against
+//     KUKEON-EGRESS counts as "displaced" — Docker pushing the jump down the
+//     chain is not churn-worthy.
 func (i *Installer) ensureForwardJump(ctx context.Context) error {
-	if _, err := i.runner.Run(ctx, "-C", "FORWARD", "-j", ForwardChainName); err == nil {
+	forwardPos, egressPos := i.forwardJumpPositions(ctx)
+
+	// Healthy: present and correctly ordered after the egress dispatch jump
+	// (or that jump is absent). No rule churn.
+	if forwardPos > 0 && (egressPos == 0 || forwardPos > egressPos) {
 		return nil
 	}
+
+	// Displaced: present but at/ahead of KUKEON-EGRESS. Drop the misplaced
+	// jump, then re-read the egress position — the delete shifts every lower
+	// rule (KUKEON-EGRESS included) up by one — before computing the slot.
+	if forwardPos > 0 {
+		if _, err := i.runner.Run(ctx, "-D", "FORWARD", "-j", ForwardChainName); err != nil {
+			return err
+		}
+		_, egressPos = i.forwardJumpPositions(ctx)
+	}
+
 	insertAt := "1"
-	if pos := i.findEgressPosition(ctx); pos > 0 {
-		insertAt = strconv.Itoa(pos + 1)
+	if egressPos > 0 {
+		insertAt = strconv.Itoa(egressPos + 1)
 	}
 	_, err := i.runner.Run(ctx, "-I", "FORWARD", insertAt, "-j", ForwardChainName)
 	return err
 }
 
-// findEgressPosition returns the 1-based position of the
-// `-j KUKEON-EGRESS` rule in FORWARD, or 0 when absent / unparseable.
-// Failures are non-fatal — callers fall back to position 1, which is
-// safe when KUKEON-EGRESS is not yet installed.
+// forwardJumpPositions returns the 1-based positions of the KUKEON-FORWARD
+// admission jump and the KUKEON-EGRESS dispatch jump within the builtin
+// FORWARD chain, read in a single `-S FORWARD` pass. A position of 0 means
+// the jump is absent (or FORWARD was unreadable). Failures are non-fatal —
+// callers fall back to the safe position-1 default.
 //
 // The token-aware match prevents a sibling chain named like
 // "KUKEON-EGRESS-FOO" from being mistaken for "KUKEON-EGRESS".
-func (i *Installer) findEgressPosition(ctx context.Context) int {
+func (i *Installer) forwardJumpPositions(ctx context.Context) (forwardPos, egressPos int) {
 	out, err := i.runner.Run(ctx, "-S", "FORWARD")
 	if err != nil {
-		return 0
+		return 0, 0
 	}
 	pos := 0
 	for _, line := range strings.Split(string(out), "\n") {
@@ -300,11 +334,14 @@ func (i *Installer) findEgressPosition(ctx context.Context) int {
 			continue
 		}
 		pos++
-		if lineJumpsTo(line, netpolicy.MasterChainName) {
-			return pos
+		switch {
+		case forwardPos == 0 && lineJumpsTo(line, ForwardChainName):
+			forwardPos = pos
+		case egressPos == 0 && lineJumpsTo(line, netpolicy.MasterChainName):
+			egressPos = pos
 		}
 	}
-	return 0
+	return forwardPos, egressPos
 }
 
 // lineJumpsTo reports whether an `iptables -S` line jumps to exactly the

--- a/internal/firewall/forward_test.go
+++ b/internal/firewall/forward_test.go
@@ -203,13 +203,19 @@ func TestInstall_IsIdempotent(t *testing.T) {
 	runner := &fakeRunner{
 		respond: map[string]fakeResp{
 			// -L succeeds → chain present.
-			// -C jump succeeds → jump present.
 			// Migration check: chain populated with already-tagged rules → no flush.
 			"-S KUKEON-FORWARD": {out: []byte(
 				"-N KUKEON-FORWARD\n" +
 					"-A KUKEON-FORWARD -m conntrack --ctstate RELATED,ESTABLISHED -m comment --comment \"kukeon-forward:established\" -j ACCEPT\n" +
 					"-A KUKEON-FORWARD -i k-+ -m comment --comment \"kukeon-forward:egress\" -j ACCEPT\n" +
 					"-A KUKEON-FORWARD -o k-+ -m comment --comment \"kukeon-forward:ingress\" -j ACCEPT\n",
+			)},
+			// FORWARD jump present and correctly ordered after KUKEON-EGRESS →
+			// ensureForwardJump finds it healthy and re-claims nothing.
+			"-S FORWARD": {out: []byte(
+				"-P FORWARD DROP\n" +
+					"-A FORWARD -j KUKEON-EGRESS\n" +
+					"-A FORWARD -j KUKEON-FORWARD\n",
 			)},
 		},
 	}
@@ -242,7 +248,12 @@ func TestInstall_MigratesUntaggedRules(t *testing.T) {
 					"-A KUKEON-FORWARD -i k-+ -j ACCEPT\n" +
 					"-A KUKEON-FORWARD -o k-+ -j ACCEPT\n",
 			)},
-			"-C FORWARD -j KUKEON-FORWARD": {},
+			// Jump already present (upgrade path migrates the child chain's
+			// rules, not the FORWARD jump) → ensureForwardJump no-ops.
+			"-S FORWARD": {out: []byte(
+				"-P FORWARD DROP\n" +
+					"-A FORWARD -j KUKEON-FORWARD\n",
+			)},
 		},
 	}
 	// After the flush, every -C against a tagged rule fails so each gets -A'd.
@@ -398,6 +409,123 @@ func TestInstall_DoesNotMatchEgressLikeSiblingChain(t *testing.T) {
 	}
 	if wasCalled(runner, []string{"-I", "FORWARD", "2", "-j", "KUKEON-FORWARD"}) {
 		t.Errorf("must not match KUKEON-EGRESS-FOO as KUKEON-EGRESS")
+	}
+}
+
+// TestInstall_SurvivesDockerChurnWithoutReorder is #1075 AC #4: when Docker
+// re-asserts its own chains (DOCKER-USER / DOCKER-FORWARD) at the top of
+// FORWARD it pushes kukeon's jumps down but never deletes them and never
+// inverts their relative order. Because KUKEON-FORWARD is ACCEPT-only and
+// position relative to Docker is immaterial to correctness, the self-assert
+// must treat this as healthy — no delete, no re-insert, no churn.
+func TestInstall_SurvivesDockerChurnWithoutReorder(t *testing.T) {
+	runner := &fakeRunner{
+		respond: map[string]fakeResp{
+			// Docker pushed kukeon's jumps down the chain; KUKEON-EGRESS is
+			// still ahead of KUKEON-FORWARD, so the ordering invariant holds.
+			"-S FORWARD": {out: []byte(
+				"-P FORWARD DROP\n" +
+					"-A FORWARD -j DOCKER-USER\n" +
+					"-A FORWARD -j DOCKER-FORWARD\n" +
+					"-A FORWARD -j KUKEON-EGRESS\n" +
+					"-A FORWARD -j KUKEON-FORWARD\n",
+			)},
+			// Chain + tagged rules already present → no migration/rule churn.
+			"-S KUKEON-FORWARD": {out: []byte(
+				"-N KUKEON-FORWARD\n" +
+					"-A KUKEON-FORWARD -m conntrack --ctstate RELATED,ESTABLISHED -m comment --comment \"kukeon-forward:established\" -j ACCEPT\n" +
+					"-A KUKEON-FORWARD -i k-+ -m comment --comment \"kukeon-forward:egress\" -j ACCEPT\n" +
+					"-A KUKEON-FORWARD -o k-+ -m comment --comment \"kukeon-forward:ingress\" -j ACCEPT\n",
+			)},
+		},
+	}
+
+	if err := newInstaller(runner).Install(context.Background()); err != nil {
+		t.Fatalf("Install: %v", err)
+	}
+	if wasCalledWithVerb(runner, "-D") {
+		t.Errorf("must not delete the jump when Docker merely reordered it; calls = %v", runner.calls)
+	}
+	if wasCalledWithVerb(runner, "-I") {
+		t.Errorf("must not re-insert the jump under harmless Docker churn; calls = %v", runner.calls)
+	}
+}
+
+// invertedForwardRunner simulates a FORWARD chain where KUKEON-FORWARD sits
+// *ahead* of KUKEON-EGRESS — the displacement that lets the blanket admission
+// shadow per-space egress DROP rules. After the self-assert deletes the
+// misplaced jump, the second `-S FORWARD` read reflects the post-delete state
+// (KUKEON-EGRESS shifted up to position 1) so the re-insert lands in the
+// correct slot. The stateless fakeRunner cannot model that shift, hence this
+// purpose-built stateful runner.
+type invertedForwardRunner struct {
+	calls   [][]string
+	deleted bool
+}
+
+func (r *invertedForwardRunner) Run(_ context.Context, args ...string) ([]byte, error) {
+	r.calls = append(r.calls, append([]string(nil), args...))
+	joined := strings.Join(args, " ")
+	switch {
+	case joined == "-S FORWARD":
+		if r.deleted {
+			// KUKEON-FORWARD removed; KUKEON-EGRESS now at position 1.
+			return []byte("-P FORWARD DROP\n-A FORWARD -j KUKEON-EGRESS\n"), nil
+		}
+		// Inverted: KUKEON-FORWARD (1) ahead of KUKEON-EGRESS (2).
+		return []byte(
+			"-P FORWARD DROP\n" +
+				"-A FORWARD -j KUKEON-FORWARD\n" +
+				"-A FORWARD -j KUKEON-EGRESS\n",
+		), nil
+	case joined == "-D FORWARD -j KUKEON-FORWARD":
+		r.deleted = true
+		return nil, nil
+	default:
+		// All existence probes (-L chain, -C rule, -S KUKEON-FORWARD) report
+		// "present/empty" so Install skips migration and rule churn and
+		// exercises only the jump self-assert.
+		return nil, nil
+	}
+}
+
+func (r *invertedForwardRunner) ran(prefix ...string) bool {
+	for _, got := range r.calls {
+		if len(got) < len(prefix) {
+			continue
+		}
+		match := true
+		for i := range prefix {
+			if got[i] != prefix[i] {
+				match = false
+				break
+			}
+		}
+		if match {
+			return true
+		}
+	}
+	return false
+}
+
+// TestInstall_ReclaimsDisplacedJump is #1075 AC #1 (the "displaced" arm):
+// when KUKEON-FORWARD is present but ahead of KUKEON-EGRESS, the self-assert
+// deletes the misplaced jump and re-inserts it immediately after
+// KUKEON-EGRESS so per-space egress DROP rules win over the blanket admission.
+func TestInstall_ReclaimsDisplacedJump(t *testing.T) {
+	runner := &invertedForwardRunner{}
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	installer := firewall.NewInstallerWithRunner(logger, runner)
+	if err := installer.Install(context.Background()); err != nil {
+		t.Fatalf("Install: %v", err)
+	}
+	if !runner.ran("-D", "FORWARD", "-j", "KUKEON-FORWARD") {
+		t.Errorf("expected the displaced jump to be deleted; calls = %v", runner.calls)
+	}
+	// After the delete, KUKEON-EGRESS is at position 1, so the jump must be
+	// re-inserted at position 2 (immediately after it).
+	if !runner.ran("-I", "FORWARD", "2", "-j", "KUKEON-FORWARD") {
+		t.Errorf("expected re-insert at position 2 (after KUKEON-EGRESS); calls = %v", runner.calls)
 	}
 }
 


### PR DESCRIPTION
## Summary

Step 2 of the firewall epic (#953): harden kukeon's self-owned `FORWARD` →
`KUKEON-FORWARD` admission jump so the per-tick reconcile self-assert
re-claims it not only when **missing** but when **displaced** ahead of the
`KUKEON-EGRESS` dispatch jump — without ever reading or writing a
Docker-owned chain. Drops the `DOCKER-USER` anchor approach the issue
rescoped away from.

### Premise reconciliation (documented per dev CLAUDE.md)

The issue (filed as "extend the #1074 reconcile pass to re-claim both kukeon
`FORWARD` jumps") predates the merged shape of step 1 (#1074 / PR #1310).
What #1074 **already** ships on `main`, and what this PR adds:

- **Already on `main` (no change needed):** `forwardAdmissionFn` →
  `firewall.Installer.Install` runs on Serve startup *and every reconcile
  tick* (`internal/daemon/server.go:316`, inside `runSpaceNetworkReconcileOnce`),
  re-asserting the `KUKEON-FORWARD` chain + its jump. The `KUKEON-EGRESS`
  dispatch jump is likewise re-asserted every tick by the existing per-space
  egress re-apply (`internal/controller/runner/provision.go:308`, reached via
  `ReconcileSpaceNetworks` → `EnsureSpace` → `ensureSpaceCNIConfig` →
  `applySpaceEgressPolicy` → `enforcer.Apply` → `ensureMasterChain`). So the
  per-tick **invocation** the issue asks to add is already wired — no new
  controller/daemon code.
- **This PR (the genuine gap):** `ensureForwardJump` previously no-op'd
  whenever the jump was present *anywhere* (`-C` existence check), so a
  precedence inversion — `KUKEON-FORWARD` ahead of `KUKEON-EGRESS`, where the
  blanket ACCEPT would shadow per-space egress DROP rules — was never healed.
  It now reads both jump positions in one `-S FORWARD` pass and, when the
  admission jump sits at/ahead of the dispatch jump, deletes and re-inserts it
  immediately after `KUKEON-EGRESS`. Position relative to Docker's own chains
  stays immaterial (KUKEON-FORWARD is ACCEPT-only and reached before the
  implicit policy DROP wherever it lands), so Docker merely pushing the jump
  down is **not** treated as displacement — preserving the "no churn on a
  healthy host" idempotency AC.

`findEgressPosition` is generalized to `forwardJumpPositions` (returns both
jump indices from a single read); no other caller existed.

### AC notes

- AC1 "re-insert at **head** when missing or displaced": re-inserted at the
  *correct* slot (immediately after `KUKEON-EGRESS` when present, else head),
  matching the documented `ForwardChainName` ordering invariant rather than a
  literal head insert that would invert precedence. Called out here for
  reviewer audit.
- AC2 "no read/write of any Docker-owned chain; `git grep DOCKER-USER` over
  package code stays empty": production code carries zero `DOCKER` references
  (`git grep DOCKER -- 'internal/firewall/*.go' ':!*_test.go'` is empty). The
  only `DOCKER-USER`/`DOCKER-FORWARD` strings are in test fixtures that
  simulate host `-S FORWARD` output — exactly what AC4 requires — which is not
  kukeon reading a Docker chain.
- AC6 empirical validation on a live Docker + kukeon host: **not runnable** on
  this dev host (no co-installed Docker + kukeon runtime). Left unticked below;
  the position-independence assumption is exercised in simulation by the
  Docker-churn test. Recommend a reviewer/operator run `iptables -S FORWARD` +
  a cross-bridge egress test on a real shared host before closing the epic.

## Test plan
- [x] `make test-root` (full CI test target, `GOWORK=off`) — passes
- [x] `GOWORK=off go test ./internal/firewall/... ./internal/netpolicy/... ./internal/daemon/... ./internal/controller/...` — passes
- [x] `GOWORK=off go vet ./internal/firewall/...` — clean
- [x] New: `TestInstall_SurvivesDockerChurnWithoutReorder` (AC4 — Docker re-asserts DOCKER-USER/DOCKER-FORWARD on top, jump survives, zero churn)
- [x] New: `TestInstall_ReclaimsDisplacedJump` (AC1 displaced arm — jump ahead of KUKEON-EGRESS is deleted + re-inserted after it)
- [x] Reboot/flush re-claim (AC5) covered by existing `TestServer_SpaceNetworkReconcileReinstallsWipedForwardChain` + `TestInstall_OnFreshHost`
- [x] `git grep DOCKER-USER` over production firewall code is empty (AC2)
- [ ] AC6 live Docker + kukeon host validation — not runnable on this dev host (no co-installed runtime); deferred to reviewer/operator

Depends on #1074 (merged via #1310).

Closes #1075