### PR TITLE
fix: thread dev-profile kukeond-config into kuke build so images land in the dev-suffix namespace

### DIFF
--- a/scripts/dev-init.sh
+++ b/scripts/dev-init.sh
@@ -73,6 +73,11 @@ DEV_PROFILE_CLIENT_CONFIG="${REPO_ROOT}/kuke-dev.yaml"
 # guarded too) overrides these.
 KUKEOND_NS="kuke-system.kukeon.io"
 SERVER_CONFIG_FLAGS=()
+# kuke build resolves the realm's containerd-namespace suffix from
+# --kukeond-config (path to kukeond.yaml), not from KUKE_CONFIGURATION. The
+# default profile leaves this empty so kuke build falls back to its default
+# /etc/kukeon/kukeond.yaml suffix (.kukeon.io), matching KUKEOND_NS above.
+BUILD_KUKEOND_CONFIG_FLAGS=()
 PRESERVE_ENV_WORKLOAD="KUKEON_HOST"
 PRESERVE_ENV_ADMIN="KUKEON_HOST,KUKEOND_SOCKET"
 
@@ -336,6 +341,12 @@ EOF
     # flag for admin commands.
     KUKEOND_NS="kuke-system.dev.kukeon.io"
     SERVER_CONFIG_FLAGS=(--server-configuration "${DEV_PROFILE_SERVER_CONFIG}")
+    # kuke build reads the namespace suffix only from --kukeond-config (the
+    # server config), never from KUKE_CONFIGURATION (the client config). Without
+    # this it falls back to the default .kukeon.io suffix and writes the built
+    # image into the wrong namespace, so kuke init/apply (which use the dev
+    # suffix) can never find it. Mirrors SERVER_CONFIG_FLAGS for admin commands.
+    BUILD_KUKEOND_CONFIG_FLAGS=(--kukeond-config "${DEV_PROFILE_SERVER_CONFIG}")
     PRESERVE_ENV_WORKLOAD="KUKEON_HOST,KUKE_CONFIGURATION"
     PRESERVE_ENV_ADMIN="KUKEON_HOST,KUKEOND_SOCKET,KUKE_CONFIGURATION"
 fi
@@ -424,6 +435,7 @@ step "Build ${KUKEOND_IMAGE_REF} into the kuke-system realm"
 # matching the exact ref `kuke init --kukeond-image` resolves below.
 sudo --preserve-env="${PRESERVE_ENV_WORKLOAD}" ./kuke build --build-arg VERSION="${KUKEOND_BUILD_VERSION}" \
     -t "${KUKEOND_IMAGE_REF}" \
+    "${BUILD_KUKEOND_CONFIG_FLAGS[@]}" \
     --realm kuke-system .
 
 step "Run kuke init with --kukeond-image ${KUKEOND_IMAGE_REF}"
@@ -623,6 +635,7 @@ sudo --preserve-env="${PRESERVE_ENV_WORKLOAD}" ./kuke create stack "${ATTACH_SMO
 step "Build ${ATTACH_SMOKE_IMAGE_REF} into the ${ATTACH_SMOKE_REALM} realm"
 sudo --preserve-env="${PRESERVE_ENV_WORKLOAD}" ./kuke build \
     -t "${ATTACH_SMOKE_IMAGE_REF}" \
+    "${BUILD_KUKEOND_CONFIG_FLAGS[@]}" \
     --realm "${ATTACH_SMOKE_REALM}" hack/attach-smoke
 
 cat > "${ATTACH_SMOKE_TMP}/cell.yaml" <<EOF


### PR DESCRIPTION
## Summary
- Under `KUKEON_PROFILE=dev`, `scripts/dev-init.sh` threaded only `KUKE_CONFIGURATION` (the *client* config) into its two `kuke build` invocations. But `kuke build` resolves the realm's containerd-namespace **suffix** from `--kukeond-config` (the *server* config; `cmd/kuke/build/build.go:95`, threaded into the kukebuild argv at `build.go:205`), never from `KUKE_CONFIGURATION`. So under the dev profile `kuke build` fell back to the default `.kukeon.io` suffix and wrote the image into `<realm>.kukeon.io`, while `kuke init` / `kuke apply` look in `<realm>.dev.kukeon.io` — every dev-profile dev-init could never find its own built image (`local-only kukeon.internal image is not present in the realm`).
- Fix mirrors the existing `SERVER_CONFIG_FLAGS` pattern: add a `BUILD_KUKEOND_CONFIG_FLAGS` array, empty in the default profile (preserves the historical `.kukeon.io` fallback) and `(--kukeond-config "${DEV_PROFILE_SERVER_CONFIG}")` under the dev profile, threaded into both `kuke build` invocations (`scripts/dev-init.sh` ~lines 435 and 635). The default profile is byte-for-byte unchanged (empty array expands to nothing).
- The issue noted the post-build `ctr` verify (which reads `KUKEOND_NS`, set to `kuke-system.dev.kukeon.io` under dev) only passed historically in the default profile because that profile's `KUKEOND_NS` matched `kuke build`'s default suffix. With this fix the dev-profile build now writes to the dev-suffix namespace, so that same verify is now correct rather than accidentally passing.

## Verification — namespace fix proven end-to-end
Ran `KUKEON_PROFILE=dev make dev-init` on a nested dev host. The kukeond image built and unpacked successfully, and landed in the **correct** namespace:

```
$ ctr -n kuke-system.dev.kukeon.io images ls | grep kukeond
kukeon.internal/kukeond:v0.0.0-dev ... sha256:07d9926... 101.1 MiB linux/amd64   # <- dev suffix (fixed)
$ ctr -n kuke-system.kukeon.io images ls | grep kukeond
(none)                                                                            # <- default suffix, was the bug target
```

This is exactly the AC: under `KUKEON_PROFILE=dev`, `kuke build` now honors the dev namespace suffix. (Before the fix, the image landed in `kuke-system.kukeon.io` — confirmed by a leftover wrong-namespace `kukeon.internal/kukeond` image from a prior run.)

## Test plan
- [x] `bash -n scripts/dev-init.sh` — syntax clean.
- [x] `KUKEON_PROFILE=dev make dev-init` — `kuke daemon reset` and the kukeond image build succeeded under the dev profile (proving the dev-profile flag wiring is intact), and the built image landed in `kuke-system.dev.kukeon.io` (the fix's target), absent from `kuke-system.kukeon.io`.
- [ ] Full `make dev-init` two-realm parity tail — **not reached on this host**: `/opt/kukeon` here was already bootstrapped under the *default* profile, so `kuke init` under the dev profile fails with a `kukeon instance mismatch` (suffix `kukeon.io`/cgroup `/kukeon` vs requested `dev.kukeon.io`/`/kukeon-dev`). This guard is orthogonal to this change — it blocks any dev-profile init on a default-profile host regardless of the build fix — and the core AC (build honors the dev suffix) is fully verified above. A clean host (or one with no prior default-profile `/opt/kukeon`) would carry the run through to the parity tail.

Note: `go build`/`make test` CI is not triggered for this PR — the `.github/workflows/test.yaml` path filter covers `**/*.go`, `Makefile`, `Dockerfile`, and go module files, not `scripts/**`. No Go sources change.

Closes #1309