### PR TITLE
fix: resolve run-path conflist and sweep leaked masquerade chains on CNI purge

### DIFF
--- a/internal/controller/runner/helpers.go
+++ b/internal/controller/runner/helpers.go
@@ -18,11 +18,14 @@ package runner
 
 import (
 	"context"
+	"crypto/sha512"
 	"errors"
 	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"regexp"
+	"strconv"
 	"strings"
 	"syscall"
 	"time"
@@ -48,35 +51,23 @@ func (r *Exec) purgeCNIForContainer(containerID, netnsPath, networkName string) 
 	// lease.
 	netnsPath = r.sanitizeDELNetns(netnsPath)
 
-	// Always try to call CNI DEL if network name is available
-	// Some CNI plugins may handle empty/invalid netns gracefully
+	// Always try to call CNI DEL if network name is available; some CNI plugins
+	// handle empty/invalid netns gracefully. A skipped or failed DEL leaves the
+	// bridge plugin's per-container masquerade nat chains stranded on the host,
+	// so runCNIDel surfaces each failure mode above Debug and records its outcome
+	// in the purge result rather than reporting a clean purge (issue #1324).
 	if networkName != "" {
-		cniConfigPath, err := r.findCNIConfigPath(networkName)
-		if err == nil {
-			var cniMgr *cni.Manager
-			cniMgr, err = cni.NewManager(
-				r.cniConf.CniBinDir,
-				r.cniConf.CniConfigDir,
-				r.cniConf.CniCacheDir,
-			)
-			if err == nil {
-				if err = cniMgr.LoadNetworkConfigList(cniConfigPath); err == nil {
-					// Attempt CNI DEL even when netnsPath is empty. libcni's
-					// DelNetworkList is netns-optional: it reconstructs teardown
-					// (including the bridge plugin's ipMasq iptables chains/rules)
-					// from the cached CNI result, which the cache-removal block
-					// below only clears *after* this DEL has run. A stopped cell
-					// has no containerd task and thus no netns path, so gating DEL
-					// on netnsPath != "" permanently leaked the per-cell CNI-*
-					// masquerade chains on every delete-while-stopped (issue #1174).
-					if err = cniMgr.DelContainerFromNetwork(r.ctx, containerID, netnsPath); err == nil {
-						purged = append(purged, "cni-del")
-						r.logger.DebugContext(r.ctx, "called CNI DEL for container", "container", containerID)
-					} else {
-						r.logger.DebugContext(r.ctx, "CNI DEL failed (netns may be invalid)", "container", containerID, "error", err)
-					}
-				}
-			}
+		purged = append(purged, r.runCNIDel(containerID, netnsPath, networkName))
+		// Belt-and-suspenders: the plugin-chain DEL above only tears down the
+		// bridge plugin's per-container masquerade chain when it runs with a
+		// LIVE netns. On the purge path the container task is already gone, so
+		// the DEL runs with an empty netns and the bridge plugin early-returns
+		// after the IPAM release — never reaching its ipMasq teardown
+		// (containernetworking/plugins bridge cmdDel). This sweep reclaims the
+		// stranded chain + its POSTROUTING jump directly so a no-netns DEL (or a
+		// conflist-lookup miss) can't leak host nat state (issue #1324).
+		if marker := r.sweepCNIMasqChain(networkName, containerID); marker != "" {
+			purged = append(purged, marker)
 		}
 	}
 
@@ -165,6 +156,162 @@ func (r *Exec) purgeCNIForContainer(containerID, netnsPath, networkName string) 
 	}
 
 	return nil
+}
+
+// runCNIDel runs the plugin-chain CNI DEL for a single container and returns a
+// purge-result marker describing the outcome. The bridge plugin's per-container
+// masquerade nat chains are only torn down by this DEL, so a skipped or failed
+// DEL leaks host nat state on every networked-cell purge — every non-success
+// path is therefore logged at Warn (above the prior Debug) and reflected in the
+// returned marker rather than reported as a clean purge (issue #1324).
+func (r *Exec) runCNIDel(containerID, netnsPath, networkName string) string {
+	cniConfigPath, err := r.findCNIConfigPath(networkName)
+	if err != nil {
+		r.logger.WarnContext(
+			r.ctx,
+			"skipping CNI DEL: network config list not found; per-container masquerade nat rules may leak",
+			"container", containerID, "network", networkName, "error", err,
+		)
+		return "cni-del-skipped:config-not-found"
+	}
+
+	cniMgr, err := cni.NewManager(
+		r.cniConf.CniBinDir,
+		r.cniConf.CniConfigDir,
+		r.cniConf.CniCacheDir,
+	)
+	if err != nil {
+		r.logger.WarnContext(
+			r.ctx,
+			"skipping CNI DEL: failed to build CNI manager; per-container masquerade nat rules may leak",
+			"container", containerID, "network", networkName, "error", err,
+		)
+		return "cni-del-skipped:manager-error"
+	}
+
+	if err = cniMgr.LoadNetworkConfigList(cniConfigPath); err != nil {
+		r.logger.WarnContext(
+			r.ctx,
+			"skipping CNI DEL: failed to load network config list; per-container masquerade nat rules may leak",
+			"container", containerID, "network", networkName, "config", cniConfigPath, "error", err,
+		)
+		return "cni-del-skipped:load-error"
+	}
+
+	// Attempt CNI DEL even when netnsPath is empty. libcni's DelNetworkList is
+	// netns-optional: it reconstructs teardown (including the bridge plugin's
+	// ipMasq iptables chains/rules) from the cached CNI result, which the
+	// cache-removal block in purgeCNIForContainer only clears *after* this DEL
+	// has run. A stopped cell has no containerd task and thus no netns path, so
+	// gating DEL on netnsPath != "" permanently leaked the per-cell CNI-*
+	// masquerade chains on every delete-while-stopped (issue #1174).
+	if err = cniMgr.DelContainerFromNetwork(r.ctx, containerID, netnsPath); err != nil {
+		r.logger.WarnContext(
+			r.ctx,
+			"CNI DEL failed; per-container masquerade nat rules may leak",
+			"container", containerID, "network", networkName, "error", err,
+		)
+		return "cni-del-failed"
+	}
+	r.logger.DebugContext(r.ctx, "called CNI DEL for container", "container", containerID)
+	return "cni-del"
+}
+
+// cniIptablesRun shells out to the iptables binary for the best-effort
+// masquerade-chain sweep below. It is a package var so tests can capture the
+// invocations without touching the host firewall; production never reassigns
+// it (mirrors the reassign-in-tests pattern cni.CNINetworksDir uses). The
+// project deliberately shells out to iptables here (as internal/netpolicy does)
+// rather than importing containernetworking/plugins, to avoid pulling a new
+// dependency closure (plugins + coreos/go-iptables) for three commands.
+//
+//nolint:gochecknoglobals // test seam for the production iptables shell-out; reassigned only by tests, never by production code
+var cniIptablesRun = func(ctx context.Context, args ...string) ([]byte, error) {
+	out, err := exec.CommandContext(ctx, "iptables", args...).CombinedOutput()
+	if err != nil {
+		return out, fmt.Errorf("iptables %s: %w: %s", strings.Join(args, " "), err, strings.TrimSpace(string(out)))
+	}
+	return out, nil
+}
+
+// cniMasqChainName reproduces the bridge plugin's per-container masquerade chain
+// name: "CNI-" + the first 24 hex chars of sha512(networkName+containerID),
+// total 28 chars. This is utils.FormatChainName from
+// github.com/containernetworking/plugins (pkg/utils), pinned here so the purge
+// sweep can target the exact chain the bridge plugin created without importing
+// the plugins module. Verified byte-for-byte against live-created chains in the
+// #1324 dev-init repro (see TestCNIMasqChainName golden values).
+func cniMasqChainName(networkName, containerID string) string {
+	const maxChainLength = 28
+	sum := sha512.Sum512([]byte(networkName + containerID))
+	return fmt.Sprintf("CNI-%x", sum)[:maxChainLength]
+}
+
+// sweepCNIMasqChain best-effort removes the bridge plugin's per-container
+// masquerade chain (CNI-<hash>) and every POSTROUTING rule jumping to it. It is
+// the backstop for the no-live-netns DEL case (see purgeCNIForContainer): the
+// bridge plugin's own DEL only tears these rules down with a live netns, so on
+// the purge path they would otherwise leak permanently (issue #1324). Returns a
+// purge-result marker when it removed anything, or "" when the chain was already
+// gone (the common case once a live-netns DEL has run). All iptables calls are
+// best-effort: a missing chain/rule is expected and not logged.
+func (r *Exec) sweepCNIMasqChain(networkName, containerID string) string {
+	chain := cniMasqChainName(networkName, containerID)
+	swept := false
+
+	// 1. Delete every POSTROUTING jump to the chain, by line number in
+	//    descending order so earlier deletes don't renumber later ones. Matching
+	//    by target chain is robust to the rule's source IP and comment text.
+	lines := r.postroutingJumpLines(chain)
+	for i := len(lines) - 1; i >= 0; i-- {
+		if _, err := cniIptablesRun(r.ctx, "-t", "nat", "-D", "POSTROUTING", strconv.Itoa(lines[i])); err != nil {
+			r.logger.WarnContext(r.ctx, "ipMasq sweep: failed to delete POSTROUTING jump",
+				"chain", chain, "line", lines[i], "error", err)
+		} else {
+			swept = true
+		}
+	}
+
+	// 2. Flush then delete the chain. Both are no-ops (their not-exist errors are
+	//    ignored) once a prior live-netns DEL already reclaimed the chain.
+	_, _ = cniIptablesRun(r.ctx, "-t", "nat", "-F", chain)
+	if _, err := cniIptablesRun(r.ctx, "-t", "nat", "-X", chain); err == nil {
+		swept = true
+	}
+
+	if swept {
+		r.logger.InfoContext(r.ctx, "swept residual CNI masquerade chain",
+			"chain", chain, "container", containerID, "network", networkName)
+		return "cni-masq-swept:" + chain
+	}
+	return ""
+}
+
+// postroutingJumpLines returns the iptables line numbers of every nat
+// POSTROUTING rule whose target is chain, parsed from
+// `iptables -t nat -L POSTROUTING --line-numbers -n`. Returns nil on any
+// iptables error (the sweep then only attempts the flush/delete).
+func (r *Exec) postroutingJumpLines(chain string) []int {
+	out, err := cniIptablesRun(r.ctx, "-t", "nat", "-L", "POSTROUTING", "--line-numbers", "-n")
+	if err != nil {
+		return nil
+	}
+	var lines []int
+	for _, raw := range strings.Split(string(out), "\n") {
+		// Rule rows are "<num> <target> <prot> <opt> <source> <dest> ...";
+		// header rows ("num target ...", "Chain POSTROUTING ...") have a
+		// non-numeric first field and are skipped by the Atoi guard.
+		fields := strings.Fields(raw)
+		if len(fields) < 2 || fields[1] != chain {
+			continue
+		}
+		n, perr := strconv.Atoi(fields[0])
+		if perr != nil {
+			continue
+		}
+		lines = append(lines, n)
+	}
+	return lines
 }
 
 // containsExactContainerID checks if the content contains the exact container ID,
