### PR TITLE
feat: render named kuke get <kind> <name> as a single table row

### DIFF
--- a/cmd/kuke/get/blueprint/blueprint.go
+++ b/cmd/kuke/get/blueprint/blueprint.go
@@ -132,7 +132,7 @@ func NewBlueprintCmd() *cobra.Command {
 	cmd.Flags().String("stack", "", "Filter blueprints by stack name")
 	_ = viper.BindPFlag(config.KUKE_GET_BLUEPRINT_STACK.ViperKey, cmd.Flags().Lookup("stack"))
 	cmd.Flags().
-		StringP("output", "o", "", "Output format (yaml, json, table, wide). Default: table for list, yaml for single resource")
+		StringP("output", "o", "", "Output format (yaml, json, table, wide). Default: table for list, table for single resource")
 	_ = viper.BindPFlag(config.KUKE_GET_OUTPUT.ViperKey, cmd.Flags().Lookup("output"))
 	_ = viper.BindPFlag(config.KUKE_GET_OUTPUT.ViperKey, cmd.Flags().Lookup("o"))
 
@@ -185,10 +185,12 @@ func printBlueprint(cmd *cobra.Command, blueprint *v1beta1.CellBlueprintDoc, for
 	switch format {
 	case shared.OutputFormatJSON:
 		return shared.PrintJSON(cmd, blueprint)
-	case shared.OutputFormatYAML, shared.OutputFormatTable:
+	case shared.OutputFormatYAML:
 		return shared.PrintYAML(cmd, blueprint)
 	default:
-		return shared.PrintYAML(cmd, blueprint)
+		// table / wide: render the single found element as a one-row table
+		// with the same columns as the list view (kubectl parity).
+		return printBlueprints(cmd, []v1beta1.CellBlueprintDoc{*blueprint}, format)
 	}
 }
 

--- a/cmd/kuke/get/blueprint/blueprint_test.go
+++ b/cmd/kuke/get/blueprint/blueprint_test.go
@@ -244,6 +244,77 @@ func TestNewBlueprintCmd(t *testing.T) {
 	}
 }
 
