### PR TITLE
fix: resolve daemon namespace under non-default suffix in kuke status STATE/STORAGE

### DIFF
--- a/cmd/kuke/status/checks.go
+++ b/cmd/kuke/status/checks.go
@@ -26,7 +26,27 @@ import (
 	"time"
 
 	"github.com/eminwux/kukeon/internal/consts"
+	v1beta1 "github.com/eminwux/kukeon/pkg/api/model/v1beta1"
 )
+
+// realmNamespace returns the containerd namespace to attribute to a realm,
+// preferring the daemon-resolved Spec.Namespace over a recomputed
+// consts.RealmNamespace. The recomputation reads the process-global
+// RealmNamespaceSuffix, which the in-process status STATE/STORAGE path does
+// not pick up from a KUKE_CONFIGURATION client config — so under a
+// non-default containerdNamespaceSuffix (the dev profile's dev.kukeon.io) it
+// returns the default-suffix namespace, false-flagging the live
+// *.dev.kukeon.io namespaces as residual and measuring the wrong (empty)
+// namespaces in STORAGE (issue #1326). Spec.Namespace is the same
+// authoritative value the daemon and the PARITY section already use. Falls
+// back to the recomputed form for a realm whose Spec.Namespace is unset
+// (e.g. a hand-built test realm or a pre-Spec.Namespace persisted doc).
+func realmNamespace(r v1beta1.RealmDoc) string {
+	if r.Spec.Namespace != "" {
+		return r.Spec.Namespace
+	}
+	return consts.RealmNamespace(r.Metadata.Name)
+}
 
 // Section names — kept as constants so the renderer's section grouping and
 // the JSON `section` field are spelled the same way everywhere.
@@ -392,7 +412,7 @@ func checkStateNamespaces(ctx context.Context, rc *runCtx) Result {
 	// in this set and falls through to the residual list below (issue #1183).
 	expectedNS := make(map[string]bool, len(realms))
 	for i := range realms {
-		ns := consts.RealmNamespace(realms[i].Metadata.Name)
+		ns := realmNamespace(realms[i])
 		expectedNS[ns] = true
 		expectedNS[consts.BuildKitHistoryNamespace(ns)] = true
 	}

--- a/cmd/kuke/status/status_test.go
+++ b/cmd/kuke/status/status_test.go
@@ -186,6 +186,35 @@ func TestCheckStateNamespaces_LiveRealmHistoryIsClean(t *testing.T) {
 	}
 }
 
+// TestCheckStateNamespaces_DevSuffixNotResidual is the issue #1326 regression
+// guard: under a non-default containerdNamespaceSuffix (the dev profile's
+// dev.kukeon.io), the live *.dev.kukeon.io namespaces the daemon actively uses
+// must not be flagged residual. The check attributes each realm's namespace
+// from its daemon-resolved Spec.Namespace, so the expected set matches the
+// actual namespaces and the dangerous `ctr namespace remove` remediation
+// against live namespaces never fires.
+func TestCheckStateNamespaces_DevSuffixNotResidual(t *testing.T) {
+	rc := &runCtx{
+		daemonClient: newFakeClient().
+			withRealmNamespace("default", "default.dev.kukeon.io").
+			withRealmNamespace("kuke-system", "kuke-system.dev.kukeon.io"),
+		ctrClient: &fakeCtrClient{namespaces: []string{
+			"default.dev.kukeon.io",
+			"kuke-system.dev.kukeon.io",
+			"kuke-system.dev.kukeon.io_history",
+		}},
+		logger: testLogger(),
+	}
+
+	r := checkStateNamespaces(context.Background(), rc)
+	if r.Status != StatusOK {
+		t.Fatalf("dev-suffix live namespaces must not be residual; got %s (%q)", r.Status, r.Detail)
+	}
+	if strings.Contains(r.Detail, "residual") {
+		t.Errorf("Detail must not flag residual namespaces; got %q", r.Detail)
+	}
+}
+
 // TestCheckParity_NestedDescent confirms the walk recurses into the
 // realm-set intersection (spaces / stacks / cells / containers) — a
 // regression in the descent loop would silently stop reporting nested
@@ -609,6 +638,19 @@ func (f *fakeClient) withRealms(names ...string) *fakeClient {
 			Metadata: v1beta1.RealmMetadata{Name: name},
 		})
 	}