@@ -382,9 +529,63 @@ func (r *Exec) findCNIConfigPath(networkName string) (string, error) {
 		return configPath, nil
 	}
 
-	// Try to find in run path (space network configs)
-	// This requires listing spaces, which we'll do as a fallback
+	// Fall back to the per-space run-path conflist. Space conflists are written
+	// as <RunPath>/<metadata>/<realm>/<space>/network.conflist (see
+	// fs.SpaceNetworkConfigPath), NOT as <networkName>.conflist under
+	// CniConfigDir — so the standard-location lookup above always misses for
+	// space networks, silently skipping the CNI DEL and leaking the bridge
+	// plugin's per-container masquerade nat chains on purge (issue #1324). The
+	// network name is BuildSpaceNetworkName(realm, space) = "<realm>-<space>",
+	// but realm and space names may themselves contain '-', so the name is not
+	// reliably reversible by splitting. Enumerate realm/space dirs and match by
+	// the recomputed network name instead — the same enumeration teardownRealmCNI
+	// relies on.
+	if runConfigPath, err := r.findSpaceConflistByNetworkName(networkName); err == nil {
+		return runConfigPath, nil
+	}
+
 	return "", fmt.Errorf("CNI config not found for network %q", networkName)
+}
+
+// findSpaceConflistByNetworkName walks the run-path metadata tree
+// (<RunPath>/<metadata>/<realm>/<space>) and returns the network.conflist for
+// the space whose recomputed network name (naming.BuildSpaceNetworkName) equals
+// networkName. Returns an error when no space dir matches or none carries a
+// conflist on disk.
+func (r *Exec) findSpaceConflistByNetworkName(networkName string) (string, error) {
+	metaRoot := fs.MetadataRoot(r.opts.RunPath)
+	realmEntries, err := os.ReadDir(metaRoot)
+	if err != nil {
+		return "", err
+	}
+	for _, realmEntry := range realmEntries {
+		if !realmEntry.IsDir() {
+			continue
+		}
+		realmName := realmEntry.Name()
+		spaceEntries, rerr := os.ReadDir(fs.RealmMetadataDir(r.opts.RunPath, realmName))
+		if rerr != nil {
+			continue
+		}
+		for _, spaceEntry := range spaceEntries {
+			if !spaceEntry.IsDir() {
+				continue
+			}
+			spaceName := spaceEntry.Name()
+			candidate, nerr := naming.BuildSpaceNetworkName(realmName, spaceName)
+			if nerr != nil || candidate != networkName {
+				continue
+			}
+			confPath, perr := fs.SpaceNetworkConfigPath(r.opts.RunPath, realmName, spaceName)
+			if perr != nil {
+				continue
+			}
+			if _, statErr := os.Stat(confPath); statErr == nil {
+				return confPath, nil
+			}
+		}
+	}
+	return "", fmt.Errorf("CNI config not found in run path for network %q", networkName)
 }
 
 // getContainerNetnsPath attempts to get the network namespace path for a container.

