### PR TITLE
feat: wire runner restart counters (RestartCount/RestartTime) (step 2)

### DIFF
--- a/internal/controller/runner/helpers.go
+++ b/internal/controller/runner/helpers.go
@@ -990,12 +990,22 @@ func (r *Exec) populateCellContainerStatuses(cell *intmodel.Cell) error {
 	// FinishTime=T with exit code 0 / no signal — a self-contradictory status).
 	// Preserving ExitCode in lockstep keeps the exit triple consistent. Issue #1137.
 	priorExitCode := make(map[string]int, len(cell.Status.Containers))
+	// Snapshot prior RestartCount/RestartTime under the same observe-and-preserve
+	// contract as the timestamps above. The reconciler's restart-on-exit pass
+	// (maybeRestartExitedContainers) is the *sole writer* of these counters
+	// (#1234); populate never increments — it only carries the persisted values
+	// across the unconditional overwrite below so the count stays monotonic and
+	// survives every reconciliation pass. Issue #1234 (epic #1151).
+	priorRestartCount := make(map[string]int, len(cell.Status.Containers))
+	priorRestartTime := make(map[string]time.Time, len(cell.Status.Containers))
 	for _, prev := range cell.Status.Containers {
 		priorStages[prev.ID] = prev.Stages
 		priorCreatedAt[prev.ID] = prev.CreatedAt
 		priorStartTime[prev.ID] = prev.StartTime
 		priorFinishTime[prev.ID] = prev.FinishTime
 		priorExitCode[prev.ID] = prev.ExitCode
+		priorRestartCount[prev.ID] = prev.RestartCount
+		priorRestartTime[prev.ID] = prev.RestartTime
 	}
 
 	statuses := make([]intmodel.ContainerStatus, 0, len(cell.Spec.Containers))
@@ -1054,20 +1064,20 @@ func (r *Exec) populateCellContainerStatuses(cell *intmodel.Cell) error {
 			exitCode = obs.ExitCode
 		}
 
-		// RestartCount/RestartTime require restart bookkeeping, but the runner has
-		// no reconciler-driven container restart-on-exit mechanism today
-		// (restartPolicy is reap-veto only, #1003) — nothing re-creates or
-		// re-starts an exited container task, so there is nothing to count from.
-		// The fields are therefore intentionally always-zero. Building the
-		// restart-on-exit mechanism and populating these counters is tracked by
-		// #1151.
+		// RestartCount/RestartTime: pure preserve. The reconciler's
+		// restart-on-exit pass (maybeRestartExitedContainers, #1233) is the sole
+		// writer — it bumps the count by one and stamps the time after a
+		// successful relaunch. populate never increments; it only carries the
+		// persisted values across this unconditional overwrite so the count is
+		// monotonic and survives reconciliation. A container that never restarted
+		// preserves a zero from a zero. Issue #1234 (epic #1151).
 		status := intmodel.ContainerStatus{
 			Name:         containerSpec.ID,
 			ID:           containerSpec.ID,
 			CreatedAt:    createdAt,
 			State:        obs.State,
-			RestartCount: 0,           // intentionally zero — see comment above (#1151)
-			RestartTime:  time.Time{}, // intentionally zero — see comment above (#1151)
+			RestartCount: priorRestartCount[containerSpec.ID],
+			RestartTime:  priorRestartTime[containerSpec.ID],
 			StartTime:    startTime,
 			FinishTime:   finishTime,
 			ExitCode:     exitCode,

--- a/internal/controller/runner/refresh.go
+++ b/internal/controller/runner/refresh.go
@@ -1350,6 +1350,15 @@ func (r *Exec) maybeRestartExitedContainers(cell intmodel.Cell) (intmodel.Cell, 
 				return cell, result, fmt.Errorf("restart container %q: %w", spec.ID, startErr)
 			}
 			cell = started
+			// Sole-writer counter bump (#1234): the relaunch succeeded, so record
+			// it on the user-visible RestartCount/RestartTime. populate is a pure
+			// preserver of these fields, so this pass is the only place they ever
+			// advance — RestartCount = prior + 1 is an exact per-restart count that
+			// stays monotonic and survives subsequent reconciliation. StartContainer
+			// re-derived statuses from the persisted (preserved) prior, so the bump
+			// lands on top of that prior; ReconcileCell's restartFired branch then
+			// persists the incremented value via persistCellStatusGuarded.
+			stampContainerRestart(&cell, spec.ID, r.nowUTC())
 			result = restartFired
 		case restartDeferred:
 			// A fired restart in the same pass takes precedence; only downgrade
@@ -1373,6 +1382,24 @@ func (r *Exec) restartContainer(cell intmodel.Cell, containerID string) (intmode
 		return r.restartContainerFn(cell, containerID)
 	}
 	return r.StartContainer(cell, containerID)
+}
+
+// stampContainerRestart records a fired restart on the user-visible
+// ContainerStatus counters (#1234): it bumps RestartCount by exactly one over the
+// preserved prior and stamps RestartTime to now. maybeRestartExitedContainers is
+// the sole caller; populateCellContainerStatuses only preserves these fields, so
+// the count is an exact per-restart tally that stays monotonic across ticks.
+// Distinct from the runner-local recordRestartAttempt bookkeeping (backoff/cap
+// gate state), which resets when the container is observed running again. A no-op
+// if the container is absent from cell.Status.Containers.
+func stampContainerRestart(cell *intmodel.Cell, containerID string, now time.Time) {
+	for i := range cell.Status.Containers {
+		if cell.Status.Containers[i].ID == containerID {
+			cell.Status.Containers[i].RestartCount++
+			cell.Status.Containers[i].RestartTime = now
+			return
+		}
+	}
 }
 
 // restartStateKey derives the per-container key for the restart bookkeeping map

--- a/internal/controller/runner/restart_on_exit_test.go
+++ b/internal/controller/runner/restart_on_exit_test.go
@@ -582,3 +582,153 @@ func TestReconcileCell_RestartHoldsCellDegraded(t *testing.T) {
 			outCell.Status.State)
 	}
 }
