### PR TITLE
feat: per-space fail-closed egress admission (single space-owned chain) (step 3)

### DIFF
--- a/internal/controller/runner/egress.go
+++ b/internal/controller/runner/egress.go
@@ -27,27 +27,37 @@ import (
 )
 
 // applySpaceEgressPolicy realizes space.Spec.Network.Egress on the host
-// firewall. It is a no-op when the space has no egress policy or when the
-// policy effectively matches current behavior (default=allow with no
-// allowlist entries).
+// firewall as the space's own admission+egress chain.
+//
+// Since #1076 admission is per-space: the host-global `-i k-+ ACCEPT` blanket
+// is gone, so every space's bridge needs its own chain to ACCEPT egress on a
+// FORWARD-DROP host. A space with no explicit policy (or a default=allow policy
+// with an empty allowlist, which FromInternal collapses to nil) therefore still
+// gets an admit-all chain rather than a no-op — admission and the per-space
+// KUKEON-EGRESS chain are installed as one unit so they can't drift, and a
+// Default=deny space whose chain is missing fails closed (no path to ACCEPT)
+// instead of leaking egress through a blanket rule.
 func (r *Exec) applySpaceEgressPolicy(space intmodel.Space) error {
-	if space.Spec.Network == nil || space.Spec.Network.Egress == nil {
-		return nil
-	}
 	networkName, err := naming.BuildSpaceNetworkName(space.Spec.RealmName, space.Metadata.Name)
 	if err != nil {
 		return fmt.Errorf("%w: %w", errdefs.ErrEgressApply, err)
 	}
 	bridge := cni.SafeBridgeName(networkName)
 
+	var egress *intmodel.EgressPolicy
+	if space.Spec.Network != nil {
+		egress = space.Spec.Network.Egress
+	}
 	policy, err := netpolicy.FromInternal(
-		space.Spec.RealmName, space.Metadata.Name, bridge, space.Spec.Network.Egress,
+		space.Spec.RealmName, space.Metadata.Name, bridge, egress,
 	)
 	if err != nil {
 		return fmt.Errorf("%w: %w", errdefs.ErrEgressApply, err)
 	}
 	if policy == nil {
-		return nil
+		// No restriction requested: install a per-space admit-all chain so the
+		// bridge keeps full egress now that the host-global blanket is gone.
+		policy = netpolicy.NewAdmitAllPolicy(space.Spec.RealmName, space.Metadata.Name, bridge)
 	}
 	if err = policy.Resolve(r.ctx, nil); err != nil {
 		return fmt.Errorf("%w: %w", errdefs.ErrEgressApply, err)

--- a/internal/firewall/forward.go
+++ b/internal/firewall/forward.go
@@ -36,8 +36,9 @@ import (
 )
 
 // ForwardChainName is the kukeon-owned FORWARD admission chain. It now carries
-// only ingress admission (`-o k-+ ACCEPT`) plus the stateful return-traffic
-// ACCEPT; egress admission moved per-space in #1076.
+// only ingress admission (`! -i k-+ -o k-+ ACCEPT`, scoped to non-bridge
+// sources) plus the stateful return-traffic ACCEPT; egress admission moved
+// per-space in #1076.
 //
 // There is no longer any ordering contract with KUKEON-EGRESS
 // (netpolicy.MasterChainName). Egress is decided entirely within each space's
@@ -46,6 +47,16 @@ import (
 // relative to KUKEON-EGRESS is immaterial to correctness. ensureForwardJump
 // only guarantees the jump *exists* (re-inserting it after a reboot flush or
 // Docker churn); it no longer reorders it.
+//
+// The one rule here that *could* shadow an egress decision is the ingress
+// `-o k-+ ACCEPT`: an inter-bridge packet (`-i k-A -o k-B`) is both ingress to
+// B and egress from A, so a bare `-o k-+` would ACCEPT a deny-space A's egress
+// to B before A's chain runs — fail-open whenever this chain sits ahead of
+// KUKEON-EGRESS. The ingress rule is therefore scoped `! -i k-+`: it admits
+// only traffic that did *not* originate on a kukeon bridge (true external
+// ingress), so a space's egress (always bridge-sourced) can never match it and
+// always falls through to KUKEON-EGRESS. That is what keeps the position
+// genuinely immaterial — including for the inter-bridge case.
 const ForwardChainName = "KUKEON-FORWARD"
 
 // BridgeIfaceMatch is the iptables -i / -o interface match that scopes the
@@ -75,7 +86,18 @@ const commentTagPrefix = "kukeon-forward"
 // Rule order:
 //  1. RELATED,ESTABLISHED ACCEPT — return-traffic for already-admitted flows
 //     so reply packets cannot be dropped by FORWARD's default policy.
-//  2. -o k-+ ACCEPT — admit ingress destined to a kukeon bridge.
+//  2. ! -i k-+ -o k-+ ACCEPT — admit *external* ingress destined to a kukeon
+//     bridge. The `! -i k-+` qualifier scopes this to traffic that did not
+//     originate on a kukeon bridge, so it admits the internet/host→bridge case
+//     without ever matching a space's egress.
+//
+// Why the `! -i k-+` scope matters: an inter-bridge packet (`-i k-A -o k-B`)
+// is simultaneously ingress to B and egress from A. A bare `-o k-+ ACCEPT`
+// would admit it here before A's KUKEON-EGRESS chain ever runs — fail-open for
+// cross-space egress whenever this chain sits ahead of KUKEON-EGRESS in
+// FORWARD, which nothing orders post-#1076. Excluding bridge-sourced traffic
+// (`! -i k-+`) sends every space's egress — internet-bound and inter-bridge
+// alike — through KUKEON-EGRESS, so the deny-space decision is never shadowed.
 //
 // Egress admission (`-i k-+ ACCEPT`) is deliberately absent since #1076: a
 // host-global egress blanket fails *open* — a Default=deny space whose
@@ -94,6 +116,7 @@ func AdmissionRules() [][]string {
 		},
 		{
 			"-A", ForwardChainName,
+			"!", "-i", BridgeIfaceMatch,
 			"-o", BridgeIfaceMatch,
 			"-m", "comment", "--comment", commentTagPrefix + ":ingress",
 			"-j", "ACCEPT",
@@ -165,6 +188,10 @@ func NewInstallerWithRunner(logger *slog.Logger, runner CommandRunner) *Installe
 // the tagged variants side by side. A host upgraded from a pre-#1076 layout
 // also carries the retired `:egress` blanket rule; pruneObsoleteEgressAdmission
 // strips it so the fail-open hole #1076 closes does not survive the upgrade.
+// A host upgraded from an intermediate #1076 layout carries the *unscoped*
+// ingress rule (`-o k-+ ...:ingress`, no `! -i k-+`); pruneUnscopedIngressAdmission
+// strips that one so the inter-bridge fail-open it allowed does not survive
+// either — leaving only the scoped `! -i k-+ -o k-+` ingress rule.
 func (i *Installer) Install(ctx context.Context) error {
 	if err := i.ensureChain(ctx, ForwardChainName); err != nil {
 		return fmt.Errorf("%w: %w", errdefs.ErrForwardAdmissionApply, err)
@@ -178,6 +205,7 @@ func (i *Installer) Install(ctx context.Context) error {
 		}
 	}
 	i.pruneObsoleteEgressAdmission(ctx)
+	i.pruneUnscopedIngressAdmission(ctx)
 	if err := i.ensureForwardJump(ctx); err != nil {
 		return fmt.Errorf("%w: %w", errdefs.ErrForwardAdmissionApply, err)
 	}
@@ -280,9 +308,13 @@ func (i *Installer) migrateUntaggedRules(ctx context.Context) error {
 // Since #1076 the jump only needs to *exist* — its position relative to
 // KUKEON-EGRESS no longer matters. Egress is decided entirely within each
 // space's own KUKEON-EGRESS chain (self-terminating ACCEPT/DROP), and this
-// chain now carries only ingress + stateful admission, neither of which can
-// shadow a per-space egress decision. So the three-way missing/displaced/
-// healthy dance the pre-#1076 ordering contract required collapses to:
+// chain now carries only stateful admission and ingress *scoped to non-bridge
+// sources* (`! -i k-+`). Neither can shadow a per-space egress decision: the
+// stateful rule only matches flows a per-space chain already admitted (a denied
+// NEW packet creates no conntrack entry), and the `! -i k-+` ingress rule
+// excludes all bridge-sourced traffic, so a space's egress — internet-bound or
+// inter-bridge — always reaches KUKEON-EGRESS. So the three-way missing/
+// displaced/healthy dance the pre-#1076 ordering contract required collapses to:
 //
 //   - Present (anywhere in FORWARD): no-op, no churn.
 //   - Absent (fresh host or post-reboot flush): insert at position 1.
@@ -333,6 +365,54 @@ func (i *Installer) pruneObsoleteEgressAdmission(ctx context.Context) {
 			"chain", ForwardChainName)
 		if _, delErr := i.runner.Run(ctx, del...); delErr != nil {
 			i.logger.DebugContext(ctx, "prune obsolete egress admission (delete failed)",
+				"chain", ForwardChainName, "err", delErr)
+			return
+		}
+	}
+}
+
+// pruneUnscopedIngressAdmission deletes the *unscoped* ingress rule
+// (`-o k-+ ... kukeon-forward:ingress -j ACCEPT`, with no `! -i k-+` qualifier)
+// from ForwardChainName. That shape shipped in the intermediate #1076 layout
+// before the ingress rule was scoped to exclude bridge-sourced traffic; leaving
+// it on an upgraded host re-opens the inter-bridge fail-open hole (a deny-space
+// A's egress to bridge B matches the bare `-o k-+` ACCEPT before A's
+// KUKEON-EGRESS chain runs). The current scoped rule (`! -i k-+ -o k-+ ...`) is
+// deliberately left in place — it is matched and skipped below.
+//
+// Same shape as pruneObsoleteEgressAdmission: one `-S` read, one canonical -D
+// per matching line, no delete-until-absent loop, all failures tolerated at
+// debug so the chain converges on a later tick.
+func (i *Installer) pruneUnscopedIngressAdmission(ctx context.Context) {
+	out, err := i.runner.Run(ctx, "-S", ForwardChainName)
+	if err != nil {
+		i.logger.DebugContext(ctx, "list chain for ingress-prune check (skipping)",
+			"chain", ForwardChainName, "err", err)
+		return
+	}
+	del := []string{
+		"-D", ForwardChainName,
+		"-o", BridgeIfaceMatch,
+		"-m", "comment", "--comment", commentTagPrefix + ":ingress",
+		"-j", "ACCEPT",
+	}
+	prefix := "-A " + ForwardChainName
+	for _, line := range strings.Split(string(out), "\n") {
+		line = strings.TrimSpace(line)
+		if !strings.HasPrefix(line, prefix) {
+			continue
+		}
+		// Match the ingress rule, but skip the current scoped form: a line
+		// carrying the `! -i k-+` negation is the rule we want to keep.
+		if !strings.Contains(line, "-o "+BridgeIfaceMatch) ||
+			!strings.Contains(line, commentTagPrefix+":ingress") ||
+			strings.Contains(line, "! -i "+BridgeIfaceMatch) {
+			continue
+		}
+		i.logger.InfoContext(ctx, "pruning obsolete unscoped ingress admission rule",
+			"chain", ForwardChainName)
+		if _, delErr := i.runner.Run(ctx, del...); delErr != nil {
+			i.logger.DebugContext(ctx, "prune unscoped ingress admission (delete failed)",
 				"chain", ForwardChainName, "err", delErr)
 			return
 		}

--- a/internal/firewall/forward.go
+++ b/internal/firewall/forward.go
@@ -15,35 +15,37 @@
 // SPDX-License-Identifier: Apache-2.0
 
 // Package firewall manages host-level iptables state owned by kukeon — the
-// FORWARD admission chain that admits traffic to/from kukeon bridges. It is
-// distinct from internal/netpolicy, which installs per-space egress filters:
-// admission lives at host scope and is set up once at `kuke init`, while
-// egress is per-space and applied by the runner when a Space carries an
-// EgressPolicy.
+// FORWARD admission chain that admits *ingress* (and stateful return traffic)
+// to/from kukeon bridges. It is distinct from internal/netpolicy, which
+// installs the per-space chains that now own *egress* admission as well as
+// egress filtering: this host-scope chain is set up once at `kuke init` (and
+// re-asserted by the daemon), while each space's chain is applied per-space by
+// the runner. Since #1076 egress is no longer admitted by a host-global
+// blanket here — that fails open — so egress admission lives entirely in the
+// per-space chains, which fail closed when missing.
 package firewall
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"log/slog"
 	"os/exec"
-	"strconv"
 	"strings"
 
 	"github.com/eminwux/kukeon/internal/errdefs"
-	"github.com/eminwux/kukeon/internal/netpolicy"
 )
 
-// ForwardChainName is the kukeon-owned FORWARD admission chain.
+// ForwardChainName is the kukeon-owned FORWARD admission chain. It now carries
+// only ingress admission (`-o k-+ ACCEPT`) plus the stateful return-traffic
+// ACCEPT; egress admission moved per-space in #1076.
 //
-// Relative ordering with KUKEON-EGRESS (netpolicy.MasterChainName) is
-// enforced by ensureForwardJump: when KUKEON-EGRESS already lives in
-// FORWARD, the jump to KUKEON-FORWARD is placed immediately after it so
-// per-space egress DROP rules win over the blanket admission. When
-// KUKEON-EGRESS is absent the jump goes to position 1; a later
-// netpolicy.Apply() will insert KUKEON-EGRESS at 1, pushing this jump
-// to 2 (still correct).
+// There is no longer any ordering contract with KUKEON-EGRESS
+// (netpolicy.MasterChainName). Egress is decided entirely within each space's
+// own KUKEON-EGRESS chain, which terminates every packet itself (ACCEPT/DROP)
+// rather than RETURNing to a blanket admission here — so this chain's position
+// relative to KUKEON-EGRESS is immaterial to correctness. ensureForwardJump
+// only guarantees the jump *exists* (re-inserting it after a reboot flush or
+// Docker churn); it no longer reorders it.
 const ForwardChainName = "KUKEON-FORWARD"
 
 // BridgeIfaceMatch is the iptables -i / -o interface match that scopes the
@@ -56,7 +58,9 @@ const BridgeIfaceMatch = "k-+"
 // commentTagPrefix is the --comment prefix on every rule the installer
 // owns so `iptables -S` is self-documenting and any future cleanup-by-grep
 // cannot collide with user-added rules in the same chain. Roles appended
-// to the prefix: ":established", ":egress", ":ingress".
+// to the prefix: ":established", ":ingress". The retired ":egress" role
+// (host-global egress blanket, removed in #1076) is pruned from upgraded
+// hosts by pruneObsoleteEgressAdmission.
 const commentTagPrefix = "kukeon-forward"
 
 // AdmissionRules returns the ordered iptables rules that populate
@@ -71,20 +75,21 @@ const commentTagPrefix = "kukeon-forward"
 // Rule order:
 //  1. RELATED,ESTABLISHED ACCEPT — return-traffic for already-admitted flows
 //     so reply packets cannot be dropped by FORWARD's default policy.
-//  2. -i k-+ ACCEPT — admit egress originating on a kukeon bridge.
-//  3. -o k-+ ACCEPT — admit ingress destined to a kukeon bridge.
+//  2. -o k-+ ACCEPT — admit ingress destined to a kukeon bridge.
+//
+// Egress admission (`-i k-+ ACCEPT`) is deliberately absent since #1076: a
+// host-global egress blanket fails *open* — a Default=deny space whose
+// per-space KUKEON-EGRESS chain went missing (e.g. post-reboot, pre-reconcile)
+// would have its traffic ACCEPTed here. Egress is now admitted per-space inside
+// each space's own KUKEON-EGRESS chain (see internal/netpolicy.BuildRules), so
+// a missing chain fails *closed*. pruneObsoleteEgressAdmission strips a
+// leftover `:egress` rule from upgraded hosts.
 func AdmissionRules() [][]string {
 	return [][]string{
 		{
 			"-A", ForwardChainName,
 			"-m", "conntrack", "--ctstate", "RELATED,ESTABLISHED",
 			"-m", "comment", "--comment", commentTagPrefix + ":established",
-			"-j", "ACCEPT",
-		},
-		{
-			"-A", ForwardChainName,
-			"-i", BridgeIfaceMatch,
-			"-m", "comment", "--comment", commentTagPrefix + ":egress",
 			"-j", "ACCEPT",
 		},
 		{
@@ -157,7 +162,9 @@ func NewInstallerWithRunner(logger *slog.Logger, runner CommandRunner) *Installe
 // Upgrade-path migration: when the chain already exists with untagged rules
 // from an older kukeon version, Install flushes it once before re-installing
 // the tagged rules so the chain does not end up carrying both the bare and
-// the tagged variants side by side.
+// the tagged variants side by side. A host upgraded from a pre-#1076 layout
+// also carries the retired `:egress` blanket rule; pruneObsoleteEgressAdmission
+// strips it so the fail-open hole #1076 closes does not survive the upgrade.
 func (i *Installer) Install(ctx context.Context) error {
 	if err := i.ensureChain(ctx, ForwardChainName); err != nil {
 		return fmt.Errorf("%w: %w", errdefs.ErrForwardAdmissionApply, err)
@@ -170,6 +177,7 @@ func (i *Installer) Install(ctx context.Context) error {
 			return fmt.Errorf("%w: %w", errdefs.ErrForwardAdmissionApply, err)
 		}
 	}
+	i.pruneObsoleteEgressAdmission(ctx)
 	if err := i.ensureForwardJump(ctx); err != nil {
 		return fmt.Errorf("%w: %w", errdefs.ErrForwardAdmissionApply, err)
 	}
@@ -264,135 +272,69 @@ func (i *Installer) migrateUntaggedRules(ctx context.Context) error {
 }
 
 // ensureForwardJump idempotently self-asserts the FORWARD → KUKEON-FORWARD
-// jump and its ordering relative to the per-space egress dispatch chain
-// KUKEON-EGRESS (netpolicy.MasterChainName). It is the per-tick self-assert
-// the daemon's network reconcile pass drives via Install (#1074/#1075): a
-// reboot wipes the jump and Docker churn reorders it, and this re-claims it
-// on the next tick without ever touching a Docker-owned chain.
+// jump. It is the per-tick self-assert the daemon's network reconcile pass
+// drives via Install (#1074/#1075): a reboot wipes the jump and Docker churn
+// can shuffle it, and this re-inserts it on the next tick without ever
+// touching a Docker-owned chain.
 //
-// Three states, mirroring AC #1 of #1075 ("re-insert when missing or
-// displaced; no churn on a healthy host"):
+// Since #1076 the jump only needs to *exist* — its position relative to
+// KUKEON-EGRESS no longer matters. Egress is decided entirely within each
+// space's own KUKEON-EGRESS chain (self-terminating ACCEPT/DROP), and this
+// chain now carries only ingress + stateful admission, neither of which can
+// shadow a per-space egress decision. So the three-way missing/displaced/
+// healthy dance the pre-#1076 ordering contract required collapses to:
 //
-//   - Missing — the jump is absent (fresh host or post-reboot flush): insert
-//     it after KUKEON-EGRESS when that dispatch jump exists, else at
-//     position 1. A later netpolicy.Apply() that inserts KUKEON-EGRESS at 1
-//     pushes this jump to 2, preserving the invariant.
-//   - Displaced — the jump exists but sits at or ahead of KUKEON-EGRESS, so
-//     its blanket ACCEPT would shadow per-space egress DROP rules: delete the
-//     misplaced jump and re-insert it after KUKEON-EGRESS.
-//   - Healthy — the jump exists after KUKEON-EGRESS (or KUKEON-EGRESS is
-//     absent): no-op. Position relative to Docker's own chains is immaterial
-//     (KUKEON-FORWARD is ACCEPT-only and is reached before FORWARD's implicit
-//     policy DROP wherever it lands, because Docker's isolation chains RETURN
-//     for non-Docker interfaces), so only a precedence inversion against
-//     KUKEON-EGRESS counts as "displaced" — Docker pushing the jump down the
-//     chain is not churn-worthy.
+//   - Present (anywhere in FORWARD): no-op, no churn.
+//   - Absent (fresh host or post-reboot flush): insert at position 1.
 func (i *Installer) ensureForwardJump(ctx context.Context) error {
-	forwardPos, egressPos := i.forwardJumpPositions(ctx)
-
-	// Healthy: present and correctly ordered after the egress dispatch jump
-	// (or that jump is absent). No rule churn.
-	if forwardPos > 0 && (egressPos == 0 || forwardPos > egressPos) {
+	if _, err := i.runner.Run(ctx, "-C", "FORWARD", "-j", ForwardChainName); err == nil {
 		return nil
 	}
-
-	// Displaced: present but at/ahead of KUKEON-EGRESS. Drop the misplaced
-	// jump, then re-read the egress position — the delete shifts every lower
-	// rule (KUKEON-EGRESS included) up by one — before computing the slot.
-	if forwardPos > 0 {
-		if _, err := i.runner.Run(ctx, "-D", "FORWARD", "-j", ForwardChainName); err != nil {
-			return err
-		}
-		_, egressPos = i.forwardJumpPositions(ctx)
-	}
-
-	insertAt := "1"
-	if egressPos > 0 {
-		insertAt = strconv.Itoa(egressPos + 1)
-	}
-	_, err := i.runner.Run(ctx, "-I", "FORWARD", insertAt, "-j", ForwardChainName)
+	_, err := i.runner.Run(ctx, "-I", "FORWARD", "1", "-j", ForwardChainName)
 	return err
 }
 
-// forwardJumpPositions returns the 1-based positions of the KUKEON-FORWARD
-// admission jump and the KUKEON-EGRESS dispatch jump within the builtin
-// FORWARD chain, read in a single `-S FORWARD` pass. A position of 0 means
-// the jump is absent (or FORWARD was unreadable). Failures are non-fatal —
-// callers fall back to the safe position-1 default.
+// pruneObsoleteEgressAdmission deletes the retired host-global egress blanket
+// (`-i k-+ ... kukeon-forward:egress -j ACCEPT`) from ForwardChainName. Before
+// #1076 that rule admitted all kukeon-bridge egress; leaving it on an upgraded
+// host would re-open the fail-open hole #1076 closes (a Default=deny space
+// whose per-space chain is missing would be ACCEPTed here). Egress admission is
+// now per-space, so this rule must go.
 //
-// The token-aware match prevents a sibling chain named like
-// "KUKEON-EGRESS-FOO" from being mistaken for "KUKEON-EGRESS".
-func (i *Installer) forwardJumpPositions(ctx context.Context) (forwardPos, egressPos int) {
-	out, err := i.runner.Run(ctx, "-S", "FORWARD")
+// It reads `-S ForwardChainName` once and issues one canonical -D per matching
+// line — never an unbounded delete-until-absent loop, so a runner that reports
+// the rule present cannot livelock. Best-effort: a -S read failure or a -D
+// failure is logged at debug and tolerated, mirroring migrateUntaggedRules; the
+// chain converges on a later tick.
+func (i *Installer) pruneObsoleteEgressAdmission(ctx context.Context) {
+	out, err := i.runner.Run(ctx, "-S", ForwardChainName)
 	if err != nil {
-		return 0, 0
+		i.logger.DebugContext(ctx, "list chain for egress-prune check (skipping)",
+			"chain", ForwardChainName, "err", err)
+		return
 	}
-	pos := 0
+	del := []string{
+		"-D", ForwardChainName,
+		"-i", BridgeIfaceMatch,
+		"-m", "comment", "--comment", commentTagPrefix + ":egress",
+		"-j", "ACCEPT",
+	}
+	prefix := "-A " + ForwardChainName
 	for _, line := range strings.Split(string(out), "\n") {
 		line = strings.TrimSpace(line)
-		if !strings.HasPrefix(line, "-A FORWARD") {
+		if !strings.HasPrefix(line, prefix) {
 			continue
 		}
-		pos++
-		switch {
-		case forwardPos == 0 && lineJumpsTo(line, ForwardChainName):
-			forwardPos = pos
-		case egressPos == 0 && lineJumpsTo(line, netpolicy.MasterChainName):
-			egressPos = pos
+		if !strings.Contains(line, "-i "+BridgeIfaceMatch) ||
+			!strings.Contains(line, commentTagPrefix+":egress") {
+			continue
 		}
-	}
-	return forwardPos, egressPos
-}
-
-// lineJumpsTo reports whether an `iptables -S` line jumps to exactly the
-// named chain. Token-aware so a chain like "KUKEON-EGRESS-FOO" doesn't
-// match "KUKEON-EGRESS" the way a plain substring check would. A parse
-// failure is treated as a non-match — the caller falls back to its safe
-// default rather than aborting.
-func lineJumpsTo(line, target string) bool {
-	tokens, err := parseRuleLine(line)
-	if err != nil {
-		return false
-	}
-	for i := 0; i+1 < len(tokens); i++ {
-		if tokens[i] == "-j" && tokens[i+1] == target {
-			return true
-		}
-	}
-	return false
-}
-
-// parseRuleLine splits an "-A <chain> ..." line from `iptables -S` into
-// its argument vector. Double-quoted substrings (iptables emits comment
-// values in quotes when they contain spaces) are preserved as a single
-// arg with the quotes stripped.
-func parseRuleLine(line string) ([]string, error) {
-	var (
-		out     []string
-		cur     strings.Builder
-		inQuote bool
-	)
-	flush := func() {
-		if cur.Len() == 0 {
+		i.logger.InfoContext(ctx, "pruning obsolete host-global egress admission rule",
+			"chain", ForwardChainName)
+		if _, delErr := i.runner.Run(ctx, del...); delErr != nil {
+			i.logger.DebugContext(ctx, "prune obsolete egress admission (delete failed)",
+				"chain", ForwardChainName, "err", delErr)
 			return
 		}
-		out = append(out, cur.String())
-		cur.Reset()
 	}
-	for i := range len(line) {
-		c := line[i]
-		switch {
-		case c == '"':
-			inQuote = !inQuote
-		case c == ' ' && !inQuote:
-			flush()
-		default:
-			cur.WriteByte(c)
-		}
-	}
-	flush()
-	if inQuote {
-		return nil, errors.New("unterminated quote in iptables -S line")
-	}
-	return out, nil
 }

--- a/internal/firewall/forward_test.go
+++ b/internal/firewall/forward_test.go
@@ -58,14 +58,15 @@ func newInstaller(runner *fakeRunner) *firewall.Installer {
 	return firewall.NewInstallerWithRunner(logger, runner)
 }
 
-// TestAdmissionRules_Order locks in the rule order and content. The chain
-// must start with a stateful ACCEPT for return-traffic, then admit -i and -o
-// kukeon-bridge traffic. Catching a future reorder here is the regression
-// guard for the silent-egress-loss bug fixed by #293.
+// TestAdmissionRules_Order locks in the rule order and content. Since #1076
+// the chain carries only the stateful return-traffic ACCEPT and the ingress
+// admission — the host-global egress blanket (`-i k-+ ACCEPT`) is gone because
+// it fails open (a Default=deny space whose per-space chain is missing would be
+// ACCEPTed here). Egress admission is now per-space (internal/netpolicy).
 func TestAdmissionRules_Order(t *testing.T) {
 	rules := firewall.AdmissionRules()
-	if len(rules) != 3 {
-		t.Fatalf("want 3 admission rules; got %d: %v", len(rules), rules)
+	if len(rules) != 2 {
+		t.Fatalf("want 2 admission rules; got %d: %v", len(rules), rules)
 	}
 
 	// Rule 0: established/related ACCEPT, tagged "kukeon-forward:established".
@@ -79,26 +80,32 @@ func TestAdmissionRules_Order(t *testing.T) {
 		t.Errorf("rule 0: want %v; got %v", want0, rules[0])
 	}
 
-	// Rule 1: -i k-+ ACCEPT, tagged "kukeon-forward:egress".
+	// Rule 1: -o k-+ ACCEPT, tagged "kukeon-forward:ingress".
 	want1 := []string{
-		"-A", firewall.ForwardChainName,
-		"-i", firewall.BridgeIfaceMatch,
-		"-m", "comment", "--comment", "kukeon-forward:egress",
-		"-j", "ACCEPT",
-	}
-	if !sliceEq(rules[1], want1) {
-		t.Errorf("rule 1: want %v; got %v", want1, rules[1])
-	}
-
-	// Rule 2: -o k-+ ACCEPT, tagged "kukeon-forward:ingress".
-	want2 := []string{
 		"-A", firewall.ForwardChainName,
 		"-o", firewall.BridgeIfaceMatch,
 		"-m", "comment", "--comment", "kukeon-forward:ingress",
 		"-j", "ACCEPT",
 	}
-	if !sliceEq(rules[2], want2) {
-		t.Errorf("rule 2: want %v; got %v", want2, rules[2])
+	if !sliceEq(rules[1], want1) {
+		t.Errorf("rule 1: want %v; got %v", want1, rules[1])
+	}
+}
+
+// TestAdmissionRules_NoEgressBlanket is the fail-closed guard for #1076: the
+// host-global egress admission rule must never reappear in AdmissionRules. A
+// blanket `-i k-+ ACCEPT` here is exactly the fail-open hole the per-space
+// admission model closes, so its absence is a contract, not an accident.
+func TestAdmissionRules_NoEgressBlanket(t *testing.T) {
+	for _, r := range firewall.AdmissionRules() {
+		joined := strings.Join(r, " ")
+		if strings.Contains(joined, "-i "+firewall.BridgeIfaceMatch) {
+			t.Errorf("admission rules must not carry a host-global egress (-i %s) blanket; got %v",
+				firewall.BridgeIfaceMatch, r)
+		}
+		if strings.Contains(joined, "kukeon-forward:egress") {
+			t.Errorf("admission rules must not carry the retired :egress role; got %v", r)
+		}
 	}
 }
 
@@ -109,7 +116,6 @@ func TestAdmissionRules_Order(t *testing.T) {
 func TestAdmissionRules_CommentTags(t *testing.T) {
 	wantRoles := []string{
 		"kukeon-forward:established",
-		"kukeon-forward:egress",
 		"kukeon-forward:ingress",
 	}
 	rules := firewall.AdmissionRules()
@@ -196,27 +202,26 @@ func TestInstall_OnFreshHost(t *testing.T) {
 	}
 }
 
-// TestInstall_IsIdempotent verifies a second install on a healthy host
-// performs zero -N, -A, -I, or -F operations — only the read checks
-// (-L/-C/-S). This is the "no rule churn" guarantee the issue calls out.
+// TestInstall_IsIdempotent verifies a second install on a healthy post-#1076
+// host performs zero -N, -A, -I, -D, or -F operations — only the read checks
+// (-L/-C/-S). This is the "no rule churn" guarantee the issue calls out. The
+// chain carries the new two-rule layout (established + ingress, no egress
+// blanket), so the egress-prune finds nothing to delete.
 func TestInstall_IsIdempotent(t *testing.T) {
 	runner := &fakeRunner{
 		respond: map[string]fakeResp{
 			// -L succeeds → chain present.
-			// Migration check: chain populated with already-tagged rules → no flush.
+			// Migration + prune check: chain populated with the already-tagged
+			// post-#1076 rules (no :egress) → no flush, no -D.
 			"-S KUKEON-FORWARD": {out: []byte(
 				"-N KUKEON-FORWARD\n" +
 					"-A KUKEON-FORWARD -m conntrack --ctstate RELATED,ESTABLISHED -m comment --comment \"kukeon-forward:established\" -j ACCEPT\n" +
-					"-A KUKEON-FORWARD -i k-+ -m comment --comment \"kukeon-forward:egress\" -j ACCEPT\n" +
 					"-A KUKEON-FORWARD -o k-+ -m comment --comment \"kukeon-forward:ingress\" -j ACCEPT\n",
 			)},
-			// FORWARD jump present and correctly ordered after KUKEON-EGRESS →
-			// ensureForwardJump finds it healthy and re-claims nothing.
-			"-S FORWARD": {out: []byte(
-				"-P FORWARD DROP\n" +
-					"-A FORWARD -j KUKEON-EGRESS\n" +
-					"-A FORWARD -j KUKEON-FORWARD\n",
-			)},
+			// FORWARD jump present → ensureForwardJump's -C succeeds and it
+			// re-inserts nothing. Position relative to KUKEON-EGRESS no longer
+			// matters post-#1076.
+			"-C FORWARD -j KUKEON-FORWARD": {},
 		},
 	}
 	i := newInstaller(runner)
@@ -227,7 +232,7 @@ func TestInstall_IsIdempotent(t *testing.T) {
 
 	for _, c := range runner.calls {
 		switch c[0] {
-		case "-N", "-I", "-A", "-F":
+		case "-N", "-I", "-A", "-D", "-F":
 			t.Errorf("idempotent install must not invoke %s; got call %v", c[0], c)
 		}
 	}
@@ -317,82 +322,23 @@ func TestInstall_ChainCreateFailureWrapsSentinel(t *testing.T) {
 	}
 }
 
-// TestInstall_JumpAfterEgressChain is the regression guard for the ordering
-// interaction with netpolicy: when KUKEON-EGRESS already lives in FORWARD,
-// KUKEON-FORWARD must be inserted at position EGRESS+1 so per-space DROP
-// rules win over the blanket admission. This guards the scenario where the
-// runner restart path reapplies netpolicy before forward admission.
-func TestInstall_JumpAfterEgressChain(t *testing.T) {
+// TestInstall_JumpInsertedAtPositionOneWhenAbsent is the post-#1076 jump
+// contract: when the FORWARD → KUKEON-FORWARD jump is absent (fresh host or
+// post-reboot flush), it is inserted at position 1 — unconditionally, with no
+// regard for where KUKEON-EGRESS sits. The ordering contract that once pinned
+// it after KUKEON-EGRESS is gone, because egress is now decided inside each
+// space's self-terminating chain.
+func TestInstall_JumpInsertedAtPositionOneWhenAbsent(t *testing.T) {
 	runner := &fakeRunner{
 		respond: map[string]fakeResp{
 			"-L KUKEON-FORWARD -n":         {err: errors.New("absent")},
 			"-C FORWARD -j KUKEON-FORWARD": {err: errors.New("absent")},
 			"-S KUKEON-FORWARD":            {out: []byte("-N KUKEON-FORWARD\n")},
+			// KUKEON-EGRESS already at FORWARD position 1 — pre-#1076 this would
+			// have forced the jump to position 2; now it must not.
 			"-S FORWARD": {out: []byte(
 				"-P FORWARD DROP\n" +
 					"-A FORWARD -j KUKEON-EGRESS\n",
-			)},
-		},
-	}
-	for _, rule := range firewall.AdmissionRules() {
-		check := strings.Join(append([]string{"-C"}, rule[1:]...), " ")
-		runner.respond[check] = fakeResp{err: errors.New("absent")}
-	}
-
-	if err := newInstaller(runner).Install(context.Background()); err != nil {
-		t.Fatalf("Install: %v", err)
-	}
-	if !wasCalled(runner, []string{"-I", "FORWARD", "2", "-j", "KUKEON-FORWARD"}) {
-		t.Errorf("expected jump at position 2 (after KUKEON-EGRESS); calls = %v", runner.calls)
-	}
-	if wasCalled(runner, []string{"-I", "FORWARD", "1", "-j", "KUKEON-FORWARD"}) {
-		t.Errorf("must not insert at position 1 when KUKEON-EGRESS already holds it")
-	}
-}
-
-// TestInstall_JumpAtPositionNplus1 covers the deeper case: KUKEON-EGRESS
-// at a non-1 position (after some unrelated rules) must still anchor the
-// KUKEON-FORWARD jump immediately after it.
-func TestInstall_JumpAtPositionNplus1(t *testing.T) {
-	runner := &fakeRunner{
-		respond: map[string]fakeResp{
-			"-L KUKEON-FORWARD -n":         {err: errors.New("absent")},
-			"-C FORWARD -j KUKEON-FORWARD": {err: errors.New("absent")},
-			"-S KUKEON-FORWARD":            {out: []byte("-N KUKEON-FORWARD\n")},
-			"-S FORWARD": {out: []byte(
-				"-P FORWARD DROP\n" +
-					"-A FORWARD -i docker0 -j ACCEPT\n" +
-					"-A FORWARD -j KUKEON-EGRESS\n",
-			)},
-		},
-	}
-	for _, rule := range firewall.AdmissionRules() {
-		check := strings.Join(append([]string{"-C"}, rule[1:]...), " ")
-		runner.respond[check] = fakeResp{err: errors.New("absent")}
-	}
-
-	if err := newInstaller(runner).Install(context.Background()); err != nil {
-		t.Fatalf("Install: %v", err)
-	}
-	if !wasCalled(runner, []string{"-I", "FORWARD", "3", "-j", "KUKEON-FORWARD"}) {
-		t.Errorf("expected jump at position 3 (after KUKEON-EGRESS at 2); calls = %v", runner.calls)
-	}
-}
-
-// TestInstall_DoesNotMatchEgressLikeSiblingChain pins the token-aware
-// match in findEgressPosition: a chain named like KUKEON-EGRESS-FOO must
-// not be mistaken for KUKEON-EGRESS. With only the sibling chain at
-// FORWARD pos 1 and KUKEON-EGRESS absent, the installer must insert
-// KUKEON-FORWARD at position 1, not 2.
-func TestInstall_DoesNotMatchEgressLikeSiblingChain(t *testing.T) {
-	runner := &fakeRunner{
-		respond: map[string]fakeResp{
-			"-L KUKEON-FORWARD -n":         {err: errors.New("absent")},
-			"-C FORWARD -j KUKEON-FORWARD": {err: errors.New("absent")},
-			"-S KUKEON-FORWARD":            {out: []byte("-N KUKEON-FORWARD\n")},
-			"-S FORWARD": {out: []byte(
-				"-P FORWARD DROP\n" +
-					"-A FORWARD -j KUKEON-EGRESS-FOO\n",
 			)},
 		},
 	}
@@ -405,36 +351,27 @@ func TestInstall_DoesNotMatchEgressLikeSiblingChain(t *testing.T) {
 		t.Fatalf("Install: %v", err)
 	}
 	if !wasCalled(runner, []string{"-I", "FORWARD", "1", "-j", "KUKEON-FORWARD"}) {
-		t.Errorf("expected jump at position 1 when only a sibling chain is present; calls = %v", runner.calls)
+		t.Errorf("expected jump at position 1 regardless of KUKEON-EGRESS; calls = %v", runner.calls)
 	}
 	if wasCalled(runner, []string{"-I", "FORWARD", "2", "-j", "KUKEON-FORWARD"}) {
-		t.Errorf("must not match KUKEON-EGRESS-FOO as KUKEON-EGRESS")
+		t.Errorf("must not anchor the jump to KUKEON-EGRESS's position anymore; calls = %v", runner.calls)
 	}
 }
 
-// TestInstall_SurvivesDockerChurnWithoutReorder is #1075 AC #4: when Docker
-// re-asserts its own chains (DOCKER-USER / DOCKER-FORWARD) at the top of
-// FORWARD it pushes kukeon's jumps down but never deletes them and never
-// inverts their relative order. Because KUKEON-FORWARD is ACCEPT-only and
-// position relative to Docker is immaterial to correctness, the self-assert
-// must treat this as healthy — no delete, no re-insert, no churn.
-func TestInstall_SurvivesDockerChurnWithoutReorder(t *testing.T) {
+// TestInstall_JumpNoChurnWhenPresent verifies the jump is left untouched
+// wherever it already sits. With egress decided per-space, the jump only needs
+// to *exist* — Docker pushing it down the chain (DOCKER-USER / DOCKER-FORWARD
+// at the top) or sitting it ahead of KUKEON-EGRESS is no longer churn-worthy,
+// so the self-assert must neither delete nor re-insert it.
+func TestInstall_JumpNoChurnWhenPresent(t *testing.T) {
 	runner := &fakeRunner{
 		respond: map[string]fakeResp{
-			// Docker pushed kukeon's jumps down the chain; KUKEON-EGRESS is
-			// still ahead of KUKEON-FORWARD, so the ordering invariant holds.
-			"-S FORWARD": {out: []byte(
-				"-P FORWARD DROP\n" +
-					"-A FORWARD -j DOCKER-USER\n" +
-					"-A FORWARD -j DOCKER-FORWARD\n" +
-					"-A FORWARD -j KUKEON-EGRESS\n" +
-					"-A FORWARD -j KUKEON-FORWARD\n",
-			)},
-			// Chain + tagged rules already present → no migration/rule churn.
+			// `-C FORWARD -j KUKEON-FORWARD` not canned → default success →
+			// jump present → ensureForwardJump no-ops. Chain carries the
+			// post-#1076 two-rule layout so prune finds nothing.
 			"-S KUKEON-FORWARD": {out: []byte(
 				"-N KUKEON-FORWARD\n" +
 					"-A KUKEON-FORWARD -m conntrack --ctstate RELATED,ESTABLISHED -m comment --comment \"kukeon-forward:established\" -j ACCEPT\n" +
-					"-A KUKEON-FORWARD -i k-+ -m comment --comment \"kukeon-forward:egress\" -j ACCEPT\n" +
 					"-A KUKEON-FORWARD -o k-+ -m comment --comment \"kukeon-forward:ingress\" -j ACCEPT\n",
 			)},
 		},
@@ -443,89 +380,66 @@ func TestInstall_SurvivesDockerChurnWithoutReorder(t *testing.T) {
 	if err := newInstaller(runner).Install(context.Background()); err != nil {
 		t.Fatalf("Install: %v", err)
 	}
-	if wasCalledWithVerb(runner, "-D") {
-		t.Errorf("must not delete the jump when Docker merely reordered it; calls = %v", runner.calls)
-	}
 	if wasCalledWithVerb(runner, "-I") {
-		t.Errorf("must not re-insert the jump under harmless Docker churn; calls = %v", runner.calls)
+		t.Errorf("must not re-insert the jump when it is already present; calls = %v", runner.calls)
+	}
+	if wasCalledWithVerb(runner, "-D") {
+		t.Errorf("must not delete the jump when it is already present; calls = %v", runner.calls)
 	}
 }
 
-// invertedForwardRunner simulates a FORWARD chain where KUKEON-FORWARD sits
-// *ahead* of KUKEON-EGRESS — the displacement that lets the blanket admission
-// shadow per-space egress DROP rules. After the self-assert deletes the
-// misplaced jump, the second `-S FORWARD` read reflects the post-delete state
-// (KUKEON-EGRESS shifted up to position 1) so the re-insert lands in the
-// correct slot. The stateless fakeRunner cannot model that shift, hence this
-// purpose-built stateful runner.
-type invertedForwardRunner struct {
-	calls   [][]string
-	deleted bool
-}
-
-func (r *invertedForwardRunner) Run(_ context.Context, args ...string) ([]byte, error) {
-	r.calls = append(r.calls, append([]string(nil), args...))
-	joined := strings.Join(args, " ")
-	switch {
-	case joined == "-S FORWARD":
-		if r.deleted {
-			// KUKEON-FORWARD removed; KUKEON-EGRESS now at position 1.
-			return []byte("-P FORWARD DROP\n-A FORWARD -j KUKEON-EGRESS\n"), nil
-		}
-		// Inverted: KUKEON-FORWARD (1) ahead of KUKEON-EGRESS (2).
-		return []byte(
-			"-P FORWARD DROP\n" +
-				"-A FORWARD -j KUKEON-FORWARD\n" +
-				"-A FORWARD -j KUKEON-EGRESS\n",
-		), nil
-	case joined == "-D FORWARD -j KUKEON-FORWARD":
-		r.deleted = true
-		return nil, nil
-	default:
-		// All existence probes (-L chain, -C rule, -S KUKEON-FORWARD) report
-		// "present/empty" so Install skips migration and rule churn and
-		// exercises only the jump self-assert.
-		return nil, nil
+// TestInstall_PrunesObsoleteEgressAdmission is the upgrade-path guard for
+// #1076: a host upgraded from the pre-#1076 layout still carries the
+// host-global egress blanket (`-i k-+ ... :egress -j ACCEPT`) in
+// KUKEON-FORWARD. Leaving it would re-open the fail-open hole, so Install must
+// -D it. The established + ingress rules already present must not be touched.
+func TestInstall_PrunesObsoleteEgressAdmission(t *testing.T) {
+	runner := &fakeRunner{
+		respond: map[string]fakeResp{
+			// Healthy chain carrying the retired :egress rule alongside the
+			// current tagged rules → migration sees only tagged rules (no
+			// flush), the ensureRule loop finds established+ingress present,
+			// and the prune deletes the egress blanket.
+			"-S KUKEON-FORWARD": {out: []byte(
+				"-N KUKEON-FORWARD\n" +
+					"-A KUKEON-FORWARD -m conntrack --ctstate RELATED,ESTABLISHED -m comment --comment \"kukeon-forward:established\" -j ACCEPT\n" +
+					"-A KUKEON-FORWARD -i k-+ -m comment --comment \"kukeon-forward:egress\" -j ACCEPT\n" +
+					"-A KUKEON-FORWARD -o k-+ -m comment --comment \"kukeon-forward:ingress\" -j ACCEPT\n",
+			)},
+			"-C FORWARD -j KUKEON-FORWARD": {},
+		},
 	}
-}
 
-func (r *invertedForwardRunner) ran(prefix ...string) bool {
-	for _, got := range r.calls {
-		if len(got) < len(prefix) {
-			continue
-		}
-		match := true
-		for i := range prefix {
-			if got[i] != prefix[i] {
-				match = false
-				break
-			}
-		}
-		if match {
-			return true
-		}
-	}
-	return false
-}
-
-// TestInstall_ReclaimsDisplacedJump is #1075 AC #1 (the "displaced" arm):
-// when KUKEON-FORWARD is present but ahead of KUKEON-EGRESS, the self-assert
-// deletes the misplaced jump and re-inserts it immediately after
-// KUKEON-EGRESS so per-space egress DROP rules win over the blanket admission.
-func TestInstall_ReclaimsDisplacedJump(t *testing.T) {
-	runner := &invertedForwardRunner{}
-	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
-	installer := firewall.NewInstallerWithRunner(logger, runner)
-	if err := installer.Install(context.Background()); err != nil {
+	if err := newInstaller(runner).Install(context.Background()); err != nil {
 		t.Fatalf("Install: %v", err)
 	}
-	if !runner.ran("-D", "FORWARD", "-j", "KUKEON-FORWARD") {
-		t.Errorf("expected the displaced jump to be deleted; calls = %v", runner.calls)
+	wantDel := []string{
+		"-D", firewall.ForwardChainName,
+		"-i", firewall.BridgeIfaceMatch,
+		"-m", "comment", "--comment", "kukeon-forward:egress",
+		"-j", "ACCEPT",
 	}
-	// After the delete, KUKEON-EGRESS is at position 1, so the jump must be
-	// re-inserted at position 2 (immediately after it).
-	if !runner.ran("-I", "FORWARD", "2", "-j", "KUKEON-FORWARD") {
-		t.Errorf("expected re-insert at position 2 (after KUKEON-EGRESS); calls = %v", runner.calls)
+	if !wasCalled(runner, wantDel) {
+		t.Errorf("expected the obsolete egress blanket to be pruned via %v; calls = %v",
+			wantDel, runner.calls)
+	}
+	// The chain must not be flushed (the current rules are tagged) and the jump
+	// is present so nothing is re-inserted.
+	if wasCalledWithVerb(runner, "-F") {
+		t.Errorf("must not flush a chain carrying current tagged rules; calls = %v", runner.calls)
+	}
+}
+
+// TestInstall_PruneNoopWhenNoEgressRule confirms the prune is a no-op on a
+// host that never carried (or already shed) the egress blanket: no -D against
+// KUKEON-FORWARD.
+func TestInstall_PruneNoopWhenNoEgressRule(t *testing.T) {
+	runner := installFreshHostRunner()
+	if err := newInstaller(runner).Install(context.Background()); err != nil {
+		t.Fatalf("Install: %v", err)
+	}
+	if wasCalledWithVerb(runner, "-D") {
+		t.Errorf("prune must not -D when no egress blanket is present; calls = %v", runner.calls)
 	}
 }
 

--- a/internal/firewall/forward_test.go
+++ b/internal/firewall/forward_test.go
@@ -80,9 +80,13 @@ func TestAdmissionRules_Order(t *testing.T) {
 		t.Errorf("rule 0: want %v; got %v", want0, rules[0])
 	}
 
-	// Rule 1: -o k-+ ACCEPT, tagged "kukeon-forward:ingress".
+	// Rule 1: ! -i k-+ -o k-+ ACCEPT, tagged "kukeon-forward:ingress". The
+	// `! -i k-+` scope excludes bridge-sourced traffic so a space's egress
+	// (always bridge-sourced) can never be admitted here — only true external
+	// ingress destined to a kukeon bridge.
 	want1 := []string{
 		"-A", firewall.ForwardChainName,
+		"!", "-i", firewall.BridgeIfaceMatch,
 		"-o", firewall.BridgeIfaceMatch,
 		"-m", "comment", "--comment", "kukeon-forward:ingress",
 		"-j", "ACCEPT",
@@ -94,18 +98,66 @@ func TestAdmissionRules_Order(t *testing.T) {
 
 // TestAdmissionRules_NoEgressBlanket is the fail-closed guard for #1076: the
 // host-global egress admission rule must never reappear in AdmissionRules. A
-// blanket `-i k-+ ACCEPT` here is exactly the fail-open hole the per-space
-// admission model closes, so its absence is a contract, not an accident.
+// *positive* blanket `-i k-+ ACCEPT` here is exactly the fail-open hole the
+// per-space admission model closes, so its absence is a contract, not an
+// accident. The *negated* `! -i k-+` qualifier on the ingress rule is the
+// opposite — it excludes bridge-sourced traffic so a space's egress can never
+// be admitted — and must be allowed.
 func TestAdmissionRules_NoEgressBlanket(t *testing.T) {
 	for _, r := range firewall.AdmissionRules() {
 		joined := strings.Join(r, " ")
-		if strings.Contains(joined, "-i "+firewall.BridgeIfaceMatch) {
+		// A positive `-i k-+` match (not the negated `! -i k-+` scope) is the
+		// fail-open blanket. The negated form admits the inter-bridge fix, so
+		// only flag `-i k-+` when it is not preceded by the `!` negation.
+		if strings.Contains(joined, "-i "+firewall.BridgeIfaceMatch) &&
+			!strings.Contains(joined, "! -i "+firewall.BridgeIfaceMatch) {
 			t.Errorf("admission rules must not carry a host-global egress (-i %s) blanket; got %v",
 				firewall.BridgeIfaceMatch, r)
 		}
 		if strings.Contains(joined, "kukeon-forward:egress") {
 			t.Errorf("admission rules must not carry the retired :egress role; got %v", r)
 		}
+	}
+}
+
+// TestAdmissionRules_IngressExcludesBridgeSources is the inter-bridge
+// fail-closed guard. The ingress ACCEPT must carry the `! -i k-+` scope so it
+// admits only traffic that did *not* originate on a kukeon bridge. Without it,
+// an inter-bridge packet (`-i k-A -o k-B`) — egress from deny-space A, ingress
+// to B — would match a bare `-o k-+ ACCEPT` and be admitted here before A's
+// KUKEON-EGRESS chain runs, a fail-open hole whenever KUKEON-FORWARD sits ahead
+// of KUKEON-EGRESS (nothing orders them post-#1076). The negation routes every
+// space's egress through KUKEON-EGRESS instead, so its position stays immaterial.
+func TestAdmissionRules_IngressExcludesBridgeSources(t *testing.T) {
+	var ingress []string
+	for _, r := range firewall.AdmissionRules() {
+		if strings.Contains(strings.Join(r, " "), "kukeon-forward:ingress") {
+			ingress = r
+			break
+		}
+	}
+	if ingress == nil {
+		t.Fatal("no ingress rule found in AdmissionRules")
+	}
+	// The rule must negate the bridge-source match: the tokens "!", "-i",
+	// "k-+" must appear in that order so a space's (bridge-sourced) egress
+	// cannot be admitted by the ingress ACCEPT.
+	found := false
+	for i := 0; i+2 < len(ingress); i++ {
+		if ingress[i] == "!" && ingress[i+1] == "-i" && ingress[i+2] == firewall.BridgeIfaceMatch {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("ingress rule must scope ingress with `! -i %s` to exclude bridge-sourced (egress) traffic; got %v",
+			firewall.BridgeIfaceMatch, ingress)
+	}
+	// And it must still admit the external→bridge ingress it exists for.
+	joined := strings.Join(ingress, " ")
+	if !strings.Contains(joined, "-o "+firewall.BridgeIfaceMatch) || !strings.Contains(joined, "-j ACCEPT") {
+		t.Errorf("ingress rule must still ACCEPT external traffic destined to a kukeon bridge (-o %s); got %v",
+			firewall.BridgeIfaceMatch, ingress)
 	}
 }
 
@@ -216,7 +268,7 @@ func TestInstall_IsIdempotent(t *testing.T) {
 			"-S KUKEON-FORWARD": {out: []byte(
 				"-N KUKEON-FORWARD\n" +
 					"-A KUKEON-FORWARD -m conntrack --ctstate RELATED,ESTABLISHED -m comment --comment \"kukeon-forward:established\" -j ACCEPT\n" +
-					"-A KUKEON-FORWARD -o k-+ -m comment --comment \"kukeon-forward:ingress\" -j ACCEPT\n",
+					"-A KUKEON-FORWARD ! -i k-+ -o k-+ -m comment --comment \"kukeon-forward:ingress\" -j ACCEPT\n",
 			)},
 			// FORWARD jump present → ensureForwardJump's -C succeeds and it
 			// re-inserts nothing. Position relative to KUKEON-EGRESS no longer
@@ -372,7 +424,7 @@ func TestInstall_JumpNoChurnWhenPresent(t *testing.T) {
 			"-S KUKEON-FORWARD": {out: []byte(
 				"-N KUKEON-FORWARD\n" +
 					"-A KUKEON-FORWARD -m conntrack --ctstate RELATED,ESTABLISHED -m comment --comment \"kukeon-forward:established\" -j ACCEPT\n" +
-					"-A KUKEON-FORWARD -o k-+ -m comment --comment \"kukeon-forward:ingress\" -j ACCEPT\n",
+					"-A KUKEON-FORWARD ! -i k-+ -o k-+ -m comment --comment \"kukeon-forward:ingress\" -j ACCEPT\n",
 			)},
 		},
 	}
@@ -404,7 +456,7 @@ func TestInstall_PrunesObsoleteEgressAdmission(t *testing.T) {
 				"-N KUKEON-FORWARD\n" +
 					"-A KUKEON-FORWARD -m conntrack --ctstate RELATED,ESTABLISHED -m comment --comment \"kukeon-forward:established\" -j ACCEPT\n" +
 					"-A KUKEON-FORWARD -i k-+ -m comment --comment \"kukeon-forward:egress\" -j ACCEPT\n" +
-					"-A KUKEON-FORWARD -o k-+ -m comment --comment \"kukeon-forward:ingress\" -j ACCEPT\n",
+					"-A KUKEON-FORWARD ! -i k-+ -o k-+ -m comment --comment \"kukeon-forward:ingress\" -j ACCEPT\n",
 			)},
 			"-C FORWARD -j KUKEON-FORWARD": {},
 		},
@@ -427,6 +479,84 @@ func TestInstall_PrunesObsoleteEgressAdmission(t *testing.T) {
 	// is present so nothing is re-inserted.
 	if wasCalledWithVerb(runner, "-F") {
 		t.Errorf("must not flush a chain carrying current tagged rules; calls = %v", runner.calls)
+	}
+}
+
+// TestInstall_PrunesUnscopedIngressAdmission is the upgrade-path guard for the
+// inter-bridge fix: a host upgraded from the intermediate #1076 layout carries
+// the *unscoped* ingress rule (`-o k-+ ... :ingress`, no `! -i k-+`) that admits
+// a deny-space's inter-bridge egress before its KUKEON-EGRESS chain runs.
+// Install must -D that rule and leave only the scoped `! -i k-+ -o k-+` form.
+func TestInstall_PrunesUnscopedIngressAdmission(t *testing.T) {
+	runner := &fakeRunner{
+		respond: map[string]fakeResp{
+			// Intermediate-#1076 host: established (tagged) + the unscoped
+			// ingress rule. Migration sees only tagged rules (no flush); the
+			// scoped replacement is absent so it gets -A'd, and the prune -D's
+			// the unscoped one.
+			"-S KUKEON-FORWARD": {out: []byte(
+				"-N KUKEON-FORWARD\n" +
+					"-A KUKEON-FORWARD -m conntrack --ctstate RELATED,ESTABLISHED -m comment --comment \"kukeon-forward:established\" -j ACCEPT\n" +
+					"-A KUKEON-FORWARD -o k-+ -m comment --comment \"kukeon-forward:ingress\" -j ACCEPT\n",
+			)},
+			"-C FORWARD -j KUKEON-FORWARD": {},
+		},
+	}
+	// Every current admission rule is absent in its current shape → each gets
+	// -A'd (the scoped ingress form in particular).
+	for _, rule := range firewall.AdmissionRules() {
+		check := strings.Join(append([]string{"-C"}, rule[1:]...), " ")
+		runner.respond[check] = fakeResp{err: errors.New("absent")}
+	}
+
+	if err := newInstaller(runner).Install(context.Background()); err != nil {
+		t.Fatalf("Install: %v", err)
+	}
+	wantDel := []string{
+		"-D", firewall.ForwardChainName,
+		"-o", firewall.BridgeIfaceMatch,
+		"-m", "comment", "--comment", "kukeon-forward:ingress",
+		"-j", "ACCEPT",
+	}
+	if !wasCalled(runner, wantDel) {
+		t.Errorf("expected the unscoped ingress rule to be pruned via %v; calls = %v",
+			wantDel, runner.calls)
+	}
+	// The scoped replacement must be installed.
+	var scoped []string
+	for _, r := range firewall.AdmissionRules() {
+		if strings.Contains(strings.Join(r, " "), "kukeon-forward:ingress") {
+			scoped = r
+		}
+	}
+	if !wasCalled(runner, scoped) {
+		t.Errorf("expected the scoped ingress rule %v to be installed; calls = %v", scoped, runner.calls)
+	}
+	// The chain must not be flushed (the existing rules are tagged).
+	if wasCalledWithVerb(runner, "-F") {
+		t.Errorf("must not flush a chain carrying tagged rules; calls = %v", runner.calls)
+	}
+}
+
+// TestInstall_DoesNotPruneScopedIngress guards the idempotency of the prune:
+// on a healthy post-fix host the ingress rule carries the `! -i k-+` scope, and
+// the unscoped-ingress prune must leave it alone (it is the rule we want).
+func TestInstall_DoesNotPruneScopedIngress(t *testing.T) {
+	runner := &fakeRunner{
+		respond: map[string]fakeResp{
+			"-S KUKEON-FORWARD": {out: []byte(
+				"-N KUKEON-FORWARD\n" +
+					"-A KUKEON-FORWARD -m conntrack --ctstate RELATED,ESTABLISHED -m comment --comment \"kukeon-forward:established\" -j ACCEPT\n" +
+					"-A KUKEON-FORWARD ! -i k-+ -o k-+ -m comment --comment \"kukeon-forward:ingress\" -j ACCEPT\n",
+			)},
+			"-C FORWARD -j KUKEON-FORWARD": {},
+		},
+	}
+	if err := newInstaller(runner).Install(context.Background()); err != nil {
+		t.Fatalf("Install: %v", err)
+	}
+	if wasCalledWithVerb(runner, "-D") {
+		t.Errorf("must not -D the scoped ingress rule; calls = %v", runner.calls)
 	}
 }
 

--- a/internal/netpolicy/policy.go
+++ b/internal/netpolicy/policy.go
@@ -106,6 +106,27 @@ func FromInternal(realmName, spaceName, bridge string, in *intmodel.EgressPolicy
 	}, nil
 }
 
+// NewAdmitAllPolicy returns a default-allow admission policy for a space's
+// bridge that carries no operator-supplied egress restriction.
+//
+// Since #1076 egress admission is per-space: the host-global `-i k-+ ACCEPT`
+// blanket in KUKEON-FORWARD is gone, so a space with no EgressPolicy (or a
+// default=allow policy with an empty allowlist, which FromInternal collapses to
+// nil) would otherwise have no path to ACCEPT its egress on a host whose
+// FORWARD policy is DROP. Installing this admit-all chain — established + a
+// terminal ACCEPT, via BuildRules — keeps such a space's egress fully open
+// while still routing it through its own space-owned chain, so the per-space
+// install/remove-as-one-unit invariant holds for every space uniformly.
+func NewAdmitAllPolicy(realmName, spaceName, bridge string) *Policy {
+	return &Policy{
+		Bridge:    bridge,
+		RealmName: realmName,
+		SpaceName: spaceName,
+		Default:   intmodel.EgressDefaultAllow,
+		Allow:     nil,
+	}
+}
+
 func normalizeDefault(d intmodel.EgressDefault) (intmodel.EgressDefault, error) {
 	switch strings.ToLower(strings.TrimSpace(string(d))) {
 	case "", string(intmodel.EgressDefaultAllow):

--- a/internal/netpolicy/rules.go
+++ b/internal/netpolicy/rules.go
@@ -44,10 +44,20 @@ type Rule struct {
 // per-space chain. The caller is responsible for ensuring the chain exists
 // (flushed) and for wiring the dispatch jump from the master chain.
 //
+// Since #1076 the per-space chain is the *single space-owned chain* that both
+// admits and filters that bridge's egress — it terminates every packet itself
+// (ACCEPT or DROP) rather than RETURNing to a host-global blanket
+// KUKEON-FORWARD `-i k-+ ACCEPT`. That blanket is gone, so a RETURN here would
+// drop the packet to FORWARD's default policy: egress admission must live in
+// this chain. The fail-closed payoff: if this chain is missing (e.g. after a
+// reboot, before the reconcile loop re-applies it) a Default=deny space has no
+// path to ACCEPT, so traffic dies at FORWARD's policy — loud no-connectivity
+// instead of the old silent unrestricted egress.
+//
 // Rule ordering matters:
-//  1. Return on RELATED/ESTABLISHED so reply traffic is never dropped.
-//  2. Each allowlist entry emits one or more RETURN rules.
-//  3. Final action: DROP (when Default=deny) or RETURN (when Default=allow).
+//  1. ACCEPT on RELATED/ESTABLISHED so reply traffic is never dropped.
+//  2. Each allowlist entry emits one or more ACCEPT rules.
+//  3. Final action: DROP (when Default=deny) or ACCEPT (when Default=allow).
 //
 // The generator is pure: no I/O, no iptables invocations.
 func BuildRules(p *Policy) []Rule {
@@ -61,7 +71,7 @@ func BuildRules(p *Policy) []Rule {
 		Args: []string{
 			"-m", "conntrack", "--ctstate", "RELATED,ESTABLISHED",
 			"-m", "comment", "--comment", tag + ":established",
-			"-j", "RETURN",
+			"-j", "ACCEPT",
 		},
 	})
 
@@ -79,7 +89,7 @@ func BuildRules(p *Policy) []Rule {
 	if p.Default == intmodel.EgressDefaultDeny {
 		terminal.Args = append(terminal.Args, "-j", "DROP")
 	} else {
-		terminal.Args = append(terminal.Args, "-j", "RETURN")
+		terminal.Args = append(terminal.Args, "-j", "ACCEPT")
 	}
 	rules = append(rules, terminal)
 
@@ -109,7 +119,7 @@ func buildAllowRules(chain, tag string, idx int, r ResolvedRule) []Rule {
 				Args: []string{
 					"-d", dst,
 					"-m", "comment", "--comment", tag + ":" + allowComment(idx, r),
-					"-j", "RETURN",
+					"-j", "ACCEPT",
 				},
 			})
 			continue
@@ -123,7 +133,7 @@ func buildAllowRules(chain, tag string, idx int, r ResolvedRule) []Rule {
 					"-p", "tcp",
 					"--dport", strconv.Itoa(port),
 					"-m", "comment", "--comment", tag + ":" + allowComment(idx, r),
-					"-j", "RETURN",
+					"-j", "ACCEPT",
 				},
 			})
 		}

--- a/internal/netpolicy/rules_test.go
+++ b/internal/netpolicy/rules_test.go
@@ -51,12 +51,17 @@ func TestBuildRules_DenyDefaultHasTerminalDrop(t *testing.T) {
 	if !strings.Contains(firstJoined, "RELATED,ESTABLISHED") {
 		t.Fatalf("first rule must allow RELATED,ESTABLISHED; got %q", firstJoined)
 	}
-	if !strings.Contains(firstJoined, "-j RETURN") {
-		t.Fatalf("first rule must RETURN; got %q", firstJoined)
+	// Since #1076 the per-space chain is self-terminating: established traffic
+	// is ACCEPTed here, not RETURNed to a host-global blanket (which is gone).
+	if !strings.Contains(firstJoined, "-j ACCEPT") {
+		t.Fatalf("first rule must ACCEPT established traffic; got %q", firstJoined)
+	}
+	if strings.Contains(firstJoined, "-j RETURN") {
+		t.Fatalf("established rule must not RETURN (no host-global blanket to fall through to); got %q", firstJoined)
 	}
 }
 
-func TestBuildRules_AllowDefaultHasTerminalReturn(t *testing.T) {
+func TestBuildRules_AllowDefaultHasTerminalAccept(t *testing.T) {
 	// An explicit allow default with at least one allow rule (otherwise
 	// FromInternal collapses to nil).
 	p, err := netpolicy.FromInternal("main", "blog", "br", &intmodel.EgressPolicy{
@@ -71,8 +76,13 @@ func TestBuildRules_AllowDefaultHasTerminalReturn(t *testing.T) {
 	rules := netpolicy.BuildRules(p)
 	last := rules[len(rules)-1]
 	joined := strings.Join(last.Args, " ")
-	if !strings.Contains(joined, "-j RETURN") {
-		t.Fatalf("allow default must terminate in RETURN; got %q", joined)
+	// Since #1076 the chain admits its own egress: a default=allow terminal
+	// ACCEPTs rather than RETURNing to a (now-removed) host-global blanket.
+	if !strings.Contains(joined, "-j ACCEPT") {
+		t.Fatalf("allow default must terminate in ACCEPT; got %q", joined)
+	}
+	if strings.Contains(joined, "-j RETURN") {
+		t.Fatalf("allow default must not RETURN post-#1076; got %q", joined)
 	}
 }
 
@@ -103,8 +113,8 @@ func TestBuildRules_CIDRAllowExpandsByPort(t *testing.T) {
 		if !strings.Contains(joined, "--dport") {
 			t.Errorf("rule %d: missing --dport: %q", i, joined)
 		}
-		if !strings.Contains(joined, "-j RETURN") {
-			t.Errorf("rule %d: missing -j RETURN: %q", i, joined)
+		if !strings.Contains(joined, "-j ACCEPT") {
+			t.Errorf("rule %d: missing -j ACCEPT: %q", i, joined)
 		}
 	}
 }
@@ -167,6 +177,74 @@ func TestBuildRules_NoPortsMeansAnyDest(t *testing.T) {
 	}
 	if !strings.Contains(joined, "-d 172.16.0.0/12") {
 		t.Fatalf("missing -d target: %q", joined)
+	}
+}
+
+// TestBuildRules_DenyChainIsSelfTerminating is the fail-closed contract for
+// #1076: a Default=deny per-space chain must terminate every packet itself
+// (ACCEPT on established/allow, DROP otherwise) and never RETURN. A RETURN
+// would fall the packet through to FORWARD — and since the host-global egress
+// blanket is gone, that is no longer an ACCEPT. The single space-owned chain
+// is the whole egress decision; if it is missing the space fails closed.
+func TestBuildRules_DenyChainIsSelfTerminating(t *testing.T) {
+	p, err := netpolicy.FromInternal("main", "blog", "br", &intmodel.EgressPolicy{
+		Default: intmodel.EgressDefaultDeny,
+		Allow: []intmodel.EgressAllowRule{
+			{CIDR: "10.0.0.0/8", Ports: []int{443}},
+			{Host: "api.example.com"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	p.Allow[1].IPs = []net.IP{net.ParseIP("192.0.2.10")}
+
+	rules := netpolicy.BuildRules(p)
+	for i, r := range rules {
+		joined := strings.Join(r.Args, " ")
+		if strings.Contains(joined, "-j RETURN") {
+			t.Errorf("rule %d must not RETURN (chain must self-terminate); got %q", i, joined)
+		}
+	}
+	// Terminal must DROP — the fail-closed default.
+	last := strings.Join(rules[len(rules)-1].Args, " ")
+	if !strings.Contains(last, "-j DROP") {
+		t.Fatalf("deny terminal must DROP; got %q", last)
+	}
+	// Every non-terminal rule (established + allow entries) must ACCEPT.
+	for i := 0; i < len(rules)-1; i++ {
+		joined := strings.Join(rules[i].Args, " ")
+		if !strings.Contains(joined, "-j ACCEPT") {
+			t.Errorf("rule %d (non-terminal) must ACCEPT; got %q", i, joined)
+		}
+	}
+}
+
+// TestNewAdmitAllPolicy_BuildsAdmitAllChain pins the per-space admit-all chain
+// installed for spaces with no operator egress restriction (#1076): a single
+// established-ACCEPT followed by a terminal ACCEPT, so the bridge keeps full
+// egress through its own chain now that the host-global blanket is gone.
+func TestNewAdmitAllPolicy_BuildsAdmitAllChain(t *testing.T) {
+	p := netpolicy.NewAdmitAllPolicy("main", "blog", "k-deadbeef")
+	if p == nil {
+		t.Fatal("NewAdmitAllPolicy must not return nil")
+	}
+	if p.Bridge != "k-deadbeef" {
+		t.Errorf("bridge: got %q, want k-deadbeef", p.Bridge)
+	}
+	rules := netpolicy.BuildRules(p)
+	// established + terminal = 2, both ACCEPT, no DROP, no RETURN.
+	if len(rules) != 2 {
+		t.Fatalf("admit-all chain must have exactly 2 rules (established + terminal); got %d: %+v", len(rules), rules)
+	}
+	for i, r := range rules {
+		joined := strings.Join(r.Args, " ")
+		if !strings.Contains(joined, "-j ACCEPT") {
+			t.Errorf("rule %d must ACCEPT in an admit-all chain; got %q", i, joined)
+		}
+		if strings.Contains(joined, "-j DROP") {
+			t.Errorf("admit-all chain must not DROP; got %q", joined)
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary

Step 3 of the spacenet epic (#953). Egress was **fail-open**: the host-global blanket admission `KUKEON-FORWARD -i k-+ ACCEPT` admitted *all* kukeon-bridge egress, so a `Default=deny` space whose per-space `KUKEON-EGRESS` chain went missing (e.g. post-reboot, after the daemon re-asserts admission but before the reconcile loop re-applies the egress chain) silently allowed all egress. The fix collapses per-space established+egress+admit into **one space-owned chain** and removes the host-global egress blanket, so a missing chain degrades to *no connectivity* (loud) instead of *unrestricted egress* (silent hole).

### What changed (the diff shows the *what*; here is the *why*)

- **`internal/netpolicy/rules.go` — the per-space chain is now self-terminating.** Established + allow entries `ACCEPT` (were `RETURN`); the terminal is `DROP` (deny) / `ACCEPT` (allow) (allow was `RETURN`). Previously the chain `RETURN`ed and relied on the host-global `-i k-+ ACCEPT` to admit. With that blanket gone, a `RETURN` would drop the packet to FORWARD's policy, so egress admission must live in the chain itself. This is what makes a missing chain fail *closed*.
- **`internal/firewall/forward.go` — host-global egress blanket removed; ingress scoped to non-bridge sources.** `AdmissionRules()` now emits only the stateful-return `ACCEPT` and the ingress `! -i k-+ -o k-+ ACCEPT`; the `-i k-+ :egress` rule is gone. The `! -i k-+` qualifier (added while addressing review) scopes ingress to traffic that did *not* originate on a kukeon bridge, so a space's egress (always bridge-sourced) can never be admitted here — see the inter-bridge note below. `ensureForwardJump` no longer maintains any ordering relative to `KUKEON-EGRESS` (AC #5): egress is decided entirely inside each self-terminating per-space chain, so the jump only needs to *exist*. The pre-#1076 positional dance (`forwardJumpPositions`/`lineJumpsTo`/`parseRuleLine`) is deleted. `pruneObsoleteEgressAdmission` strips a leftover `:egress` rule from upgraded hosts, and `pruneUnscopedIngressAdmission` strips a leftover *unscoped* `-o k-+ :ingress` rule (the intermediate-#1076 shape) so the inter-bridge fail-open does not survive the upgrade either.
- **`internal/controller/runner/egress.go` + `internal/netpolicy/policy.go` — admission is installed per-space, as one unit with the chain (AC #1, #2).** `applySpaceEgressPolicy` now installs a chain for **every** space, not just those carrying an `EgressPolicy`.

### Non-obvious blast-radius decision (reviewer: please push back if this oversteps)

Removing the host-global `-i k-+` blanket means a space with **no egress policy** (or `default=allow` with an empty allowlist) would otherwise have **no path to ACCEPT** its egress on a host whose FORWARD policy is `DROP` — which is exactly the situation the admission chain exists for. So `applySpaceEgressPolicy` is no longer a no-op for those spaces: it installs a per-space **admit-all** chain (`netpolicy.NewAdmitAllPolicy` → established `ACCEPT` + terminal `ACCEPT`). This keeps their egress fully open while routing it through their own space-owned chain, so the install/remove-as-one-unit invariant holds uniformly. This is a behavioral expansion (every space now gets an iptables chain via the reconcile loop / provision path); it is required by AC #1 + the fail-closed goal, but it is the largest-radius part of the change.

### Relationship to step 2 (#1075, merged)

Step 2 added the FORWARD-jump self-assert with a *displaced-relative-to-KUKEON-EGRESS* re-claim arm. Step 3 is the AC #5 retirement of that ordering contract: the **missing → re-insert** self-assert is kept (still needed for reboot/Docker-flush recovery), but the **displaced** arm is removed because, with no egress blanket here, the jump's position relative to `KUKEON-EGRESS` no longer affects correctness (an established packet can't reach a deny-space ACCEPT it was never granted — the NEW packet was dropped, so no conntrack entry exists).

### Inter-bridge egress (review follow-up)

The reviewer flagged that the ingress rule `-o k-+ ACCEPT` would also match an **inter-bridge** packet (`-i k-A -o k-B`) — which is egress from space A *and* ingress to bridge B — and so, if `KUKEON-FORWARD` sat ahead of `KUKEON-EGRESS`, would admit a deny-space A's cross-space egress before A's chain ran. Confirmed: no inter-bridge DROP existed anywhere in the tree, so this was a real fail-open for cross-space egress, and it made the "position immaterial" claim above false for that case.

Fix (AC #5-consistent — scopes the rule rather than restoring ordering): the ingress rule is now `! -i k-+ -o k-+ ACCEPT`. It admits only traffic that did not originate on a kukeon bridge (true external ingress), so every space's egress — internet-bound and inter-bridge alike — falls through to `KUKEON-EGRESS` and its own self-terminating chain decides, regardless of position. The stateful rule cannot re-open the hole either: a denied NEW inter-bridge packet now reaches A's chain and is `DROP`ped, so no conntrack entry is ever created for the `RELATED,ESTABLISHED` rule to match. This restores the "position immaterial" claim as a genuine invariant for all three cases (internet-bound egress, external ingress, inter-bridge).

## Acceptance criteria

- [x] Per-space admission targets only that space's bridge `k-<8hex>`, not the host-global `k-+` (the dispatch `-i <bridge>` from `KUKEON-EGRESS`; the `-i k-+` blanket is removed).
- [x] Admission and the space's `KUKEON-EGRESS` chain are installed/removed as one unit (`applySpaceEgressPolicy` → `enforcer.Apply` installs chain + dispatch; `removeSpaceEgressPolicy` removes both).
- [x] `Default=deny` space emits no blanket bridge ACCEPT; bridge traffic flows only through the allow-list chain ending in DROP (`TestBuildRules_DenyChainIsSelfTerminating`, `TestAdmissionRules_NoEgressBlanket`).
- [x] A missing egress chain yields no connectivity (fail-closed), not unrestricted egress (no host-global `-i k-+ ACCEPT` remains; chain is self-terminating).
- [x] The cross-chain positional ordering contract (`forward.go:40-46`) is removed/obsoleted (`ensureForwardJump` simplified; positional helpers deleted; `TestInstall_JumpInsertedAtPositionOneWhenAbsent`, `TestInstall_JumpNoChurnWhenPresent`).
- [x] Tests: deny-default fail-closed behavior + chain ordering (firewall + netpolicy suites below).

## Test plan

- [x] `make test` (full CI unit suite: `test-root` + `test-kukebuild`) — green.
- [x] `GOWORK=off go vet ./internal/firewall/... ./internal/netpolicy/... ./internal/controller/...` — clean.
- [x] New/updated unit tests: `internal/firewall` (no-egress-blanket, ingress-excludes-bridge-sources, jump-insert-at-1, no-churn-when-present, prune-obsolete-egress, prune-unscoped-ingress, does-not-prune-scoped-ingress, prune-noop) and `internal/netpolicy` (deny self-terminating, allow-terminal ACCEPT, admit-all chain shape).
- [x] Tree-wide `git grep` sweep: no remaining `-i k-+` egress-admission rule or `kukeon-forward:egress` reference outside the prune path/comments.
- [ ] `make dev-init` (KUKEON_PROFILE=dev) end-to-end smoke — **blocked: environmental disk limit, not a code issue.** The run fails inside the BuildKit kukeond-image build (`make release-build`) with `no space left on device` writing `/root/.cache/go-build` and the `/var/lib/containerd` content-store ingest, while the host filesystem has 115G free — the build sandbox has a separate, size-constrained filesystem on this dev host. The failure is in the image-**build** phase (compiling the binary), *before* `kuke init` runs, so it never reaches the daemon-parity / firewall path this change touches. Per the disk case, this defers to disked CI rather than stalling. The firewall/netpolicy behavior is covered by the unit tests above.

Closes #1076