--- a/internal/controller/runner/helpers_test.go
+++ b/internal/controller/runner/helpers_test.go
@@ -20,6 +20,7 @@
 package runner
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
@@ -35,6 +36,8 @@ import (
 	"github.com/eminwux/kukeon/internal/cni"
 	"github.com/eminwux/kukeon/internal/errdefs"
 	intmodel "github.com/eminwux/kukeon/internal/modelhub"
+	"github.com/eminwux/kukeon/internal/util/fs"
+	"github.com/eminwux/kukeon/internal/util/naming"
 	v1beta1 "github.com/eminwux/kukeon/pkg/api/model/v1beta1"
 )
 
@@ -165,6 +168,18 @@ func TestBuildRootCNINetworkName_DeterministicWhenSpaceMissing(t *testing.T) {
 	if got != want {
 		t.Errorf("buildRootCNINetworkName() = %q, want %q when space metadata is absent", got, want)
 	}
+}
+
+// TestMain default-stubs the package iptables shell-out (cniIptablesRun) so no
+// unit test that reaches the #1324 masquerade-chain sweep via purgeCNIForContainer
+// ever touches the host firewall. The erroring stub makes the sweep find nothing
+// and append no marker. Tests that assert on the sweep itself
+// (TestSweepCNIMasqChain*) install their own recording fake over this default.
+func TestMain(m *testing.M) {
+	cniIptablesRun = func(_ context.Context, _ ...string) ([]byte, error) {
+		return nil, errors.New("iptables stubbed in test")
+	}
+	os.Exit(m.Run())
 }
 
 // TestContainsExactContainerID covers the safety-net matcher every CNI/IPAM