+
+// TestMaybeRestartExitedContainers_BumpsRestartCounterByOne pins AC items 1 & 2
+// of #1234: a fired restart bumps the user-visible RestartCount by exactly one
+// over the preserved prior and stamps RestartTime to now. maybeRestartExitedContainers
+// is the sole writer, so the increment must land on the returned cell's status.
+func TestMaybeRestartExitedContainers_BumpsRestartCounterByOne(t *testing.T) {
+	now := time.Unix(1_700_000_000, 0).UTC()
+	r, fired := recordingRestarter(now, nil)
+	cell := restartTestCell(intmodel.RestartPolicyAlways, intmodel.ContainerStateExited, 0)
+
+	out, result, err := r.maybeRestartExitedContainers(cell)
+	if err != nil {
+		t.Fatalf("maybeRestartExitedContainers: unexpected error: %v", err)
+	}
+	if result != restartFired {
+		t.Fatalf("result = %v, want restartFired", result)
+	}
+	if len(*fired) != 1 || (*fired)[0] != "work" {
+		t.Fatalf("relaunched %v, want exactly [work]", *fired)
+	}
+
+	work := containerStatusByID(t, out, "work")
+	if work.RestartCount != 1 {
+		t.Errorf("RestartCount = %d, want 1 (exactly one bump over the zero prior)", work.RestartCount)
+	}
+	if !work.RestartTime.Equal(now) {
+		t.Errorf("RestartTime = %v, want %v (the wall-clock of the relaunch)", work.RestartTime, now)
+	}
+
+	// The root container is not restarted, so its counters stay zero — the bump
+	// is per-container, not cell-wide.
+	root := containerStatusByID(t, out, "root")
+	if root.RestartCount != 0 || !root.RestartTime.IsZero() {
+		t.Errorf("root RestartCount=%d RestartTime=%v, want 0/zero (root is never restarted)",
+			root.RestartCount, root.RestartTime)
+	}
+}
+
+// TestMaybeRestartExitedContainers_RestartCounterMonotonic pins AC item 4: the
+// count advances by one from whatever prior the status carried, so successive
+// restarts tally monotonically (no Docker-style reset).
+func TestMaybeRestartExitedContainers_RestartCounterMonotonic(t *testing.T) {
+	now := time.Unix(1_700_000_000, 0).UTC()
+	r, _ := recordingRestarter(now, nil)
+	cell := restartTestCell(intmodel.RestartPolicyAlways, intmodel.ContainerStateExited, 0)
+	// Seed a non-zero prior, as populate would have preserved from earlier ticks.
+	for i := range cell.Status.Containers {
+		if cell.Status.Containers[i].ID == "work" {
+			cell.Status.Containers[i].RestartCount = 4
+			cell.Status.Containers[i].RestartTime = now.Add(-time.Hour)
+		}
+	}
+
+	out, result, err := r.maybeRestartExitedContainers(cell)
+	if err != nil {
+		t.Fatalf("maybeRestartExitedContainers: unexpected error: %v", err)
+	}
+	if result != restartFired {
+		t.Fatalf("result = %v, want restartFired", result)
+	}
+	work := containerStatusByID(t, out, "work")
+	if work.RestartCount != 5 {
+		t.Errorf("RestartCount = %d, want 5 (prior 4 + 1, monotonic — no reset)", work.RestartCount)
+	}
+	if !work.RestartTime.Equal(now) {
+		t.Errorf("RestartTime = %v, want refreshed to %v on each restart", work.RestartTime, now)
+	}
+}
+
+// TestMaybeRestartExitedContainers_NoBumpWhenNoRestartFires confirms the counter
+// is untouched when no restart is owed — the sole-writer contract means a
+// no-fire tick must leave RestartCount/RestartTime exactly as populate preserved
+// them.
+func TestMaybeRestartExitedContainers_NoBumpWhenNoRestartFires(t *testing.T) {
+	now := time.Unix(1_700_000_000, 0).UTC()
+	r, fired := recordingRestarter(now, nil)
+	// never-policy clean exit: no restart owed.
+	cell := restartTestCell(intmodel.RestartPolicyNever, intmodel.ContainerStateStopped, 0)
+	for i := range cell.Status.Containers {
+		if cell.Status.Containers[i].ID == "work" {
+			cell.Status.Containers[i].RestartCount = 2
+			cell.Status.Containers[i].RestartTime = now.Add(-time.Hour)
+		}
+	}
+
+	out, result, err := r.maybeRestartExitedContainers(cell)
+	if err != nil {
+		t.Fatalf("maybeRestartExitedContainers: unexpected error: %v", err)
+	}
+	if result != restartNone || len(*fired) != 0 {
+		t.Fatalf("result = %v, fired = %v, want restartNone with no relaunch", result, *fired)
+	}
+	work := containerStatusByID(t, out, "work")
+	if work.RestartCount != 2 || !work.RestartTime.Equal(now.Add(-time.Hour)) {
+		t.Errorf("RestartCount=%d RestartTime=%v, want untouched 2/%v (no fire ⇒ no bump)",
+			work.RestartCount, work.RestartTime, now.Add(-time.Hour))
+	}
+}
+
+// containerStatusByID returns the status for containerID in cell, failing the
+// test if absent.
+func containerStatusByID(t *testing.T, cell intmodel.Cell, containerID string) intmodel.ContainerStatus {
+	t.Helper()
+	for _, s := range cell.Status.Containers {
+		if s.ID == containerID {
+			return s
+		}
+	}
+	t.Fatalf("container %q not found in cell status", containerID)
+	return intmodel.ContainerStatus{}
+}
+
+// TestPopulateCellContainerStatuses_PreservesRestartCounters is the populate
+// half of #1234: populateCellContainerStatuses is a pure preserver of
+// RestartCount/RestartTime — it carries the persisted values across the
+// unconditional overwrite and never increments, even across repeated passes.
+func TestPopulateCellContainerStatuses_PreservesRestartCounters(t *testing.T) {
+	realm, space, stack, cellName := "default", "kukeon", "kukeon", "web"
+	containerID, containerdID := "root", "kukeon_kukeon_web_root"
+
+	fake := &deleteCellFakeClient{
+		existsContainerFn: func(_, _ string) (bool, error) { return true, nil },
+		taskStatusFn: func(_, _ string) (containerd.Status, error) {
+			return containerd.Status{Status: containerd.Running}, nil
+		},
+	}
+	r := newDeleteCellTestExec(t, fake)
+	seedDeleteCellRealm(t, r, realm)
+
+	cell := containerStateCell(realm, space, stack, cellName, containerID, containerdID)
+	restartTime := time.Date(2026, 6, 7, 20, 35, 4, 0, time.UTC)
+	cell.Status.Containers = []intmodel.ContainerStatus{
+		{ID: containerID, RestartCount: 3, RestartTime: restartTime},
+	}
+
+	// Two consecutive populate passes must both preserve the prior values
+	// unchanged — populate never writes these counters.
+	for pass := 1; pass <= 2; pass++ {
+		if err := r.populateCellContainerStatuses(&cell); err != nil {
+			t.Fatalf("populateCellContainerStatuses (pass %d): unexpected error: %v", pass, err)
+		}
+		got := cell.Status.Containers[0]
+		if got.RestartCount != 3 {
+			t.Errorf("pass %d: RestartCount = %d, want preserved 3 (populate never increments)", pass, got.RestartCount)
+		}
+		if !got.RestartTime.Equal(restartTime) {
+			t.Errorf("pass %d: RestartTime = %v, want preserved %v", pass, got.RestartTime, restartTime)
+		}
+	}
+}

