### PR TITLE
fix: bind KUKE_CONFIGURATION env so in-process image verbs honor the dev-profile suffix

### DIFF
--- a/cmd/kuke/clientconfig_test.go
+++ b/cmd/kuke/clientconfig_test.go
@@ -277,6 +277,57 @@ spec:
 	}
 }
 
+// TestLoadClientConfigurationHonorsKukeConfigurationEnv pins the #1325 fix:
+// the dev-init mechanism points in-process client commands at the dev-profile
+// config via the KUKE_CONFIGURATION *env var* (not the --configuration flag),
+// so loadClientConfiguration must bind that env before reading the path. The
+// sibling TestLoadClientConfigurationSeedsViper seeds the viper key directly,
+// which masked the missing BindEnv: with the env var alone, the daemon-
+// independent `kuke image *` / `kuke get image*` paths resolved the default
+// `.kukeon.io` suffix instead of the configured `dev.kukeon.io`.
+func TestLoadClientConfigurationHonorsKukeConfigurationEnv(t *testing.T) {
+	t.Cleanup(viper.Reset)
+	restoreRuntimeGlobals(t)
+
+	viper.Reset()
+	cmd, err := NewKukeCmd()
+	if err != nil {
+		t.Fatalf("NewKukeCmd() error = %v", err)
+	}
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "kuke-dev.yaml")
+	content := `apiVersion: v1beta1
+kind: ClientConfiguration
+metadata:
+  name: default
+spec:
+  containerdNamespaceSuffix: dev.kukeon.io
+  cgroupRoot: /kukeon-dev
+`
+	if writeErr := os.WriteFile(path, []byte(content), 0o644); writeErr != nil {
+		t.Fatalf("WriteFile: %v", writeErr)
+	}
+	// Drive the path through the env var only — no viper.Set, no --configuration
+	// flag — exactly how scripts/dev-init.sh invokes every `kuke` client command.
+	t.Setenv(config.KUKE_CONFIGURATION.EnvVar(), path)
+
+	if loadErr := loadClientConfiguration(cmd); loadErr != nil {
+		t.Fatalf("loadClientConfiguration() error = %v", loadErr)
+	}
+	if got := viper.GetString(config.KUKEON_ROOT_NAMESPACE_SUFFIX.ViperKey); got != "dev.kukeon.io" {
+		t.Errorf("ContainerdNamespaceSuffix from KUKE_CONFIGURATION env: got %q, want %q "+
+			"(loadClientConfiguration must BindEnv before reading the path)", got, "dev.kukeon.io")
+	}
+	// The package-level suffix is what consts.RealmNamespace appends, so the
+	// in-process image controller resolves <realm>.dev.kukeon.io only when
+	// ConfigureRuntime observed the env-supplied config.
+	if got, want := consts.RealmNamespace("kuke-system"), "kuke-system.dev.kukeon.io"; got != want {
+		t.Errorf("consts.RealmNamespace: got %q, want %q "+
+			"(image verbs must resolve the env-configured suffix)", got, want)
+	}
+}
+
 // TestMaybeWriteClientConfigurationDefaultSkipsCustomPath locks the guard
 // that prevents tests (and operators pointing --configuration at a custom
 // location) from writing to ~/.kuke/kuke.yaml on the host. The path-equality