@@ -361,5 +376,266 @@ func TestPurgeCNIForContainer_CallsDelWithEmptyNetns(t *testing.T) {
 	}
 	if !strings.Contains(string(calls), "DEL") {
 		t.Fatalf("expected a DEL invocation recorded, got %q", string(calls))
+	}
+}
+
+// TestFindCNIConfigPath_ResolvesRunPathConflist is the core regression guard for
+// issue #1324. Space conflists are written per-space as
+// <RunPath>/<metadata>/<realm>/<space>/network.conflist, never as
+// <networkName>.conflist under CniConfigDir — so the old findCNIConfigPath
+// (which only ever checked the CniConfigDir standard location and had an
+// unimplemented run-path fallback) always missed for space networks, silently
+// skipping the CNI DEL and leaking the bridge plugin's per-container masquerade
+// nat chains on every networked-cell purge. The realm name here carries a '-'
+// to exercise the no-reverse-split resolution (the network name "<realm>-<space>"
+// is matched by recomputing it per space dir, not by splitting on '-').
+func TestFindCNIConfigPath_ResolvesRunPathConflist(t *testing.T) {
+	const (
+		realmName = "dev-init-attach" // '-' in realm name: name is not reversible by split
+		spaceName = "ds"
+	)
+	runPath := t.TempDir()
+	confPath, err := fs.SpaceNetworkConfigPath(runPath, realmName, spaceName)
+	if err != nil {
+		t.Fatalf("SpaceNetworkConfigPath: %v", err)
+	}
+	if err = os.MkdirAll(filepath.Dir(confPath), 0o750); err != nil {
+		t.Fatalf("mkdir conflist dir: %v", err)
+	}
+	if err = os.WriteFile(confPath, []byte(`{"cniVersion":"0.4.0","name":"dev-init-attach-ds","plugins":[]}`), 0o600); err != nil {
+		t.Fatalf("write conflist: %v", err)
+	}
+
+	// Empty CniConfigDir so the standard-location lookup misses and the run-path
+	// fallback is the only thing that can resolve the conflist.
+	emptyConfDir := t.TempDir()
+	r := &Exec{
+		ctx:     context.Background(),
+		logger:  slog.New(slog.NewTextHandler(io.Discard, nil)),
+		opts:    Options{RunPath: runPath},
+		cniConf: &cni.Conf{CniConfigDir: emptyConfDir, CniBinDir: emptyConfDir, CniCacheDir: emptyConfDir},
+	}
+
+	networkName, err := naming.BuildSpaceNetworkName(realmName, spaceName)
+	if err != nil {
+		t.Fatalf("BuildSpaceNetworkName: %v", err)
+	}
+	got, err := r.findCNIConfigPath(networkName)
+	if err != nil {
+		t.Fatalf("findCNIConfigPath(%q) returned error: %v", networkName, err)
+	}
+	if got != confPath {
+		t.Fatalf("findCNIConfigPath(%q) = %q, want run-path conflist %q", networkName, got, confPath)
+	}
+
+	// A network with no matching space dir must still error (the lookup must not
+	// resolve to an unrelated space's conflist).
+	if _, err = r.findCNIConfigPath("no-such-network"); err == nil {
+		t.Fatalf("findCNIConfigPath(no-such-network) = nil error, want not-found")
+	}
+}
+
+// TestPurgeCNIForContainer_RunPathConflistRunsDEL is the end-to-end #1324 guard:
+// with the conflist present ONLY at the per-space run path (and the CniConfigDir
+// standard location empty), purgeCNIForContainer must resolve it via the
+// fallback and actually run the CNI DEL, recording "cni-del" in the purge result
+// rather than a silent skip. A fake CNI plugin records the DEL invocation.
+func TestPurgeCNIForContainer_RunPathConflistRunsDEL(t *testing.T) {
+	const (
+		realmName   = "default"
+		spaceName   = "myspace"
+		containerID = "cid-100"
+	)
+	networkName, err := naming.BuildSpaceNetworkName(realmName, spaceName)
+	if err != nil {
+		t.Fatalf("BuildSpaceNetworkName: %v", err)
+	}
+
+	binDir := t.TempDir()
+	cacheDir := t.TempDir()
+	emptyConfDir := t.TempDir() // CniConfigDir intentionally empty: forces the run-path fallback.
+
+	// Fake CNI plugin: records each invocation's CNI_COMMAND to a marker file.
+	markerPath := filepath.Join(t.TempDir(), "del-calls")
+	pluginScript := "#!/bin/sh\nprintf '%s\\n' \"$CNI_COMMAND\" >> \"" + markerPath + "\"\nexit 0\n"
+	if err = os.WriteFile(filepath.Join(binDir, "recorddel"), []byte(pluginScript), 0o755); err != nil {
+		t.Fatalf("write fake plugin: %v", err)
+	}
+
+	// Conflist lives ONLY at the per-space run path — the exact on-disk layout
+	// that made findCNIConfigPath miss before this fix.
+	runPath := t.TempDir()
+	confPath, err := fs.SpaceNetworkConfigPath(runPath, realmName, spaceName)
+	if err != nil {
+		t.Fatalf("SpaceNetworkConfigPath: %v", err)
+	}
+	if err = os.MkdirAll(filepath.Dir(confPath), 0o750); err != nil {
+		t.Fatalf("mkdir conflist dir: %v", err)
+	}
+	conflist := `{
+  "cniVersion": "0.4.0",
+  "name": "` + networkName + `",
+  "plugins": [ { "type": "recorddel" } ]
+}`
+	if err = os.WriteFile(confPath, []byte(conflist), 0o600); err != nil {
+		t.Fatalf("write conflist: %v", err)
+	}
+
+	var logBuf bytes.Buffer
+	r := &Exec{
+		ctx:     context.Background(),
+		logger:  slog.New(slog.NewTextHandler(&logBuf, nil)),
+		opts:    Options{RunPath: runPath},
+		cniConf: &cni.Conf{CniConfigDir: emptyConfDir, CniBinDir: binDir, CniCacheDir: cacheDir},
+	}
+
+	if err = r.purgeCNIForContainer(containerID, "", networkName); err != nil {
+		t.Fatalf("purgeCNIForContainer returned error: %v", err)
+	}
+
+	// DEL must have fired through the run-path conflist.
+	calls, err := os.ReadFile(markerPath)
+	if err != nil {
+		t.Fatalf("CNI DEL was not invoked via run-path conflist (marker file absent): %v", err)
+	}
+	if !strings.Contains(string(calls), "DEL") {
+		t.Fatalf("expected a DEL invocation recorded, got %q", string(calls))
+	}
+	// The purge result must record a real cni-del, not a skip/failure.
+	logged := logBuf.String()
+	if !strings.Contains(logged, "cni-del") || strings.Contains(logged, "cni-del-skipped") ||
+		strings.Contains(logged, "cni-del-failed") {
+		t.Fatalf("purge result did not record a clean cni-del: %s", logged)
+	}
+}
+
+// TestPurgeCNIForContainer_SurfacesSkippedDEL covers AC #2: a skipped CNI DEL
+// (conflist resolvable nowhere) must surface above Debug (Warn) and be reflected
+// in the purge result, not swallowed and reported as a clean purge (#1324).
+func TestPurgeCNIForContainer_SurfacesSkippedDEL(t *testing.T) {
+	emptyDir := t.TempDir()
+	var logBuf bytes.Buffer
+	r := &Exec{
+		ctx:    context.Background(),
+		logger: slog.New(slog.NewTextHandler(&logBuf, nil)),
+		// RunPath points at a tree with no metadata, so the run-path fallback
+		// also misses and the DEL is genuinely unresolvable.
+		opts:    Options{RunPath: t.TempDir()},
+		cniConf: &cni.Conf{CniConfigDir: emptyDir, CniBinDir: emptyDir, CniCacheDir: emptyDir},
+	}
+
+	if err := r.purgeCNIForContainer("cid-100", "", "default-myspace"); err != nil {
+		t.Fatalf("purgeCNIForContainer returned error: %v", err)
+	}
+
+	logged := logBuf.String()
+	if !strings.Contains(logged, "level=WARN") {
+		t.Fatalf("expected a WARN log for the skipped DEL, got: %s", logged)
+	}
+	if !strings.Contains(logged, "cni-del-skipped:config-not-found") {
+		t.Fatalf("expected purge result to record cni-del-skipped:config-not-found, got: %s", logged)
+	}
+}
+
+// TestCNIMasqChainName pins the per-container masquerade chain-name replica used
+// by the purge sweep against golden values captured from live-created chains in
+// the #1324 dev-init repro. cniMasqChainName must equal utils.FormatChainName
+// from github.com/containernetworking/plugins byte-for-byte, or the sweep would
+// target the wrong (or no) chain and the masquerade nat rules would still leak.
+func TestCNIMasqChainName(t *testing.T) {
+	tests := []struct {
+		network     string
+		containerID string
+		want        string
+	}{
+		{"default-default", "default_default_natleak-test_root", "CNI-e12a15b29243523ec04d02b9"},
+		{"dev-init-attach-ds", "ds_dks_cattach_root", "CNI-ec12256cec4057b1122e3662"},
+	}
+	for _, tt := range tests {
+		if got := cniMasqChainName(tt.network, tt.containerID); got != tt.want {
+			t.Errorf("cniMasqChainName(%q, %q) = %q, want %q", tt.network, tt.containerID, got, tt.want)
+		}
+	}
+}
+
+// TestSweepCNIMasqChain is the regression guard for the #1324 belt-and-suspenders
+// sweep: on the purge path the bridge plugin's empty-netns DEL never reaches its
+// ipMasq teardown, so the masquerade chain + its POSTROUTING jumps must be
+// removed directly. It injects a fake iptables runner and asserts the sweep
+// discovers the jumps, deletes them by line number (descending so earlier
+// deletes don't renumber later ones), then flushes and deletes the chain.
+func TestSweepCNIMasqChain(t *testing.T) {
+	const (
+		network     = "default-default"
+		containerID = "default_default_natleak-test_root"
+	)
+	chain := cniMasqChainName(network, containerID) // CNI-e12a15b29243523ec04d02b9
+
+	// Canned `iptables -t nat -L POSTROUTING --line-numbers -n`: two rules jump
+	// to our chain (lines 2 and 4); the header rows and unrelated rules must be
+	// ignored.
+	listOutput := strings.Join([]string{
+		"Chain POSTROUTING (policy ACCEPT)",
+		"num  target          prot opt source       destination",
+		"1    KUKEON-FORWARD  all  --  0.0.0.0/0    0.0.0.0/0",
+		"2    " + chain + "  all  --  10.89.0.36   0.0.0.0/0",
+		"3    OTHER-CHAIN     all  --  0.0.0.0/0    0.0.0.0/0",
+		"4    " + chain + "  all  --  10.88.0.36   0.0.0.0/0",
+		"",
+	}, "\n")
+
+	var calls [][]string
+	prev := cniIptablesRun
+	cniIptablesRun = func(_ context.Context, args ...string) ([]byte, error) {
+		calls = append(calls, args)
+		if len(args) >= 3 && args[2] == "-L" {
+			return []byte(listOutput), nil
+		}
+		return nil, nil
+	}
+	t.Cleanup(func() { cniIptablesRun = prev })
+
+	r := &Exec{ctx: context.Background(), logger: slog.New(slog.NewTextHandler(io.Discard, nil))}
+	marker := r.sweepCNIMasqChain(network, containerID)
+
+	if want := "cni-masq-swept:" + chain; marker != want {
+		t.Fatalf("marker = %q, want %q", marker, want)
+	}
+
+	wantSeq := [][]string{
+		{"-t", "nat", "-L", "POSTROUTING", "--line-numbers", "-n"},
+		{"-t", "nat", "-D", "POSTROUTING", "4"}, // descending: line 4 before line 2
+		{"-t", "nat", "-D", "POSTROUTING", "2"},
+		{"-t", "nat", "-F", chain},
+		{"-t", "nat", "-X", chain},
+	}
+	if len(calls) != len(wantSeq) {
+		t.Fatalf("issued %d iptables calls, want %d: %v", len(calls), len(wantSeq), calls)
+	}
+	for i := range wantSeq {
+		if strings.Join(calls[i], " ") != strings.Join(wantSeq[i], " ") {
+			t.Errorf("call %d = %v, want %v", i, calls[i], wantSeq[i])
+		}
+	}
+}
+
+// TestSweepCNIMasqChain_NoChainNoMarker covers the common post-live-netns-DEL
+// case: the chain is already gone, so the sweep finds no jumps, its flush/delete
+// no-op, and it returns "" (no false "swept" marker in the purge result).
+func TestSweepCNIMasqChain_NoChainNoMarker(t *testing.T) {
+	prev := cniIptablesRun
+	cniIptablesRun = func(_ context.Context, args ...string) ([]byte, error) {
+		if len(args) >= 3 && args[2] == "-L" {
+			// POSTROUTING with no rule jumping to our chain.
+			return []byte("Chain POSTROUTING (policy ACCEPT)\nnum  target\n1    KUKEON-FORWARD\n"), nil
+		}
+		// -F / -X on an absent chain fail, like real iptables.
+		return nil, errors.New("iptables: No chain/target/match by that name")
+	}
+	t.Cleanup(func() { cniIptablesRun = prev })
+
+	r := &Exec{ctx: context.Background(), logger: slog.New(slog.NewTextHandler(io.Discard, nil))}
+	if marker := r.sweepCNIMasqChain("default-default", "default_default_natleak-test_root"); marker != "" {
+		t.Fatalf("marker = %q, want empty (chain already gone)", marker)
 	}
 }