--- a/internal/controller/runner/runner.go
+++ b/internal/controller/runner/runner.go
@@ -350,11 +350,12 @@ type Exec struct {
 	// the attempt count and last-attempt time the restart pass uses to enforce
 	// the per-container backoff floor and the on-failure retry cap. Keyed by
 	// cellLockKey + container ID. Deliberately NOT the persisted user-visible
-	// RestartCount / RestartTime on ContainerStatus — that bookkeeping is
-	// #1234's scope (documented intentionally-zero in #1303); this is
-	// runner-local gate state only, reset whenever the container is observed
-	// running again. Guarded by restartStatesMu; lazily initialized so *Exec
-	// values built directly in tests participate without fixture wiring.
+	// RestartCount / RestartTime on ContainerStatus — those are written by
+	// maybeRestartExitedContainers via stampContainerRestart (#1234) and
+	// preserved by populateCellContainerStatuses; this is runner-local gate state
+	// only, reset whenever the container is observed running again. Guarded by
+	// restartStatesMu; lazily initialized so *Exec values built directly in tests
+	// participate without fixture wiring.
 	restartStates   map[string]*containerRestartState
 	restartStatesMu sync.Mutex
 


### PR DESCRIPTION
## Summary

- Phase 2 of the restart-on-exit epic (#1151). Step 1 (#1233, PR #1308) landed the reconciler restart pass (`maybeRestartExitedContainers` in `refresh.go`) as the single place a non-root container restart happens. This step makes that pass the **sole writer** of the user-visible `RestartCount`/`RestartTime` counters and turns `populateCellContainerStatuses` into a pure preserver of them.
- **Sole-writer increment** (`refresh.go`): new `stampContainerRestart` helper, called from `maybeRestartExitedContainers` immediately after a successful relaunch — bumps `RestartCount` by exactly one over the preserved prior and stamps `RestartTime = r.nowUTC()`. `StartContainer` re-derives statuses from the persisted (preserved) prior, so the bump lands on top of it; `ReconcileCell`'s `restartFired` branch then persists the incremented value via the existing `persistCellStatusGuarded` path. Single increment site ⇒ exact, monotonic count that survives ticks.
- **Pure preserver** (`helpers.go`): `populateCellContainerStatuses` now snapshots `priorRestartCount`/`priorRestartTime` (same observe-and-preserve contract as `CreatedAt`/`StartTime`/`ExitCode`) and carries them across the unconditional overwrite. It never increments; a never-restarted container preserves zero from zero. The prior intentionally-zero block is gone.
- **Comment refresh** (`runner.go`): the `restartStates` doc-comment previously flagged the user-visible counters as "#1234's scope (documented intentionally-zero in #1303)"; updated to point at `stampContainerRestart` / the populate preserve now that they're wired.

## Premise-rot note (salvageable — flagged per dev CLAUDE.md)

The issue's Proposal says to "Replace the `TODO(#1146)` markers (`helpers.go:864-865`)". Those markers no longer exist: #1303 (the #1146 marker-documentation chore) landed first and replaced them with `intentionally-zero` comments, which had since shifted to ~`helpers.go:1057-1070`. Per the issue's own *"Ordering vs #1146"* note ("if #1146's marker-documentation chore lands first, this step supersedes its comments"), I superseded the current intentionally-zero block rather than the original `TODO(#1146)` text. Intent unchanged — these are the same lines, just relabeled and relocated by the intervening chore.

## Test plan

- [x] `make test` (full CI suite, `test-root` + `test-kukebuild`) — green, `MAKE-TEST-EXIT=0`, no FAIL lines.
- [x] `GOWORK=off go build ./internal/controller/runner/` and `go vet` — clean.
- [x] New colocated unit tests in `internal/controller/runner/restart_on_exit_test.go`:
  - `TestMaybeRestartExitedContainers_BumpsRestartCounterByOne` — increment-by-one + `RestartTime` stamp on a fired restart; root container untouched (AC 1, 2).
  - `TestMaybeRestartExitedContainers_RestartCounterMonotonic` — prior 4 → 5, no reset (AC 4).
  - `TestMaybeRestartExitedContainers_NoBumpWhenNoRestartFires` — sole-writer contract: a no-fire tick leaves the counters exactly as preserved.
  - `TestPopulateCellContainerStatuses_PreservesRestartCounters` — populate preserves across two passes, never increments (AC 3, 5).

## Acceptance criteria

- [x] `RestartCount` increments by exactly one per reconciler-driven restart and survives subsequent reconciliation passes (increment in the restart pass + populate preserve).
- [x] `RestartTime` reflects the wall-clock time of the most recent restart and survives subsequent passes.
- [x] `populateCellContainerStatuses` never increments — pure preserver; the intentionally-zero block (the relabeled `TODO(#1146)` markers — see premise-rot note) is gone.
- [x] Counters are monotonic (no reset while the container record lives).
- [x] Unit coverage colocated with runner tests: counter increment on restart, preservation across populate passes.

Closes #1234