+// TestNewBlueprintCmd_NamedSingleRow pins the #1323 kubectl-parity flip: a
+// named `kuke get blueprint <name>` renders a single table row by default,
+// while `-o yaml` / `-o json` still emit the full document.
+func TestNewBlueprintCmd_NamedSingleRow(t *testing.T) {
+	t.Cleanup(viper.Reset)
+
+	fake := &fakeClient{
+		getBlueprintFn: func(doc v1beta1.CellBlueprintDoc) (kukeonv1.GetBlueprintResult, error) {
+			return kukeonv1.GetBlueprintResult{
+				Blueprint:      v1beta1.CellBlueprintDoc{Metadata: doc.Metadata},
+				MetadataExists: true,
+			}, nil
+		},
+	}
+
+	run := func(t *testing.T, args ...string) string {
+		t.Helper()
+		t.Cleanup(viper.Reset)
+		cmd := blueprint.NewBlueprintCmd()
+		buf := &bytes.Buffer{}
+		cmd.SetOut(buf)
+		cmd.SetErr(buf)
+		ctx := context.WithValue(context.Background(), blueprint.MockControllerKey{}, kukeonv1.Client(fake))
+		cmd.SetContext(ctx)
+		cmd.SetArgs(append([]string{"web"}, args...))
+		if err := cmd.Execute(); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		return buf.String()
+	}
+
+	t.Run("default renders single table row", func(t *testing.T) {
+		out := run(t)
+		for _, col := range []string{"NAME", "REALM", "SPACE", "STACK"} {
+			if !strings.Contains(out, col) {
+				t.Errorf("named default missing column %q; got:\n%s", col, out)
+			}
+		}
+		if !strings.Contains(out, "web") {
+			t.Errorf("expected single row carrying name; got:\n%s", out)
+		}
+		if strings.Contains(out, "metadata:") {
+			t.Errorf("named default must not emit the full document; got:\n%s", out)
+		}
+	})
+
+	t.Run("-o wide renders a single row", func(t *testing.T) {
+		out := run(t, "-o", "wide")
+		if !strings.Contains(out, "NAME") || !strings.Contains(out, "web") {
+			t.Errorf("named wide should render the single row; got:\n%s", out)
+		}
+		if strings.Contains(out, "metadata:") {
+			t.Errorf("named wide must not emit the full document; got:\n%s", out)
+		}
+	})
+
+	t.Run("-o yaml emits the full document", func(t *testing.T) {
+		out := run(t, "-o", "yaml")
+		if !strings.Contains(out, "metadata:") {
+			t.Errorf("-o yaml should emit the document; got:\n%s", out)
+		}
+	})
+
+	t.Run("-o json emits the full document", func(t *testing.T) {
+		out := run(t, "-o", "json")
+		if !strings.Contains(out, "\"metadata\"") {
+			t.Errorf("-o json should emit the document; got:\n%s", out)
+		}
+	})
+}
+
 type fakeClient struct {
 	kukeonv1.FakeClient
 

--- a/cmd/kuke/get/cell/cell.go
+++ b/cmd/kuke/get/cell/cell.go
@@ -146,7 +146,7 @@ table — surface it with ` + "`-o yaml` / `-o json`" + ` when needed.`,
 				if !result.MetadataExists {
 					return fmt.Errorf("cell %q not found in stack %q/%q/%q", name, realm, space, stack)
 				}
-				return printCell(cmd, &result.Cell, outputFormat)
+				return printCell(cmd, &result.Cell, outputFormat, wide)
 			}
 
 			cells, err := client.ListCells(cmd.Context(), realm, space, stack)
@@ -165,7 +165,7 @@ table — surface it with ` + "`-o yaml` / `-o json`" + ` when needed.`,
 	cmd.Flags().String("stack", "", "Filter cells by stack name")
 	_ = viper.BindPFlag(config.KUKE_GET_CELL_STACK.ViperKey, cmd.Flags().Lookup("stack"))
 	cmd.Flags().
-		StringP("output", "o", "", "Output format (yaml, json, table, wide). Default: table for list, yaml for single resource")
+		StringP("output", "o", "", "Output format (yaml, json, table, wide). Default: table for list, table for single resource")
 	_ = viper.BindPFlag(config.KUKE_GET_OUTPUT.ViperKey, cmd.Flags().Lookup("output"))
 	_ = viper.BindPFlag(config.KUKE_GET_OUTPUT.ViperKey, cmd.Flags().Lookup("o"))
 
@@ -276,12 +276,18 @@ func filterCellsBySelector(cells []v1beta1.CellDoc, selector *shared.LabelSelect
 	return out
 }
 
-func printCell(cmd *cobra.Command, cell *v1beta1.CellDoc, format shared.OutputFormat) error {
+func printCell(cmd *cobra.Command, cell *v1beta1.CellDoc, format shared.OutputFormat, wide bool) error {
 	switch format {
 	case shared.OutputFormatJSON:
 		return shared.PrintJSON(cmd, cell)
-	default:
+	case shared.OutputFormatYAML:
 		return shared.PrintYAML(cmd, cell)
+	default:
+		// table / wide: render the single found element as a one-row table
+		// with the same columns as the list view (kubectl parity). `wide`
+		// is carried separately because resolveOutput normalises `wide` to
+		// `table` plus a bool.
+		return printCells(cmd, []v1beta1.CellDoc{*cell}, format, wide)
 	}
 }
 

--- a/cmd/kuke/get/cell/cell_test.go
+++ b/cmd/kuke/get/cell/cell_test.go
@@ -141,6 +141,84 @@ func TestNewCellCmd(t *testing.T) {
 // TestNewCellCmd_DefaultColumns pins the default `kuke get cell` column set
 // after #929 restored SYNC: NAME REALM SPACE STACK STATE SYNC AGE — seven
 // columns, no CGROUP / CONTROLLERS / CONTAINERS / BRIDGE / DIVERGENCE.
+// TestNewCellCmd_NamedSingleRow pins the #1323 kubectl-parity flip: a named
+// `kuke get cell <name>` renders a single table row by default (and the wide
+// row with `-o wide`), while `-o yaml` / `-o json` still emit the full
+// document.
+func TestNewCellCmd_NamedSingleRow(t *testing.T) {
+	t.Cleanup(viper.Reset)
+
+	fake := &fakeClient{
+		getCellFn: func(_ v1beta1.CellDoc) (kukeonv1.GetCellResult, error) {
+			return kukeonv1.GetCellResult{
+				Cell: v1beta1.CellDoc{
+					Metadata: v1beta1.CellMetadata{Name: "ce1"},
+					Spec:     v1beta1.CellSpec{RealmID: "r1", SpaceID: "s1", StackID: "st1"},
+					Status:   v1beta1.CellStatus{State: v1beta1.CellStateReady},
+				},
+				MetadataExists: true,
+			}, nil
+		},
+	}
+
+	run := func(t *testing.T, args ...string) string {
+		t.Helper()
+		t.Cleanup(viper.Reset)
+		cmd := cell.NewCellCmd()
+		buf := &bytes.Buffer{}
+		cmd.SetOut(buf)
+		cmd.SetErr(buf)
+		ctx := context.WithValue(context.Background(), cell.MockControllerKey{}, kukeonv1.Client(fake))
+		cmd.SetContext(ctx)
+		cmd.SetArgs(append([]string{"ce1", "--realm", "r1", "--space", "s1", "--stack", "st1"}, args...))
+		if err := cmd.Execute(); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		return buf.String()
+	}
+
+	t.Run("default renders single table row", func(t *testing.T) {
+		out := run(t)
+		for _, col := range []string{"NAME", "REALM", "SPACE", "STACK", "STATE", "SYNC", "AGE"} {
+			if !strings.Contains(out, col) {
+				t.Errorf("named default missing column %q; got:\n%s", col, out)
+			}
+		}
+		if !strings.Contains(out, "ce1") {
+			t.Errorf("expected single row carrying name; got:\n%s", out)
+		}
+		if strings.Contains(out, "metadata:") || strings.Contains(out, "CONTAINERS") {
+			t.Errorf("named default must not emit document/wide columns; got:\n%s", out)
+		}
+	})
+
+	t.Run("-o wide renders single wide row", func(t *testing.T) {
+		out := run(t, "-o", "wide")
+		for _, col := range []string{"NAME", "STATE", "CONTAINERS", "BRIDGE", "DIVERGENCE"} {
+			if !strings.Contains(out, col) {
+				t.Errorf("named wide missing column %q; got:\n%s", col, out)
+			}
+		}
+		if strings.Contains(out, "metadata:") {
+			t.Errorf("named wide must not emit the full document; got:\n%s", out)
+		}
+	})
+
+	t.Run("-o yaml emits the full document", func(t *testing.T) {
+		out := run(t, "-o", "yaml")
+		if !strings.Contains(out, "metadata:") {
+			t.Errorf("-o yaml should emit the document; got:\n%s", out)
+		}
+	})
+
+	t.Run("-o json emits the full document", func(t *testing.T) {
+		out := run(t, "-o", "json")
+		if !strings.Contains(out, "\"metadata\"") {
+			t.Errorf("-o json should emit the document; got:\n%s", out)
+		}
+	})
+}
+
 func TestNewCellCmd_DefaultColumns(t *testing.T) {
 	t.Cleanup(viper.Reset)
 

--- a/cmd/kuke/get/config/config.go
+++ b/cmd/kuke/get/config/config.go
@@ -132,7 +132,7 @@ func NewConfigCmd() *cobra.Command {
 	cmd.Flags().String("stack", "", "Filter configs by stack name")
 	_ = viper.BindPFlag(config.KUKE_GET_CONFIG_STACK.ViperKey, cmd.Flags().Lookup("stack"))
 	cmd.Flags().
-		StringP("output", "o", "", "Output format (yaml, json, table, wide). Default: table for list, yaml for single resource")
+		StringP("output", "o", "", "Output format (yaml, json, table, wide). Default: table for list, table for single resource")
 	_ = viper.BindPFlag(config.KUKE_GET_OUTPUT.ViperKey, cmd.Flags().Lookup("output"))
 	_ = viper.BindPFlag(config.KUKE_GET_OUTPUT.ViperKey, cmd.Flags().Lookup("o"))
 
@@ -185,10 +185,12 @@ func printConfig(cmd *cobra.Command, cfg *v1beta1.CellConfigDoc, format shared.O
 	switch format {
 	case shared.OutputFormatJSON:
 		return shared.PrintJSON(cmd, cfg)
-	case shared.OutputFormatYAML, shared.OutputFormatTable:
+	case shared.OutputFormatYAML:
 		return shared.PrintYAML(cmd, cfg)
 	default:
-		return shared.PrintYAML(cmd, cfg)
+		// table / wide: render the single found element as a one-row table
+		// with the same columns as the list view (kubectl parity).
+		return printConfigs(cmd, []v1beta1.CellConfigDoc{*cfg}, format)
 	}
 }
 

--- a/cmd/kuke/get/config/config_test.go
+++ b/cmd/kuke/get/config/config_test.go
@@ -244,6 +244,77 @@ func TestNewConfigCmd(t *testing.T) {
 	}
 }
 
+// TestNewConfigCmd_NamedSingleRow pins the #1323 kubectl-parity flip: a named
+// `kuke get config <name>` renders a single table row by default, while
+// `-o yaml` / `-o json` still emit the full document.
+func TestNewConfigCmd_NamedSingleRow(t *testing.T) {
+	t.Cleanup(viper.Reset)
+
+	fake := &fakeClient{
+		getConfigFn: func(doc v1beta1.CellConfigDoc) (kukeonv1.GetConfigResult, error) {
+			return kukeonv1.GetConfigResult{
+				Config:         v1beta1.CellConfigDoc{Metadata: doc.Metadata},
+				MetadataExists: true,
+			}, nil
+		},
+	}
+
+	run := func(t *testing.T, args ...string) string {
+		t.Helper()
+		t.Cleanup(viper.Reset)
+		cmd := configcmd.NewConfigCmd()
+		buf := &bytes.Buffer{}
+		cmd.SetOut(buf)
+		cmd.SetErr(buf)
+		ctx := context.WithValue(context.Background(), configcmd.MockControllerKey{}, kukeonv1.Client(fake))
+		cmd.SetContext(ctx)
+		cmd.SetArgs(append([]string{"web"}, args...))
+		if err := cmd.Execute(); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		return buf.String()
+	}
+
+	t.Run("default renders single table row", func(t *testing.T) {
+		out := run(t)
+		for _, col := range []string{"NAME", "REALM", "SPACE", "STACK"} {
+			if !strings.Contains(out, col) {
+				t.Errorf("named default missing column %q; got:\n%s", col, out)
+			}
+		}
+		if !strings.Contains(out, "web") {
+			t.Errorf("expected single row carrying name; got:\n%s", out)
+		}
+		if strings.Contains(out, "metadata:") {
+			t.Errorf("named default must not emit the full document; got:\n%s", out)
+		}
+	})
+
+	t.Run("-o wide renders a single row", func(t *testing.T) {
+		out := run(t, "-o", "wide")
+		if !strings.Contains(out, "NAME") || !strings.Contains(out, "web") {
+			t.Errorf("named wide should render the single row; got:\n%s", out)
+		}
+		if strings.Contains(out, "metadata:") {
+			t.Errorf("named wide must not emit the full document; got:\n%s", out)
+		}
+	})
+
+	t.Run("-o yaml emits the full document", func(t *testing.T) {
+		out := run(t, "-o", "yaml")
+		if !strings.Contains(out, "metadata:") {
+			t.Errorf("-o yaml should emit the document; got:\n%s", out)
+		}
+	})
+
+	t.Run("-o json emits the full document", func(t *testing.T) {
+		out := run(t, "-o", "json")
+		if !strings.Contains(out, "\"metadata\"") {
+			t.Errorf("-o json should emit the document; got:\n%s", out)
+		}
+	})
+}
+
 type fakeClient struct {
 	kukeonv1.FakeClient
 

--- a/cmd/kuke/get/container/container.go
+++ b/cmd/kuke/get/container/container.go
@@ -72,7 +72,7 @@ full container spec.`,
 	cmd.Flags().String("cell", "", "Filter containers by cell name")
 	_ = viper.BindPFlag(config.KUKE_GET_CONTAINER_CELL.ViperKey, cmd.Flags().Lookup("cell"))
 	cmd.Flags().
-		StringP("output", "o", "", "Output format (yaml, json, table, wide). Default: table for list, yaml for single resource")
+		StringP("output", "o", "", "Output format (yaml, json, table, wide). Default: table for list, table for single resource")
 	_ = viper.BindPFlag(config.KUKE_GET_OUTPUT.ViperKey, cmd.Flags().Lookup("output"))
 	_ = viper.BindPFlag(config.KUKE_GET_OUTPUT.ViperKey, cmd.Flags().Lookup("o"))
 
@@ -172,7 +172,49 @@ func runContainerCmd(cmd *cobra.Command, args []string) error {
 			return fmt.Errorf("container %q not found", name)
 		}
 
-		return printContainer(cmd, &result.Container, outputFormat)
+		if outputFormat == shared.OutputFormatYAML || outputFormat == shared.OutputFormatJSON {
+			return printContainer(cmd, &result.Container, outputFormat)
+		}
+		// table / wide: render the single found container as a one-row table
+		// with the same columns as the list view (kubectl parity). Build the
+		// single-element spec slice + probe map the list renderer expects,
+		// backfilling scope coordinates the daemon may leave unset on the
+		// returned spec (same defensive backfill the list path applies).
+		spec := result.Container.Spec
+		if spec.ID == "" {
+			spec.ID = name
+		}
+		if spec.RealmID == "" {
+			spec.RealmID = realm
+		}
+		if spec.SpaceID == "" {
+			spec.SpaceID = space
+		}
+		if spec.StackID == "" {
+			spec.StackID = stack
+		}
+		if spec.CellID == "" {
+			spec.CellID = cell
+		}
+		st := result.Container.Status
+		probes := map[string]containerProbe{
+			spec.ID: {
+				state:        containerStateToString(st.State),
+				restartCount: st.RestartCount,
+				createdAt:    st.CreatedAt,
+				exitCode:     st.ExitCode,
+				exitSignal:   st.ExitSignal,
+				labels:       result.Container.Metadata.Labels,
+			},
+		}
+		return printContainersWithState(
+			cmd,
+			[]v1beta1.ContainerSpec{spec},
+			probes,
+			outputFormat,
+			wide,
+			"",
+		)
 	}
 
 	// List path — query each container's state by calling GetContainer.

--- a/cmd/kuke/get/container/container_test.go
+++ b/cmd/kuke/get/container/container_test.go
@@ -346,6 +346,94 @@ func TestGetContainer_NotFound_SurfacesSentinel(t *testing.T) {
 // column set after the epic:get redefinition (issue #605): NAME REALM SPACE
 // STACK CELL STATE RESTARTS AGE — eight columns. ROOT (as a column), IMAGE
 // (as a default column), and CGROUP must NOT appear.
+// TestNewContainerCmd_NamedSingleRow pins the #1323 kubectl-parity flip: a
+// named `kuke get container <name>` renders a single table row by default (and
+// the wide row with `-o wide`), while `-o yaml` / `-o json` still emit the full
+// document.
+func TestNewContainerCmd_NamedSingleRow(t *testing.T) {
+	t.Cleanup(viper.Reset)
+
+	fake := &fakeClient{
+		getContainerFn: func(_ v1beta1.ContainerDoc) (kukeonv1.GetContainerResult, error) {
+			return kukeonv1.GetContainerResult{
+				Container: v1beta1.ContainerDoc{
+					Metadata: v1beta1.ContainerMetadata{Name: "co1"},
+					Spec: v1beta1.ContainerSpec{
+						ID:      "co1",
+						RealmID: "r1",
+						SpaceID: "s1",
+						StackID: "st1",
+						CellID:  "ce1",
+						Image:   "alpine:3.20",
+					},
+					Status: v1beta1.ContainerStatus{State: v1beta1.ContainerStateReady},
+				},
+				ContainerExists: true,
+			}, nil
+		},
+	}
+
+	run := func(t *testing.T, args ...string) string {
+		t.Helper()
+		t.Cleanup(viper.Reset)
+		cmd := container.NewContainerCmd()
+		buf := &bytes.Buffer{}
+		cmd.SetOut(buf)
+		cmd.SetErr(buf)
+		ctx := context.WithValue(context.Background(), container.MockControllerKey{}, kukeonv1.Client(fake))
+		cmd.SetContext(ctx)
+		cmd.SetArgs(append([]string{"co1", "--realm", "r1", "--space", "s1", "--stack", "st1", "--cell", "ce1"}, args...))
+		if err := cmd.Execute(); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		return buf.String()
+	}
+
+	t.Run("default renders single table row", func(t *testing.T) {
+		out := run(t)
+		for _, col := range []string{"NAME", "REALM", "SPACE", "STACK", "CELL", "STATE", "RESTARTS", "AGE"} {
+			if !strings.Contains(out, col) {
+				t.Errorf("named default missing column %q; got:\n%s", col, out)
+			}
+		}
+		if !strings.Contains(out, "co1") {
+			t.Errorf("expected single row carrying name; got:\n%s", out)
+		}
+		if strings.Contains(out, "metadata:") || strings.Contains(out, "IMAGE") {
+			t.Errorf("named default must not emit document/wide columns; got:\n%s", out)
+		}
+	})
+
+	t.Run("-o wide renders single wide row", func(t *testing.T) {
+		out := run(t, "-o", "wide")
+		for _, col := range []string{"NAME", "STATE", "IMAGE", "EXIT"} {
+			if !strings.Contains(out, col) {
+				t.Errorf("named wide missing column %q; got:\n%s", col, out)
+			}
+		}
+		if !strings.Contains(out, "alpine:3.20") {
+			t.Errorf("expected IMAGE value in wide row; got:\n%s", out)
+		}
+		if strings.Contains(out, "metadata:") {
+			t.Errorf("named wide must not emit the full document; got:\n%s", out)
+		}
+	})
+
+	t.Run("-o yaml emits the full document", func(t *testing.T) {
+		out := run(t, "-o", "yaml")
+		if !strings.Contains(out, "metadata:") {
+			t.Errorf("-o yaml should emit the document; got:\n%s", out)
+		}
+	})
+
+	t.Run("-o json emits the full document", func(t *testing.T) {
+		out := run(t, "-o", "json")
+		if !strings.Contains(out, "\"metadata\"") {
+			t.Errorf("-o json should emit the document; got:\n%s", out)
+		}
+	})
+}
+
 func TestNewContainerCmd_DefaultColumns(t *testing.T) {
 	t.Cleanup(viper.Reset)
 

--- a/cmd/kuke/get/image/image.go
+++ b/cmd/kuke/get/image/image.go
@@ -66,8 +66,8 @@ type Client interface {
 
 // NewImageCmd builds the `kuke get image` subcommand. With no positional and
 // no `--realm`, it lists images across every realm. With `--realm <r>` it
-// narrows to one. With a positional `<ref>` it describes that one image
-// (yaml by default, json with `-o json`).
+// narrows to one. With a positional `<ref>` it renders that one image as a
+// single table row by default (the full document via `-o yaml` / `-o json`).
 func NewImageCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:           "image [ref]",
@@ -81,7 +81,7 @@ func NewImageCmd() *cobra.Command {
 
 	cmd.Flags().String("realm", "", "Filter images by realm name; omit to list across every realm")
 	cmd.Flags().
-		StringP("output", "o", "", "Output format (yaml, json, table, wide). Default: table for list, yaml for single resource")
+		StringP("output", "o", "", "Output format (yaml, json, table, wide). Default: table for list, table for single resource")
 	_ = viper.BindPFlag(config.KUKE_GET_OUTPUT.ViperKey, cmd.Flags().Lookup("output"))
 	_ = viper.BindPFlag(config.KUKE_GET_OUTPUT.ViperKey, cmd.Flags().Lookup("o"))
 
@@ -114,7 +114,17 @@ func runImageCmd(cmd *cobra.Command, args []string) error {
 			}
 			return getErr
 		}
-		return printImage(cmd, res.Image, format)
+		if format == getshared.OutputFormatYAML || format == getshared.OutputFormatJSON {
+			return printImage(cmd, res.Image, format)
+		}
+		// table / wide: render the single found image as a one-row table with
+		// the same columns as the list view (kubectl parity).
+		return printImages(
+			cmd,
+			[]kukeonv1.ListImagesResult{{Realm: realm, Images: []kukeonv1.ImageInfo{res.Image}}},
+			format,
+			wide,
+		)
 	}
 
 	if realm != "" {

--- a/cmd/kuke/get/image/image_test.go
+++ b/cmd/kuke/get/image/image_test.go
@@ -132,7 +132,10 @@ func TestImageCmd_ListSingleRealmNarrowing(t *testing.T) {
 	}
 }
 
-func TestImageCmd_DescribeSingleImageYAMLDefault(t *testing.T) {
+// TestImageCmd_DescribeSingleImageTableDefault covers the #1323 kubectl-parity
+// flip: a named `kuke get image <ref>` with no `-o` flag renders a single
+// table row (same columns as the list view), not the full YAML document.
+func TestImageCmd_DescribeSingleImageTableDefault(t *testing.T) {
 	want := kukeonv1.ImageInfo{
 		Name:      "docker.io/library/alpine:3.20",
 		Size:      7_500_000,
@@ -160,6 +163,84 @@ func TestImageCmd_DescribeSingleImageYAMLDefault(t *testing.T) {
 	}
 
 	out, err := runImageGet(t, fake, []string{want.Name})
+	if err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	// Single table row: the list-view header columns plus the one image, and
+	// the full document must NOT be emitted (no yaml/json keys).
+	for _, col := range []string{"NAME", "REALM", "SIZE", "AGE"} {
+		if !strings.Contains(out, col) {
+			t.Errorf("expected table header column %q, got:\n%s", col, out)
+		}
+	}
+	if !strings.Contains(out, want.Name) || !strings.Contains(out, "default") {
+		t.Errorf("expected single row carrying name+realm, got:\n%s", out)
+	}
+	if strings.Contains(out, "mediaType:") || strings.Contains(out, "digest:") {
+		t.Errorf("table default must not emit the full document, got:\n%s", out)
+	}
+}
+
+// TestImageCmd_DescribeSingleImageWide covers the named single-wide row: a
+// named `kuke get image <ref> -o wide` renders the one image with the wide
+// CREATED / DIGEST columns appended (#1323).
+func TestImageCmd_DescribeSingleImageWide(t *testing.T) {
+	digest := "sha256:abcd1234"
+	want := kukeonv1.ImageInfo{
+		Name:      "docker.io/library/alpine:3.20",
+		Size:      7_500_000,
+		CreatedAt: time.Date(2026, 1, 2, 3, 4, 5, 0, time.UTC),
+		Digest:    digest,
+	}
+	fake := &fakeImageClient{
+		getImageFn: func(realm, _ string) (kukeonv1.GetImageResult, error) {
+			return kukeonv1.GetImageResult{Realm: realm, Image: want}, nil
+		},
+		listImagesFn: func(string) (kukeonv1.ListImagesResult, error) {
+			t.Fatal("ListImages should not be called when a positional ref is supplied")
+			return kukeonv1.ListImagesResult{}, nil
+		},
+	}
+
+	out, err := runImageGet(t, fake, []string{want.Name, "-o", "wide"})
+	if err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	for _, col := range []string{"NAME", "REALM", "SIZE", "AGE", "CREATED", "DIGEST", "2026-01-02T03:04:05Z", digest} {
+		if !strings.Contains(out, col) {
+			t.Errorf("expected %q in named wide output, got:\n%s", col, out)
+		}
+	}
+	if strings.Contains(out, "mediaType:") {
+		t.Errorf("named wide must not emit the full document, got:\n%s", out)
+	}
+}
+
+// TestImageCmd_DescribeSingleImageYAML covers the preserved document path:
+// `-o yaml` on a named get still emits the full image document with the
+// CLI's camelCase key convention (#1194).
+func TestImageCmd_DescribeSingleImageYAML(t *testing.T) {
+	want := kukeonv1.ImageInfo{
+		Name:      "docker.io/library/alpine:3.20",
+		Size:      7_500_000,
+		Digest:    "sha256:cafef00d",
+		MediaType: "application/vnd.oci.image.manifest.v1+json",
+	}
+	fake := &fakeImageClient{
+		getImageFn: func(realm, ref string) (kukeonv1.GetImageResult, error) {
+			return kukeonv1.GetImageResult{
+				Realm:     "default",
+				Namespace: "default.kukeon.io",
+				Image:     want,
+			}, nil
+		},
+		listImagesFn: func(string) (kukeonv1.ListImagesResult, error) {
+			t.Fatal("ListImages should not be called when a positional ref is supplied")
+			return kukeonv1.ListImagesResult{}, nil
+		},
+	}
+
+	out, err := runImageGet(t, fake, []string{want.Name, "-o", "yaml"})
 	if err != nil {
 		t.Fatalf("run: %v", err)
 	}

--- a/cmd/kuke/get/realm/realm.go
+++ b/cmd/kuke/get/realm/realm.go
@@ -98,7 +98,7 @@ func NewRealmCmd() *cobra.Command {
 	}
 
 	cmd.Flags().
-		StringP("output", "o", "", "Output format (yaml, json, table, wide). Default: table for list, yaml for single resource")
+		StringP("output", "o", "", "Output format (yaml, json, table, wide). Default: table for list, table for single resource")
 	_ = viper.BindPFlag(config.KUKE_GET_OUTPUT.ViperKey, cmd.Flags().Lookup("output"))
 	_ = viper.BindPFlag(config.KUKE_GET_OUTPUT.ViperKey, cmd.Flags().Lookup("o"))
 
@@ -144,8 +144,12 @@ func printRealm(cmd *cobra.Command, realm *v1beta1.RealmDoc, format shared.Outpu
 	switch format {
 	case shared.OutputFormatJSON:
 		return shared.PrintJSON(cmd, realm)
-	default:
+	case shared.OutputFormatYAML:
 		return shared.PrintYAML(cmd, realm)
+	default:
+		// table / wide: render the single found element as a one-row table
+		// with the same columns as the list view (kubectl parity).
+		return printRealms(cmd, []v1beta1.RealmDoc{*realm}, format)
 	}
 }
 

--- a/cmd/kuke/get/realm/realm_test.go
+++ b/cmd/kuke/get/realm/realm_test.go
@@ -140,6 +140,86 @@ func TestNewRealmCmd(t *testing.T) {
 	}
 }
 
+// TestNewRealmCmd_NamedSingleRow pins the #1323 kubectl-parity flip: a named
+// `kuke get realm <name>` renders a single table row by default (and the wide
+// row with `-o wide`), while `-o yaml` / `-o json` still emit the full
+// document.
+func TestNewRealmCmd_NamedSingleRow(t *testing.T) {
+	t.Cleanup(viper.Reset)
+
+	fake := &fakeClient{
+		getRealmFn: func(_ v1beta1.RealmDoc) (kukeonv1.GetRealmResult, error) {
+			return kukeonv1.GetRealmResult{
+				Realm: v1beta1.RealmDoc{
+					APIVersion: v1beta1.APIVersionV1Beta1,
+					Kind:       v1beta1.KindRealm,
+					Metadata:   v1beta1.RealmMetadata{Name: "r1"},
+					Spec:       v1beta1.RealmSpec{Namespace: "ns1"},
+					Status:     v1beta1.RealmStatus{State: v1beta1.RealmStateReady},
+				},
+				MetadataExists: true,
+			}, nil
+		},
+	}
+
+	run := func(t *testing.T, args ...string) string {
+		t.Helper()
+		t.Cleanup(viper.Reset)
+		cmd := realm.NewRealmCmd()
+		buf := &bytes.Buffer{}
+		cmd.SetOut(buf)
+		cmd.SetErr(buf)
+		ctx := context.WithValue(context.Background(), realm.MockControllerKey{}, kukeonv1.Client(fake))
+		cmd.SetContext(ctx)
+		cmd.SetArgs(append([]string{"r1"}, args...))
+		if err := cmd.Execute(); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		return buf.String()
+	}
+
+	t.Run("default renders single table row", func(t *testing.T) {
+		out := run(t)
+		header := testutil.FirstLine(out)
+		for _, col := range []string{"NAME", "STATE", "AGE"} {
+			if !strings.Contains(header, col) {
+				t.Errorf("named default header missing %q; got: %q", col, header)
+			}
+		}
+		if !strings.Contains(out, "r1") {
+			t.Errorf("expected single row carrying name; got:\n%s", out)
+		}
+		if strings.Contains(out, "metadata:") || strings.Contains(out, "NAMESPACE") {
+			t.Errorf("named default must not emit document/wide columns; got:\n%s", out)
+		}
+	})
+
+	t.Run("-o wide renders single wide row", func(t *testing.T) {
+		out := run(t, "-o", "wide")
+		header := testutil.FirstLine(out)
+		if !strings.Contains(header, "NAMESPACE") {
+			t.Errorf("named wide header missing NAMESPACE; got: %q", header)
+		}
+		if !strings.Contains(out, "ns1") {
+			t.Errorf("expected NAMESPACE value in wide row; got:\n%s", out)
+		}
+	})
+
+	t.Run("-o yaml emits the full document", func(t *testing.T) {
+		out := run(t, "-o", "yaml")
+		if !strings.Contains(out, "metadata:") {
+			t.Errorf("-o yaml should emit the document; got:\n%s", out)
+		}
+	})
+
+	t.Run("-o json emits the full document", func(t *testing.T) {
+		out := run(t, "-o", "json")
+		if !strings.Contains(out, "\"metadata\"") {
+			t.Errorf("-o json should emit the document; got:\n%s", out)
+		}
+	})
+}
+
 func TestNewRealmCmd_Structure(t *testing.T) {
 	cmd := realm.NewRealmCmd()
 	if cmd.Use != "realm [name]" {

--- a/cmd/kuke/get/secret/secret.go
+++ b/cmd/kuke/get/secret/secret.go
@@ -124,7 +124,7 @@ func NewSecretCmd() *cobra.Command {
 	cmd.Flags().String("cell", "", "Filter secrets by cell name")
 	_ = viper.BindPFlag(config.KUKE_GET_SECRET_CELL.ViperKey, cmd.Flags().Lookup("cell"))
 	cmd.Flags().
-		StringP("output", "o", "", "Output format (yaml, json, table, wide). Default: table for list, yaml for single resource")
+		StringP("output", "o", "", "Output format (yaml, json, table, wide). Default: table for list, table for single resource")
 	_ = viper.BindPFlag(config.KUKE_GET_OUTPUT.ViperKey, cmd.Flags().Lookup("output"))
 	_ = viper.BindPFlag(config.KUKE_GET_OUTPUT.ViperKey, cmd.Flags().Lookup("o"))
 
@@ -150,10 +150,12 @@ func printSecret(cmd *cobra.Command, secret *v1beta1.SecretDoc, format shared.Ou
 	switch format {
 	case shared.OutputFormatJSON:
 		return shared.PrintJSON(cmd, secret)
-	case shared.OutputFormatYAML, shared.OutputFormatTable:
+	case shared.OutputFormatYAML:
 		return shared.PrintYAML(cmd, secret)
 	default:
-		return shared.PrintYAML(cmd, secret)
+		// table / wide: render the single found element as a one-row table
+		// with the same columns as the list view (kubectl parity).
+		return printSecrets(cmd, []v1beta1.SecretDoc{*secret}, format)
 	}
 }
 

--- a/cmd/kuke/get/secret/secret_test.go
+++ b/cmd/kuke/get/secret/secret_test.go
@@ -187,6 +187,77 @@ func TestNewSecretCmd(t *testing.T) {
 	}
 }
 
+// TestNewSecretCmd_NamedSingleRow pins the #1323 kubectl-parity flip: a named
+// `kuke get secret <name>` renders a single table row by default, while
+// `-o yaml` / `-o json` still emit the full document.
+func TestNewSecretCmd_NamedSingleRow(t *testing.T) {
+	t.Cleanup(viper.Reset)
+
+	fake := &fakeClient{
+		getSecretFn: func(doc v1beta1.SecretDoc) (kukeonv1.GetSecretResult, error) {
+			return kukeonv1.GetSecretResult{
+				Secret:         v1beta1.SecretDoc{Metadata: doc.Metadata},
+				MetadataExists: true,
+			}, nil
+		},
+	}
+
+	run := func(t *testing.T, args ...string) string {
+		t.Helper()
+		t.Cleanup(viper.Reset)
+		cmd := secret.NewSecretCmd()
+		buf := &bytes.Buffer{}
+		cmd.SetOut(buf)
+		cmd.SetErr(buf)
+		ctx := context.WithValue(context.Background(), secret.MockControllerKey{}, kukeonv1.Client(fake))
+		cmd.SetContext(ctx)
+		cmd.SetArgs(append([]string{"tok", "--realm", "r1", "--space", "s1"}, args...))
+		if err := cmd.Execute(); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		return buf.String()
+	}
+
+	t.Run("default renders single table row", func(t *testing.T) {
+		out := run(t)
+		for _, col := range []string{"NAME", "REALM", "SPACE", "STACK", "CELL"} {
+			if !strings.Contains(out, col) {
+				t.Errorf("named default missing column %q; got:\n%s", col, out)
+			}
+		}
+		if !strings.Contains(out, "tok") {
+			t.Errorf("expected single row carrying name; got:\n%s", out)
+		}
+		if strings.Contains(out, "metadata:") {
+			t.Errorf("named default must not emit the full document; got:\n%s", out)
+		}
+	})
+
+	t.Run("-o wide renders a single row", func(t *testing.T) {
+		out := run(t, "-o", "wide")
+		if !strings.Contains(out, "NAME") || !strings.Contains(out, "tok") {
+			t.Errorf("named wide should render the single row; got:\n%s", out)
+		}
+		if strings.Contains(out, "metadata:") {
+			t.Errorf("named wide must not emit the full document; got:\n%s", out)
+		}
+	})
+
+	t.Run("-o yaml emits the full document", func(t *testing.T) {
+		out := run(t, "-o", "yaml")
+		if !strings.Contains(out, "metadata:") {
+			t.Errorf("-o yaml should emit the document; got:\n%s", out)
+		}
+	})
+
+	t.Run("-o json emits the full document", func(t *testing.T) {
+		out := run(t, "-o", "json")
+		if !strings.Contains(out, "\"metadata\"") {
+			t.Errorf("-o json should emit the document; got:\n%s", out)
+		}
+	})
+}
+
 type fakeClient struct {
 	kukeonv1.FakeClient
 

--- a/cmd/kuke/get/space/space.go
+++ b/cmd/kuke/get/space/space.go
@@ -110,7 +110,7 @@ func NewSpaceCmd() *cobra.Command {
 	_ = viper.BindPFlag(config.KUKE_GET_SPACE_REALM.ViperKey, cmd.Flags().Lookup("realm"))
 
 	cmd.Flags().
-		StringP("output", "o", "", "Output format (yaml, json, table, wide). Default: table for list, yaml for single resource")
+		StringP("output", "o", "", "Output format (yaml, json, table, wide). Default: table for list, table for single resource")
 	_ = viper.BindPFlag(config.KUKE_GET_OUTPUT.ViperKey, cmd.Flags().Lookup("output"))
 	_ = viper.BindPFlag(config.KUKE_GET_OUTPUT.ViperKey, cmd.Flags().Lookup("o"))
 
@@ -151,8 +151,12 @@ func printSpace(cmd *cobra.Command, space *v1beta1.SpaceDoc, format shared.Outpu
 	switch format {
 	case shared.OutputFormatJSON:
 		return shared.PrintJSON(cmd, space)
-	default:
+	case shared.OutputFormatYAML:
 		return shared.PrintYAML(cmd, space)
+	default:
+		// table / wide: render the single found element as a one-row table
+		// with the same columns as the list view (kubectl parity).
+		return printSpaces(cmd, []v1beta1.SpaceDoc{*space}, format)
 	}
 }
 

--- a/cmd/kuke/get/space/space_test.go
+++ b/cmd/kuke/get/space/space_test.go
@@ -144,6 +144,83 @@ func TestNewSpaceCmd(t *testing.T) {
 // renders `allow`/`deny`/`-` across the nil-cases for Spec.Network and
 // Spec.Network.Egress; NET-DEFAULTS renders `yes`/`-` boolean of whether
 // Spec.Defaults != nil. CGROUP/CONTROLLERS never appear in any table.
+// TestNewSpaceCmd_NamedSingleRow pins the #1323 kubectl-parity flip: a named
+// `kuke get space <name>` renders a single table row by default (and the wide
+// row with `-o wide`), while `-o yaml` / `-o json` still emit the full
+// document.
+func TestNewSpaceCmd_NamedSingleRow(t *testing.T) {
+	t.Cleanup(viper.Reset)
+
+	fake := &fakeClient{
+		getSpaceFn: func(_ v1beta1.SpaceDoc) (kukeonv1.GetSpaceResult, error) {
+			return kukeonv1.GetSpaceResult{
+				Space: v1beta1.SpaceDoc{
+					Metadata: v1beta1.SpaceMetadata{Name: "s1"},
+					Spec:     v1beta1.SpaceSpec{RealmID: "r1"},
+					Status:   v1beta1.SpaceStatus{State: v1beta1.SpaceStateReady},
+				},
+				MetadataExists: true,
+			}, nil
+		},
+	}
+
+	run := func(t *testing.T, args ...string) string {
+		t.Helper()
+		t.Cleanup(viper.Reset)
+		cmd := space.NewSpaceCmd()
+		buf := &bytes.Buffer{}
+		cmd.SetOut(buf)
+		cmd.SetErr(buf)
+		ctx := context.WithValue(context.Background(), space.MockControllerKey{}, kukeonv1.Client(fake))
+		cmd.SetContext(ctx)
+		cmd.SetArgs(append([]string{"s1", "--realm", "r1"}, args...))
+		if err := cmd.Execute(); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		return buf.String()
+	}
+
+	t.Run("default renders single table row", func(t *testing.T) {
+		out := run(t)
+		header := testutil.FirstLine(out)
+		for _, col := range []string{"NAME", "REALM", "STATE", "AGE"} {
+			if !strings.Contains(header, col) {
+				t.Errorf("named default header missing %q; got: %q", col, header)
+			}
+		}
+		if !strings.Contains(out, "s1") {
+			t.Errorf("expected single row carrying name; got:\n%s", out)
+		}
+		if strings.Contains(out, "metadata:") || strings.Contains(out, "EGRESS") {
+			t.Errorf("named default must not emit document/wide columns; got:\n%s", out)
+		}
+	})
+
+	t.Run("-o wide renders single wide row", func(t *testing.T) {
+		out := run(t, "-o", "wide")
+		header := testutil.FirstLine(out)
+		for _, col := range []string{"NAME", "REALM", "EGRESS", "NET-DEFAULTS"} {
+			if !strings.Contains(header, col) {
+				t.Errorf("named wide header missing %q; got: %q", col, header)
+			}
+		}
+	})
+
+	t.Run("-o yaml emits the full document", func(t *testing.T) {
+		out := run(t, "-o", "yaml")
+		if !strings.Contains(out, "metadata:") {
+			t.Errorf("-o yaml should emit the document; got:\n%s", out)
+		}
+	})
+
+	t.Run("-o json emits the full document", func(t *testing.T) {
+		out := run(t, "-o", "json")
+		if !strings.Contains(out, "\"metadata\"") {
+			t.Errorf("-o json should emit the document; got:\n%s", out)
+		}
+	})
+}
+
 func TestNewSpaceCmd_Columns(t *testing.T) {
 	t.Cleanup(viper.Reset)
 

--- a/cmd/kuke/get/stack/stack.go
+++ b/cmd/kuke/get/stack/stack.go
@@ -121,7 +121,7 @@ func NewStackCmd() *cobra.Command {
 	cmd.Flags().String("space", "", "Filter stacks by space name")
 	_ = viper.BindPFlag(config.KUKE_GET_STACK_SPACE.ViperKey, cmd.Flags().Lookup("space"))
 	cmd.Flags().
-		StringP("output", "o", "", "Output format (yaml, json, table, wide). Default: table for list, yaml for single resource")
+		StringP("output", "o", "", "Output format (yaml, json, table, wide). Default: table for list, table for single resource")
 	_ = viper.BindPFlag(config.KUKE_GET_OUTPUT.ViperKey, cmd.Flags().Lookup("output"))
 	_ = viper.BindPFlag(config.KUKE_GET_OUTPUT.ViperKey, cmd.Flags().Lookup("o"))
 
@@ -163,8 +163,12 @@ func printStack(cmd *cobra.Command, stack *v1beta1.StackDoc, format shared.Outpu
 	switch format {
 	case shared.OutputFormatJSON:
 		return shared.PrintJSON(cmd, stack)
-	default:
+	case shared.OutputFormatYAML:
 		return shared.PrintYAML(cmd, stack)
+	default:
+		// table / wide: render the single found element as a one-row table
+		// with the same columns as the list view (kubectl parity).
+		return printStacks(cmd, []v1beta1.StackDoc{*stack}, format)
 	}
 }
 

--- a/cmd/kuke/get/stack/stack_test.go
+++ b/cmd/kuke/get/stack/stack_test.go
@@ -145,6 +145,86 @@ func TestNewStackCmd(t *testing.T) {
 // the same shape as default. Also re-pins the cross-cutting epic
 // invariants from #827: the `CGROUP`/`CONTROLLERS` columns and the
 // `--show-controllers` flag stay gone.
+// TestNewStackCmd_NamedSingleRow pins the #1323 kubectl-parity flip: a named
+// `kuke get stack <name>` renders a single table row by default, while
+// `-o yaml` / `-o json` still emit the full document. Stack has no per-entity
+// `-o wide` columns, so wide renders the same shape as default (#603).
+func TestNewStackCmd_NamedSingleRow(t *testing.T) {
+	t.Cleanup(viper.Reset)
+
+	fake := &fakeClient{
+		getStackFn: func(_ v1beta1.StackDoc) (kukeonv1.GetStackResult, error) {
+			return kukeonv1.GetStackResult{
+				Stack: v1beta1.StackDoc{
+					Metadata: v1beta1.StackMetadata{Name: "st1"},
+					Spec:     v1beta1.StackSpec{RealmID: "r1", SpaceID: "s1"},
+					Status:   v1beta1.StackStatus{State: v1beta1.StackStateReady},
+				},
+				MetadataExists: true,
+			}, nil
+		},
+	}
+
+	run := func(t *testing.T, args ...string) string {
+		t.Helper()
+		t.Cleanup(viper.Reset)
+		cmd := stack.NewStackCmd()
+		buf := &bytes.Buffer{}
+		cmd.SetOut(buf)
+		cmd.SetErr(buf)
+		ctx := context.WithValue(context.Background(), stack.MockControllerKey{}, kukeonv1.Client(fake))
+		cmd.SetContext(ctx)
+		cmd.SetArgs(append([]string{"st1", "--realm", "r1", "--space", "s1"}, args...))
+		if err := cmd.Execute(); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		return buf.String()
+	}
+
+	t.Run("default renders single table row", func(t *testing.T) {
+		out := run(t)
+		header := testutil.FirstLine(out)
+		for _, col := range []string{"NAME", "REALM", "SPACE", "STATE", "AGE"} {
+			if !strings.Contains(header, col) {
+				t.Errorf("named default header missing %q; got: %q", col, header)
+			}
+		}
+		if !strings.Contains(out, "st1") {
+			t.Errorf("expected single row carrying name; got:\n%s", out)
+		}
+		if strings.Contains(out, "metadata:") {
+			t.Errorf("named default must not emit the full document; got:\n%s", out)
+		}
+	})
+
+	t.Run("-o wide renders single row", func(t *testing.T) {
+		out := run(t, "-o", "wide")
+		header := testutil.FirstLine(out)
+		for _, col := range []string{"NAME", "REALM", "SPACE", "STATE", "AGE"} {
+			if !strings.Contains(header, col) {
+				t.Errorf("named wide header missing %q; got: %q", col, header)
+			}
+		}
+		if strings.Contains(out, "metadata:") {
+			t.Errorf("named wide must not emit the full document; got:\n%s", out)
+		}
+	})
+
+	t.Run("-o yaml emits the full document", func(t *testing.T) {
+		out := run(t, "-o", "yaml")
+		if !strings.Contains(out, "metadata:") {
+			t.Errorf("-o yaml should emit the document; got:\n%s", out)
+		}
+	})
+
+	t.Run("-o json emits the full document", func(t *testing.T) {
+		out := run(t, "-o", "json")
+		if !strings.Contains(out, "\"metadata\"") {
+			t.Errorf("-o json should emit the document; got:\n%s", out)
+		}
+	})
+}
+
 func TestNewStackCmd_Columns(t *testing.T) {
 	t.Cleanup(viper.Reset)
 

--- a/cmd/kuke/get/volume/volume.go
+++ b/cmd/kuke/get/volume/volume.go
@@ -122,7 +122,7 @@ func NewVolumeCmd() *cobra.Command {
 	cmd.Flags().String("stack", "", "Filter volumes by stack name")
 	_ = viper.BindPFlag(config.KUKE_GET_VOLUME_STACK.ViperKey, cmd.Flags().Lookup("stack"))
 	cmd.Flags().
-		StringP("output", "o", "", "Output format (yaml, json, table, wide). Default: table for list, yaml for single resource")
+		StringP("output", "o", "", "Output format (yaml, json, table, wide). Default: table for list, table for single resource")
 	_ = viper.BindPFlag(config.KUKE_GET_OUTPUT.ViperKey, cmd.Flags().Lookup("output"))
 	_ = viper.BindPFlag(config.KUKE_GET_OUTPUT.ViperKey, cmd.Flags().Lookup("o"))
 
@@ -147,10 +147,12 @@ func printVolume(cmd *cobra.Command, volume *v1beta1.VolumeDoc, format shared.Ou
 	switch format {
 	case shared.OutputFormatJSON:
 		return shared.PrintJSON(cmd, volume)
-	case shared.OutputFormatYAML, shared.OutputFormatTable, shared.OutputFormatWide:
+	case shared.OutputFormatYAML:
 		return shared.PrintYAML(cmd, volume)
 	default:
-		return shared.PrintYAML(cmd, volume)
+		// table / wide: render the single found element as a one-row table
+		// with the same columns as the list view (kubectl parity).
+		return printVolumes(cmd, []v1beta1.VolumeDoc{*volume}, format)
 	}
 }
 

--- a/cmd/kuke/get/volume/volume_test.go
+++ b/cmd/kuke/get/volume/volume_test.go
@@ -177,6 +177,77 @@ func TestNewVolumeCmd(t *testing.T) {
 	}
 }
 
+// TestNewVolumeCmd_NamedSingleRow pins the #1323 kubectl-parity flip: a named
+// `kuke get volume <name>` renders a single table row by default, while
+// `-o yaml` / `-o json` still emit the full document.
+func TestNewVolumeCmd_NamedSingleRow(t *testing.T) {
+	t.Cleanup(viper.Reset)
+
+	fake := &fakeClient{
+		getVolumeFn: func(doc v1beta1.VolumeDoc) (kukeonv1.GetVolumeResult, error) {
+			return kukeonv1.GetVolumeResult{
+				Volume:         v1beta1.VolumeDoc{Metadata: doc.Metadata},
+				MetadataExists: true,
+			}, nil
+		},
+	}
+
+	run := func(t *testing.T, args ...string) string {
+		t.Helper()
+		t.Cleanup(viper.Reset)
+		cmd := volume.NewVolumeCmd()
+		buf := &bytes.Buffer{}
+		cmd.SetOut(buf)
+		cmd.SetErr(buf)
+		ctx := context.WithValue(context.Background(), volume.MockControllerKey{}, kukeonv1.Client(fake))
+		cmd.SetContext(ctx)
+		cmd.SetArgs(append([]string{"vol1", "--realm", "r1", "--space", "s1"}, args...))
+		if err := cmd.Execute(); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		return buf.String()
+	}
+
+	t.Run("default renders single table row", func(t *testing.T) {
+		out := run(t)
+		for _, col := range []string{"NAME", "REALM", "SPACE", "STACK"} {
+			if !strings.Contains(out, col) {
+				t.Errorf("named default missing column %q; got:\n%s", col, out)
+			}
+		}
+		if !strings.Contains(out, "vol1") {
+			t.Errorf("expected single row carrying name; got:\n%s", out)
+		}
+		if strings.Contains(out, "metadata:") {
+			t.Errorf("named default must not emit the full document; got:\n%s", out)
+		}
+	})
+
+	t.Run("-o wide renders a single row", func(t *testing.T) {
+		out := run(t, "-o", "wide")
+		if !strings.Contains(out, "NAME") || !strings.Contains(out, "vol1") {
+			t.Errorf("named wide should render the single row; got:\n%s", out)
+		}
+		if strings.Contains(out, "metadata:") {
+			t.Errorf("named wide must not emit the full document; got:\n%s", out)
+		}
+	})
+
+	t.Run("-o yaml emits the full document", func(t *testing.T) {
+		out := run(t, "-o", "yaml")
+		if !strings.Contains(out, "metadata:") {
+			t.Errorf("-o yaml should emit the document; got:\n%s", out)
+		}
+	})
+
+	t.Run("-o json emits the full document", func(t *testing.T) {
+		out := run(t, "-o", "json")
+		if !strings.Contains(out, "\"metadata\"") {
+			t.Errorf("-o json should emit the document; got:\n%s", out)
+		}
+	})
+}
+
 type fakeClient struct {
 	kukeonv1.FakeClient
 

--- a/docs/cli-use-cases.md
+++ b/docs/cli-use-cases.md
@@ -160,20 +160,22 @@ kuke get cells
 kuke get containers --cell <name>                # filter within current scope
 kuke get images                                  # cross-realm by default
 kuke get image --realm <name>                    # narrow to one realm
-kuke get image <ref> --realm <name>              # describe a single image (yaml default)
+kuke get image <ref> --realm <name>              # describe a single image (single table row)
+kuke get realm <name>                            # single table row (same cols as the list)
 kuke get realm <name> -o yaml                    # full spec+status
 kuke get realm <name> -o json
+kuke get realm <name> -o wide                    # single wide row
 kuke get realms -o wide                          # default cols + NAMESPACE
 ```
 
 **Invariants.**
 
 - Exit code 0 even when the result set is empty; the CLI prints a brief "no resources found" line rather than failing.
-- Table output is the default for **lists**; YAML is the default for a **single named resource**. Both behaviors are overridable via `-o {yaml,json,table,wide}`.
+- Table output is the default for **both lists and a single named resource** (#1323, kubectl parity): a named `kuke get <kind> <name>` renders a **single table row** with the same columns as the list view, filtered to that one element; `-o wide` renders the single wide row where the kind defines wide columns. The full document is reached via `-o yaml` / `-o json`. **Breaking UX change:** scripts that relied on a bare named get emitting YAML must switch to `-o yaml`. All behaviors are overridable via `-o {yaml,json,table,wide}`.
 - After `kuke init`, `kuke get realms` lists at least `default` and `kuke-system`. `kuke get realms --no-daemon` must produce the same row set — divergence is a regression (see AGENTS.md daemon-parity guard).
 - The realm default table is `NAME STATE AGE`; `-o wide` appends `NAMESPACE`. The retired `--show-controllers` flag and the `CGROUP` / `CONTROLLERS` columns are gone (epic:get) — surface `cgroupPath` / `subtreeControllers` via `-o yaml` or `-o json` when investigating.
 - `kuke get realms --no-daemon` works without `sudo` when `/opt/kukeon` is readable by the `kukeon` group; this is the supported escape hatch when the daemon is down.
-- `kuke get image[s]` lists across **every realm** by default; columns are `NAME REALM SIZE AGE`. `--realm <r>` narrows to one realm but keeps the `REALM` column for grep-ability. `-o wide` appends `CREATED` and `DIGEST`. `-o yaml` / `-o json` emit one `kukeonv1.ListImagesResult` per realm. With a positional `<ref>` the command describes a single image (yaml by default, `-o json` switches to json); `--realm` defaults to `default` on this path.
+- `kuke get image[s]` lists across **every realm** by default; columns are `NAME REALM SIZE AGE`. `--realm <r>` narrows to one realm but keeps the `REALM` column for grep-ability. `-o wide` appends `CREATED` and `DIGEST`. `-o yaml` / `-o json` emit one `kukeonv1.ListImagesResult` per realm. With a positional `<ref>` the command renders a **single table row** by default (same `NAME REALM SIZE AGE` columns, `-o wide` appends `CREATED` / `DIGEST`); `-o yaml` / `-o json` describe the full image document; `--realm` defaults to `default` on this path.
 - `kuke get image` is daemon-independent: image methods do not traverse the kukeond RPC (#226), so the persistent `--no-daemon` on `kuke get` is a no-op for this leaf — every invocation goes in-process via the containerd socket.
 - `kuke get containers --cell <name>` (and `--space <name>` / `--stack <name>`) filter **within the scope passed on the command line**. The operator must supply matching `--realm/--space/--stack` to filter into a non-default scope. When a filter returns zero rows but the named cell/space/stack exists in a different scope, the table output appends a `Hint:` line naming the realm/space/stack where it does exist, so the operator can re-run with the right flags. The hint applies to the `table` output only — `-o yaml` and `-o json` still emit an empty list, exit code 0.
 

--- a/docs/site/cli/kuke-get.md
+++ b/docs/site/cli/kuke-get.md
@@ -13,7 +13,7 @@ Resources: `realm`, `space`, `stack`, `cell`, `container`, `image`, `blueprint`,
 
 | Flag                | Description                                                                                                                                                                                                   |
 | ------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `--output`, `-o`    | Output format: `yaml`, `json`, `table`, `wide`. Default: `table` for list, `yaml` for a single resource. `wide` accepted by every `kuke get <kind>` for symmetry; per-kind wide columns vary (see each kind). |
+| `--output`, `-o`    | Output format: `yaml`, `json`, `table`, `wide`. Default: `table` for both a list and a single named resource (#1323). `wide` accepted by every `kuke get <kind>` for symmetry; per-kind wide columns vary (see each kind). |
 | `--selector`, `-l`  | Label selector (kubectl-style) to filter list results. Supports `=`, `==`, `!=`, existence (`key`), absence (`!key`), and comma-separated AND (e.g. `env=prod,tier!=db` or `env,!debug`). Rejected with a positional `NAME`. |
 
 Plus all [global flags](kuke.md). Every `kuke get <kind>` accepts the explicit `--no-daemon` flag to bypass the daemon (inherited as a persistent flag from the parent `get` command); `KUKEON_NO_DAEMON=true` and `--run-path /opt/kukeon` (which auto-promotes the command into in-process mode) work as well.
@@ -38,7 +38,7 @@ All scope flags default to `default`. See the [realm default note](commands.md#c
 ## Behavior
 
 - **List** (no positional arg): returns every resource matching the scope flags. Default output is a table.
-- **Single** (positional arg): returns the one matching resource. Default output is YAML.
+- **Single** (positional arg): returns the one matching resource. Default output is a **single table row** with the same columns as the list view (#1323, kubectl parity); `-o wide` renders the single wide row. The full document is reached via `-o yaml` / `-o json`. (Breaking change: scripts that relied on a bare named get emitting YAML must switch to `-o yaml`.)
 
 ## Default tables and `-o wide` columns
 


### PR DESCRIPTION
## Summary
- Flips the default rendering of a named `kuke get <kind> <name>` from the full resource document to a **single table row** (same columns as the list view, filtered to one element) across all 10 kinds — completing the kubectl-parity story epic #601 started. The full document stays reachable via `-o yaml` / `-o json`, and `-o wide` renders the single wide row where the kind defines wide columns.
- Mechanically, each subcommand's singular printer now routes `yaml`/`json` to the document printer and `table`/`wide` to the existing list renderer with a one-element slice. Seven kinds (realm, space, stack, blueprint, config, secret, volume) feed the list renderer's `format`-driven path; the three `wide bool`-plumbed kinds (cell, container, image) thread the `wide` flag through. Each `-o` help string updated from `yaml for single resource` → `table for single resource`.
- Per the invocation argument ("update cli dox for use case also"), this PR **also** lands the docs the issue body had deferred to a separate `documentation` follow-up: `docs/cli-use-cases.md` and `docs/site/cli/kuke-get.md`. **Gate-vs-flip note for the reviewer:** the docs were bundled here because the user explicitly requested it in this session; the issue body's "separate follow-up" remains the default if you'd prefer to split.

## Notes on non-obvious calls
- Not-found handling, scope-flag requirements, and selector/name mutual-exclusion are untouched — only the rendering of a *found* element changes.
- `container`'s named branch builds the single-element `[]ContainerSpec` + `containerProbe` map the list renderer expects, backfilling scope coordinates the daemon may leave unset (mirrors the list path's defensive backfill).
- `image`'s named branch wraps `res.Image` in a one-element `ListImagesResult{Realm, Images}` for the list renderer.

## Test plan
- [x] `make test` (full CI suite, `test-root` + `test-kukebuild`) — exit 0, no failures
- [x] `go vet ./cmd/kuke/get/...` — clean
- [x] `gofmt -l cmd/kuke/get/` — clean
- [x] Per-kind named-get tests added covering the single-row path (table + wide where applicable) and the preserved `-o yaml` / `-o json` document path for all 10 kinds (realm, space, stack, blueprint, config, secret, volume, cell, container, image)
- [x] Updated the image package's prior `…YAMLDefault` test to the new contract (default → table row; document via `-o yaml`)

Closes #1323