### PR DESCRIPTION
## Summary

Purging a CNI-networked cell (directly or via cascade realm purge) left the bridge plugin's per-container `CNI-<hash>` masquerade chain and its `POSTROUTING -s <podIP>` jump stranded in the host `nat` table, accumulating on every networked-cell purge (issue #1324). This PR fixes it in three parts:

1. **`findCNIConfigPath` run-path fallback** (`helpers.go`). The documented-but-unimplemented fallback now resolves the per-space conflist at `<RunPath>/<metadata>/<realm>/<space>/network.conflist`. Space conflists are never written as `<networkName>.conflist` under `CniConfigDir`, so the old lookup always missed for space networks and the CNI DEL was silently skipped. Resolution enumerates realm/space dirs and matches by the recomputed network name (robust to `-` in realm/space names, unlike reverse-splitting `<realm>-<space>`). Keeps the signature unchanged so all ~15 `purgeCNIForContainer` callers benefit at once — lowest blast radius.

2. **Surface skipped/failed CNI DEL** (`runCNIDel` in `helpers.go`). Every non-success DEL path (conflist not found, manager build error, config-list load error, DEL failure) now logs at **Warn** (was Debug or fully swallowed) and records its outcome (`cni-del-skipped:*` / `cni-del-failed`) in the purge result instead of reporting a clean purge.