--- a/cmd/kuke/kuke.go
+++ b/cmd/kuke/kuke.go
@@ -284,6 +284,19 @@ func LoadConfig() error {
 // PersistentPreRunE so every subcommand sees the seeded defaults before
 // reading viper.
 func loadClientConfiguration(cmd *cobra.Command) error {
+	// Bind the KUKE_CONFIGURATION env var to viper before reading the path.
+	// The `--configuration` flag is bound in SetPersistentLoggingFlags, but
+	// without this env binding `viper.GetString` only ever sees the flag (and
+	// its default ~/.kuke/kuke.yaml) — so `KUKE_CONFIGURATION=<dev config>`,
+	// the mechanism scripts/dev-init.sh uses to point every in-process client
+	// command at the dev-profile config, was silently ignored. That left the
+	// daemon-independent `kuke image *` / `kuke get image*` paths (#217/#226)
+	// resolving the default `.kukeon.io` suffix while daemon-routed kinds
+	// (get realms) reflected the daemon's own dev config and looked correct,
+	// masking the gap (#1325). BindEnv runs here, ahead of the path read,
+	// because loadClientConfiguration is invoked from PersistentPreRunE before
+	// loadConfig's other BindEnv calls.
+	_ = config.KUKE_CONFIGURATION.BindEnv()
 	path := viper.GetString(config.KUKE_CONFIGURATION.ViperKey)
 	if path == "" {
 		path = config.DefaultClientConfigurationFile()

--- a/scripts/dev-init.sh
+++ b/scripts/dev-init.sh
@@ -330,9 +330,9 @@ EOF
     fi
 
     # KUKE_CONFIGURATION is bound to viper for every `kuke` subcommand
-    # (KUKE_CONFIGURATION.BindEnv in cmd/kuke/kuke.go's loadConfig), so
-    # exporting it here routes every client invocation below through the
-    # dev-profile client config. sudo invocations must add KUKE_CONFIGURATION
+    # (KUKE_CONFIGURATION.BindEnv in cmd/kuke/kuke.go's loadClientConfiguration,
+    # ahead of the path read), so exporting it here routes every client
+    # invocation below through the dev-profile client config. sudo invocations must add KUKE_CONFIGURATION
     # to --preserve-env=... or the value is stripped at the sudo boundary.
     export KUKE_CONFIGURATION="${DEV_PROFILE_CLIENT_CONFIG}"
 


### PR DESCRIPTION
## Summary

Under `KUKEON_PROFILE=dev`, `kuke image *` / `kuke get image*` ignored the configured `containerdNamespaceSuffix` and resolved the default `<realm>.kukeon.io` namespace, so the daemon's own images (in `<realm>.dev.kukeon.io`) were invisible and `image load`/`prune`/`delete` landed in a parallel, unused namespace.

**Verified root cause — differs from the issue's hypothesis.** The issue speculated the image command tree bypasses the root `PersistentPreRunE`, or that namespace resolution is captured before `ConfigureRuntime` runs, and explicitly asked the implementer to confirm. Neither holds: the image trees register no `PersistentPreRunE`, so the root's runs for them, and resolution is per-call. The real cause is that **`KUKE_CONFIGURATION` was never bound to viper** (`git log -S` confirms it never existed). `loadClientConfiguration` reads the config path via `viper.GetString(config.KUKE_CONFIGURATION.ViperKey)`, which only had a `BindPFlag` for `--configuration` (default `~/.kuke/kuke.yaml`). So `KUKE_CONFIGURATION=<dev config>` — the env var `scripts/dev-init.sh` exports to point every in-process client command at the dev config — was silently dropped, the dev config was never read, and the suffix stayed `.kukeon.io`. Daemon-routed kinds (`get realms`) reflected the daemon's *own* dev config and looked correct, masking the gap exactly as the issue describes.

Empirically confirmed with a viper probe: an unbound key returns the flag default and ignores the env var; `BindEnv` makes the env win over an unchanged flag's default (correct precedence: explicit flag > env > flag default).

### Fix
- `cmd/kuke/kuke.go`: call `config.KUKE_CONFIGURATION.BindEnv()` at the top of `loadClientConfiguration`, **before** the path read. It must live here (not in `loadConfig`, where the other `BindEnv` calls are) because `loadClientConfiguration` runs earlier in `PersistentPreRunE`.
- `cmd/kuke/clientconfig_test.go`: regression test driving the path through the **env var only** (`t.Setenv`, no `viper.Set`/flag) — the sibling `…SeedsViper` test seeded the viper key directly, which is precisely why this slipped through. Asserts both the suffix viper key and `consts.RealmNamespace("kuke-system") == "kuke-system.dev.kukeon.io"`.
- `scripts/dev-init.sh`: corrected an inline comment that asserted this binding already existed "in loadConfig" — it pointed at the wrong function and the binding it claimed was in fact absent. Now points at `loadClientConfiguration` ahead of the path read.

This is a root-cause fix at the env-binding layer rather than threading the suffix into the image controller specifically (the issue's Proposal item 1 offered either). It also makes other in-process client paths (e.g. `--no-daemon` workloads) honor a `KUKE_CONFIGURATION`-supplied config, which is the documented dev-init contract. **Proposal item 2 (a `--containerd-namespace-suffix` escape-hatch flag on the image commands) is intentionally not implemented** — the issue marked it "if one is intended" and none of the AC items require it; the lower-blast-radius reading is to fix the binding and skip the new flag surface.

## Test plan
- [x] `GOWORK=off go test ./cmd/kuke/ -run TestLoadClientConfiguration -v` — new + existing pass
- [x] Confirmed the new test **fails without the fix** (reproduces the issue: `got "kuke-system.kukeon.io", want "kuke-system.dev.kukeon.io"`) and passes with it
- [x] `GOWORK=off go build ./...` (exit 0)
- [x] `GOWORK=off go test $(go list ./... | grep -v /e2e)` — full suite, 0 failures, exit 0
- [x] `cd cmd/kukebuild && GOWORK=off go test ./...` (exit 0)
- [x] `GOWORK=off go vet ./cmd/kuke/` (exit 0)
- [x] `pre-commit run --files …` — all hooks pass (golangci-lint, go fmt, addlicense, …)
- [ ] `make dev-init` dev-profile smoke — not run; the dev daemon / standalone containerd is not provisioned on this host. The fix's observable (suffix resolution from the env-supplied config) is covered by the failing-without-fix regression test above. Note: this fix also repairs the dev-init `--no-daemon` `get realms` parity tail, which depends on the same `KUKE_CONFIGURATION` env binding.

### Note on `GOWORK=off`
The host's go1.25.5 + repo `go.work` trips a pre-existing `containerd/cgroups/v2` compile break unrelated to this change; `GOWORK=off` builds against go.mod's pinned graph (the standard local workaround) and is green.

## Acceptance criteria
- [x] With a dev-suffix client config, `kuke get image[s]` resolves `<realm>.dev.kukeon.io` (suffix + `consts.RealmNamespace` asserted in the regression test; the in-process list/get path reads the same package var)
- [x] `kuke image load --realm <r>` writes to `<realm>.<configured-suffix>` — same `consts.RealmNamespace` resolution (`internal/controller/image.go:175`)
- [x] `kuke image prune` / `kuke image delete` operate on `<realm>.<configured-suffix>` — same resolution (`:212`, `:175`)
- [x] No regression to `<realm>.kukeon.io` when no suffix is configured (unbound/unset env → flag default → existing `…AbsentFileNoError` + `…SeedsViper` tests stay green)

Closes #1325