+	return f
+}
+
+// withRealmNamespace seeds one realm carrying an explicit daemon-resolved
+// Spec.Namespace — the shape a non-default containerdNamespaceSuffix (the dev
+// profile's dev.kukeon.io) produces. The STATE/STORAGE checks attribute the
+// namespace from Spec.Namespace rather than recomputing it, so this exercises
+// the suffix-aware path (issue #1326).
+func (f *fakeClient) withRealmNamespace(name, namespace string) *fakeClient {
+	f.realms = append(f.realms, v1beta1.RealmDoc{
+		Metadata: v1beta1.RealmMetadata{Name: name},
+		Spec:     v1beta1.RealmSpec{Namespace: namespace},
+	})
 	return f
 }
 

--- a/cmd/kuke/status/storage.go
+++ b/cmd/kuke/status/storage.go
@@ -60,8 +60,8 @@ func checkStorage(ctx context.Context, rc *runCtx) []Result {
 		}}
 	}
 
-	realms := enumerateRealmsForStorage(ctx, rc)
-	if len(realms) == 0 {
+	targets := enumerateRealmsForStorage(ctx, rc)
+	if len(targets) == 0 {
 		return []Result{{
 			Section: sectionStorage,
 			Name:    "realms",
@@ -70,27 +70,44 @@ func checkStorage(ctx context.Context, rc *runCtx) []Result {
 		}}
 	}
 
-	results := make([]Result, 0, len(realms))
-	for _, realm := range realms {
-		results = append(results, storageRowForRealm(rc, realm))
+	results := make([]Result, 0, len(targets))
+	for _, target := range targets {
+		results = append(results, storageRowForRealm(rc, target))
 	}
 	return results
 }
 
-// enumerateRealmsForStorage returns the realm names to probe. Prefers
-// the daemon's ListRealms (canonical source) and falls back to deriving
-// realm names from the ctr namespace list when the daemon is down or
-// listing fails — the section still has something to report, with the
-// daemon-down rationale surfacing on the daemon row above.
-func enumerateRealmsForStorage(ctx context.Context, rc *runCtx) []string {
+// realmStorageTarget pairs a realm's display-name label with the containerd
+// namespace whose footprint the storage row probes. Carrying the namespace
+// explicitly — the daemon-resolved Spec.Namespace on the canonical path, the
+// actual ctr namespace on the fallback — keeps the probe off the recomputed
+// consts.RealmNamespace, which mis-resolves the namespace under a non-default
+// containerdNamespaceSuffix the in-process path never picked up (issue #1326).
+type realmStorageTarget struct {
+	name      string
+	namespace string
+}
+
+// enumerateRealmsForStorage returns the realms to probe, each carrying both
+// the display-name label and the containerd namespace. Prefers the daemon's
+// ListRealms (canonical source) — taking the namespace from the realm's
+// daemon-resolved Spec.Namespace so a non-default containerdNamespaceSuffix
+// is honored (issue #1326) — and falls back to deriving realms from the ctr
+// namespace list when the daemon is down or listing fails, where the actual
+// namespace is the one enumerated. The fallback keeps the section populated,
+// with the daemon-down rationale surfacing on the daemon row above.
+func enumerateRealmsForStorage(ctx context.Context, rc *runCtx) []realmStorageTarget {
 	if rc.daemonClient != nil {
 		realms, err := rc.daemonClient.ListRealms(ctx)
 		if err == nil {
-			out := make([]string, 0, len(realms))
+			out := make([]realmStorageTarget, 0, len(realms))
 			for i := range realms {
-				out = append(out, realms[i].Metadata.Name)
+				out = append(out, realmStorageTarget{
+					name:      realms[i].Metadata.Name,
+					namespace: realmNamespace(realms[i]),
+				})
 			}
-			sort.Strings(out)
+			sortStorageTargets(out)
 			return out
 		}
 	}
@@ -99,14 +116,22 @@ func enumerateRealmsForStorage(ctx context.Context, rc *runCtx) []string {
 	if err != nil {
 		return nil
 	}
-	out := make([]string, 0, len(nsList))
+	out := make([]realmStorageTarget, 0, len(nsList))
 	for _, ns := range nsList {
 		if realm := consts.RealmFromNamespace(ns); realm != "" {
-			out = append(out, realm)
+			out = append(out, realmStorageTarget{name: realm, namespace: ns})
 		}
 	}
-	sort.Strings(out)
+	sortStorageTargets(out)
 	return out
+}
+
+// sortStorageTargets orders targets by their display name so the rendered
+// storage rows stay stable regardless of daemon/ctr enumeration order.
+func sortStorageTargets(targets []realmStorageTarget) {
+	sort.Slice(targets, func(i, j int) bool {
+		return targets[i].name < targets[j].name
+	})
 }
 
 // storageRowForRealm probes one realm's containerd namespace and
@@ -114,13 +139,13 @@ func enumerateRealmsForStorage(ctx context.Context, rc *runCtx) []string {
 // containerd metadata read shouldn't be a regression signal alongside
 // the parity walk's FAIL, and the operator already has the host
 // section's signal.
-func storageRowForRealm(rc *runCtx, realm string) Result {
+func storageRowForRealm(rc *runCtx, target realmStorageTarget) Result {
 	r := Result{
 		Section: sectionStorage,
-		Name:    realm,
+		Name:    target.name,
 	}
 
-	ns := consts.RealmNamespace(realm)
+	ns := target.namespace
 	stats, err := rc.ctrClient.NamespaceStorage(ns)
 	if err != nil {
 		r.Status = StatusWARN

--- a/cmd/kuke/status/storage_test.go
+++ b/cmd/kuke/status/storage_test.go
@@ -86,6 +86,61 @@ func TestCheckStorage_PerRealmRow(t *testing.T) {
 	}
 }
 
+// TestCheckStorage_DevSuffixProbesLiveNamespaces is the issue #1326
+// regression guard for STORAGE: under a non-default
+// containerdNamespaceSuffix (the dev profile's dev.kukeon.io), each row must
+// probe the realm's daemon-resolved Spec.Namespace (*.dev.kukeon.io) — the
+// populated namespaces the daemon and PARITY use — rather than the recomputed
+// default-suffix namespaces, which are empty and report a zero footprint.
+func TestCheckStorage_DevSuffixProbesLiveNamespaces(t *testing.T) {
+	rc := &runCtx{
+		daemonClient: newFakeClient().
+			withRealmNamespace("default", "default.dev.kukeon.io").
+			withRealmNamespace("kuke-system", "kuke-system.dev.kukeon.io"),
+		ctrClient: &fakeCtrClient{
+			namespaces: []string{"default.dev.kukeon.io", "kuke-system.dev.kukeon.io"},
+			storage: map[string]ctr.StorageStats{
+				"default.dev.kukeon.io":     {Snapshots: 3, Leases: 4, Blobs: 5, BlobsBytes: 6 * 1024 * 1024},
+				"kuke-system.dev.kukeon.io": {Snapshots: 7, Leases: 8, Blobs: 9, BlobsBytes: 10 * 1024 * 1024},
+				// Default-suffix namespaces deliberately absent: a recompute
+				// would probe these, miss, and report a zero footprint.
+			},
+		},
+	}
+
+	results := checkStorage(context.Background(), rc)
+	if len(results) != 2 {
+		t.Fatalf("expected one row per realm; got %d (%+v)", len(results), results)
+	}
+
+	byName := map[string]Result{}
+	for _, r := range results {
+		byName[r.Name] = r
+	}
+
+	def, ok := byName["default"]
+	if !ok {
+		t.Fatalf("expected row for default realm; got %+v", byName)
+	}
+	if !strings.Contains(def.Detail, "default.dev.kukeon.io") {
+		t.Errorf("default Detail should name the dev-suffix namespace; got %q", def.Detail)
+	}
+	if def.Storage == nil || def.Storage.Blobs != 5 {
+		t.Errorf("default row should carry the dev-namespace footprint (5 blobs); got %+v", def.Storage)
+	}
+
+	sys, ok := byName["kuke-system"]
+	if !ok {
+		t.Fatalf("expected row for kuke-system realm; got %+v", byName)
+	}
+	if !strings.Contains(sys.Detail, "kuke-system.dev.kukeon.io") {
+		t.Errorf("kuke-system Detail should name the dev-suffix namespace; got %q", sys.Detail)
+	}
+	if sys.Storage == nil || sys.Storage.Blobs != 9 {
+		t.Errorf("kuke-system row should carry the dev-namespace footprint (9 blobs); got %+v", sys.Storage)
+	}
+}
+
 // TestCheckStorage_DaemonDownFallsBackToNamespaces pins the degraded
 // path: a daemon-down run still surfaces per-namespace figures by
 // deriving realm names from the ctr namespace list. The section stays


### PR DESCRIPTION
## Summary

`kuke status` mis-resolved containerd namespaces in its in-process `STATE` and `STORAGE` sections under a non-default `containerdNamespaceSuffix` (the dev profile's `dev.kukeon.io`). Both recomputed the namespace via `consts.RealmNamespace(realm)`, which reads the process-global `RealmNamespaceSuffix`. That global is only set to the dev suffix when `ConfigureRuntime` runs with the client config — which the in-process status path does not pick up — so it stayed at the default `.kukeon.io`:

- **STATE** built the *expected* namespace set with the default suffix, so the live `*.dev.kukeon.io` namespaces the running daemon uses were flagged **residual** with a `ctr -n <ns> namespace remove` remediation — following it would **delete the running daemon's namespaces and data**.
- **STORAGE** probed `<realm>.kukeon.io` (default suffix, empty) instead of the populated `<realm>.dev.kukeon.io`, so the per-realm footprint always read zero.

The `PARITY` section was already correct because it routes through the daemon. This change makes `STATE`/`STORAGE` use the **same daemon-authoritative source `PARITY` uses**: each realm's `Spec.Namespace` (the namespace the daemon resolved at its own startup with the configured suffix) rather than recomputing it in-process.

### Why `Spec.Namespace` rather than the issue's literal proposals
The issue proposed (1) running `ConfigureRuntime` on the status path or (2) making the residual detector "suffix-aware" from the resolved suffix. Investigation showed the deeper root cause is that **`KUKE_CONFIGURATION` is never bound to viper** — `scripts/dev-init.sh:332-333` asserts `KUKE_CONFIGURATION.BindEnv` exists in `cmd/kuke/kuke.go`'s `loadConfig`, but it does not (verified: passing the dev config via the `KUKE_CONFIGURATION` env var is silently ignored, while `--configuration` is honored). So both literal proposals would still read the unconfigured default suffix in-process and **not** fix the bug. Using the realm's daemon-resolved `Spec.Namespace` fixes `STATE`/`STORAGE` precisely, is the lowest-blast-radius change (two localized call sites, no PreRun wiring touched), and is robust regardless of the env-binding gap.

This deeper env-binding gap is the **shared root cause with #1325** (out of scope here per the issue). It is left for the unified fix #1325 contemplates; this PR does not touch the `kuke image*` surface. The unbound-env / false dev-init comment is surfaced here for the reviewer/PM rather than fixed in this scoped PR.

A realm whose `Spec.Namespace` is unset falls back to the recomputed `consts.RealmNamespace(name)`, preserving default-profile behavior.

## Test plan
- [x] `make test-root` (full root module suite) — pass
- [x] `make test-kukebuild` — pass
- [x] `GOWORK=off go test ./cmd/kuke/status/...` — pass, incl. new regression tests
- [x] `GOWORK=off go vet ./cmd/kuke/status/...` — clean
- [x] `pre-commit run --files <changed>` — all hooks pass (gofmt, golangci-lint, addlicense, go-mod-tidy)
- [ ] `KUKEON_PROFILE=dev make dev-init` end-to-end smoke — not run; requires bootstrapping a dev-profile daemon on the host. The change is CLI-only (does not touch the build path, daemon, or `/opt/kukeon`), and the dev-profile `STATE`/`STORAGE` behavior is covered by the two new unit regression tests below.

### New regression tests
- `TestCheckStateNamespaces_DevSuffixNotResidual` — dev-suffix realms + live `*.dev.kukeon.io` ctr namespaces ⇒ STATE is OK, no `residual` flag.
- `TestCheckStorage_DevSuffixProbesLiveNamespaces` — STORAGE probes the realms' `Spec.Namespace` (`*.dev.kukeon.io`) and reports their footprint, not the empty default-suffix namespaces.

## Acceptance criteria
- [x] Dev-suffix client config: STATE does **not** list active `*.dev.kukeon.io` as residual (no dangerous remediation against live namespaces).
- [x] STORAGE reports the footprint of `<realm>.<configured-suffix>` (matches PARITY / the daemon).
- [x] Default profile behavior unchanged (`<realm>.kukeon.io` when no suffix configured) — unset `Spec.Namespace` falls back to `consts.RealmNamespace`; existing tests still green.

Closes #1326