3. **Belt-and-suspenders masquerade-chain sweep** (`sweepCNIMasqChain` in `helpers.go`). After the DEL, directly remove the deterministic `CNI-<FormatChainName(network, containerID)>` chain and its `POSTROUTING` jumps. **See the premise-rot note below — this turned out to be required, not optional.**

### Premise-rot finding (documented per dev CLAUDE.md)

The issue diagnosed the leak as purely a conflist-lookup miss (fix #1) and listed the chain sweep (#3) as an optional "consider". Validating fix #1 on-device surfaced a **deeper root cause**: even when the DEL runs and returns success (`purged=[cni-del]`), the masquerade chain still leaks on the purge path. The bridge plugin's `cmdDel` (`containernetworking/plugins@v1.9.0` bridge.go:788-789) early-returns after the IPAM release when invoked with an **empty netns** — never reaching its `TeardownIPMasqForNetworks` call. On the purge path the container task is already gone, so the DEL always runs with an empty netns. I confirmed live: a live-netns DEL (`kuke stop`) cleans the chain; the empty-netns DEL (`kuke purge`) does not. So fix #1+#2 satisfy AC #2 but **cannot** satisfy AC #1 alone — the sweep (#3) is the only thing that reclaims the chain when there is no live netns. The underlying intent (no leaked nat rules after purge) is unchanged, so I implemented #3 as a core part of the fix rather than stalling.

### Design calls (for reviewer pushback)

- **Shell out to iptables rather than import `containernetworking/plugins`.** `ip.TeardownIPMasqForNetworks` would be the exact teardown, but `plugins` is not a current dependency and would pull a new closure (`plugins` + `coreos/go-iptables`) for three commands. The project's established convention (`internal/netpolicy.IptablesEnforcer`) shells out to `iptables` via `exec.Command`; the sweep matches that. Adopting a new dependency is a call I avoided making unilaterally.
- **Deterministic chain-name replica.** `cniMasqChainName` reproduces `utils.FormatChainName` (`"CNI-" + hex(sha512(network+containerID))[:24]`). Verified byte-for-byte against two live-created chains in `TestCNIMasqChainName` (golden values), including the issue's exact `CNI-ec12256cec4057b1122e3662`.
- **Jump removal by line number**, parsed from `iptables -L POSTROUTING --line-numbers -n` and deleted descending — robust to the rule's source IP and comment text, no IP capture or comment-string matching required.

## Test plan

- [x] `make test` (full CI suite: `test-root` + `test-kukebuild`) — pass
- [x] `pre-commit run --files <changed>` — pass (golangci-lint incl. `gochecknoglobals` nolint, gofmt, addlicense)
- [x] New unit tests (`internal/controller/runner/helpers_test.go`):
  - `TestFindCNIConfigPath_ResolvesRunPathConflist` — run-path fallback resolves the per-space conflist (realm name with `-` exercises no-reverse-split)
  - `TestPurgeCNIForContainer_RunPathConflistRunsDEL` — DEL fires via the run-path conflist and records `cni-del` (fake CNI plugin)
  - `TestPurgeCNIForContainer_SurfacesSkippedDEL` — skipped DEL surfaces at Warn + `cni-del-skipped:config-not-found`
  - `TestCNIMasqChainName` — chain-name replica matches live chains (golden)
  - `TestSweepCNIMasqChain` / `_NoChainNoMarker` — sweep deletes jumps (descending) + flush/delete chain; no false marker when chain absent
  - `TestMain` default-stubs the iptables shell-out so no unit test touches the host firewall
- [x] **On-device end-to-end** (`KUKEON_PROFILE=dev make dev-init`, exit 0):
  - Clean cell create→start→purge (`natleak3`): chain `CNI-fa5b2f0a...` + `POSTROUTING` jump fully reclaimed; daemon log: `purged="[cni-del cni-masq-swept:CNI-fa5b2f0a6a8eeb62a3411ecd]"`
  - **Cascade realm purge** (dev-init attach-smoke `dev-init-attach/ds/dks/cattach`): the issue's exact persistent leak `CNI-ec12256cec4057b1122e3662` swept; `iptables -t nat -S` shows no `dev-init-attach` residue
  - Daemon-parity tail + attach smoke pass

## Acceptance criteria

- [x] After `kuke purge` (cell, and cascade realm) of a CNI-networked cell, `iptables -t nat -S` contains no residual `CNI-<hash>` chain or `POSTROUTING -s <podIP> -j CNI-<hash>` rule for the purged cell — validated on-device for both paths.
- [x] The purge log/result reflects a real CNI DEL (`cni-del` in the purged list) for networked cells, and a failed/skipped DEL is surfaced above Debug (Warn).
- [x] A regression test covers the resolution + sweep (iptables-free unit tests asserting `findCNIConfigPath` resolves the run-path conflist, `purgeCNIForContainer` records `cni-del`, and the masquerade-chain sweep issues the expected delete/flush/delete sequence), plus on-device validation of the full create→purge→no-leaked-nat-rule cycle.

## Out of scope

- Retroactive GC of chains leaked by pre-fix purges (the fix prevents new leaks; it does not reclaim historical orphans the issue did not ask to GC).
- Host connectivity / `KUKEON-EGRESS`/`KUKEON-FORWARD` (verified healthy).
- The already-fixed netns-gating (#1174) and daemon-netns (#1219) DEL paths.

Closes #1324