### PR TITLE
fix: exclude restart-policy-pinned root from StartCell running-container guard on Exited cells

### DIFF
--- a/internal/controller/get_cell.go
+++ b/internal/controller/get_cell.go
@@ -149,6 +149,21 @@ func rootContainerID(cell intmodel.Cell) string {
 	return ""
 }
 
+// hasNonRootContainerSpec reports whether the cell carries at least one
+// non-root (workload) container in spec. It mirrors the runner package's
+// derivation split (deriveCellStateFromNonRootContainerStatuses): a cell with
+// a non-root workload follows its workloads' lifecycle and its root is just the
+// cell shell, whereas a root-only cell (kukeond-style / cgroup-only) has the
+// root standing in as the workload.
+func hasNonRootContainerSpec(cell intmodel.Cell) bool {
+	for i := range cell.Spec.Containers {
+		if !cell.Spec.Containers[i].Root {
+			return true
+		}
+	}
+	return false
+}
+
 // ListCells lists all cells, optionally filtered by realm, space, and/or stack.
 func (b *Exec) ListCells(realmName, spaceName, stackName string) ([]intmodel.Cell, error) {
 	return b.runner.ListCells(realmName, spaceName, stackName)

--- a/internal/controller/start_cell.go
+++ b/internal/controller/start_cell.go
@@ -133,14 +133,27 @@ func (b *Exec) StartCell(cell intmodel.Cell) (StartCellResult, error) {
 	// This prevents blocking starts when containers have crashed externally but metadata still shows Ready state.
 	// Only Ready / Stopped / Exited reach here — the recovery switch above
 	// already claimed Pending / Unknown (refused) and Failed / Error / Degraded
-	// (recreate), so a leftover-running root on a recoverable terminal cell no
-	// longer trips this guard. Degraded is no longer in the fall-through set: an
-	// operator start/restart of a partially-down cell routes through the recovery
-	// recreate above so it lands Ready in a single action (#1317 review).
+	// (recreate). The guard blocks on live *workloads*, not the cell shell: on a
+	// cell with a non-root workload spec the root container is excluded, because
+	// a #1003 restart-policy veto (a non-root workload that exits cleanly under
+	// on-failure, or exits under never) deliberately leaves the root alive on an
+	// otherwise-Exited cell, and that pinned root must not wedge the cell against
+	// `kuke run` / `start` / `restart` (#1316). Root-only cells (kukeond-style /
+	// cgroup-only, no non-root spec) keep the root in the check — there the root
+	// IS the workload, so a running root must still block a duplicate start. The
+	// root/non-root split is the same one deriveCellStateFromNonRootContainer-
+	// Statuses uses to derive the cell state in the first place.
 	if len(internalCell.Status.Containers) > 0 {
-		// Check if any container is actually running
+		rootID := ""
+		if hasNonRootContainerSpec(internalCell) {
+			rootID = rootContainerID(internalCell)
+		}
+		// Check if any non-root container is actually running
 		hasRunningContainer := false
 		for _, containerStatus := range internalCell.Status.Containers {
+			if rootID != "" && containerStatus.ID == rootID {
+				continue
+			}
 			if containerStatus.State == intmodel.ContainerStateReady {
 				hasRunningContainer = true
 				break

--- a/internal/controller/start_cell_test.go
+++ b/internal/controller/start_cell_test.go
@@ -546,6 +546,89 @@ func TestStartCell_ReadyStateValidation(t *testing.T) {
 			},
 			wantErr: false,
 		},
+		{
+			// #1316: an Exited cell whose non-root workload cleanly exited under a
+			// restart-policy that vetoes wind-down (on-failure clean exit, or
+			// never) deliberately keeps its ROOT container alive (#1003). Exited is
+			// NOT in the recovery switch above (its container records are intact and
+			// re-runnable), so it falls through to this guard — which must exclude
+			// the live root and allow the start, restarting the root rather than
+			// refusing. Before the fix the running root tripped "has running
+			// containers and must first be stopped", wedging the cell (it would
+			// neither wind down nor restart). The fix narrows the guard to live
+			// non-root workloads.
+			name:      "cell in Exited state with restart-policy-pinned live root allows start",
+			cellName:  "exited-cell-live-root",
+			realmName: "test-realm",
+			spaceName: "test-space",
+			stackName: "test-stack",
+			setupRunner: func(f *fakeRunner) {
+				existingCell := buildTestCell("exited-cell-live-root", "test-realm", "test-space", "test-stack")
+				existingCell.Status.State = intmodel.CellStateExited
+				existingCell.Spec.Containers = []intmodel.ContainerSpec{
+					{ID: "root", Image: "alpine:latest", Root: true},
+					{ID: "container1", Image: "alpine:latest"},
+				}
+				// Root still running (restart-policy veto leaves it alive), non-root
+				// workload exited cleanly — the Ready 1/2 shape from the repro.
+				existingCell.Status.Containers = []intmodel.ContainerStatus{
+					{ID: "root", State: intmodel.ContainerStateReady},
+					{ID: "container1", State: intmodel.ContainerStateExited},
+				}
+				f.GetCellFn = func(_ intmodel.Cell) (intmodel.Cell, error) {
+					return existingCell, nil
+				}
+				f.ExistsCgroupFn = func(_ any) (bool, error) {
+					return true, nil
+				}
+				f.ExistsCellRootContainerFn = func(_ intmodel.Cell) (bool, error) {
+					return true, nil
+				}
+				// The start must go through a plain StartCell (Exited is not a
+				// recovery-switch state) — assert it is reached, not refused.
+				f.StartCellFn = func(cell intmodel.Cell) (intmodel.Cell, error) {
+					cell.Status.State = intmodel.CellStateReady
+					return cell, nil
+				}
+				f.UpdateCellMetadataFn = func(_ intmodel.Cell) error {
+					return nil
+				}
+			},
+			wantErr: false,
+		},
+		{
+			// #1316 guardrail: a root-only cell (kukeond-style, no non-root spec)
+			// keeps the root in the running-container check — there the root IS the
+			// workload, so a live root must still block a duplicate start. This pins
+			// that the root-exclusion is gated on hasNonRootContainerSpec and does
+			// not leak into root-only cells.
+			name:      "root-only cell with running root still blocks start",
+			cellName:  "root-only-cell",
+			realmName: "test-realm",
+			spaceName: "test-space",
+			stackName: "test-stack",
+			setupRunner: func(f *fakeRunner) {
+				existingCell := buildTestCell("root-only-cell", "test-realm", "test-space", "test-stack")
+				existingCell.Status.State = intmodel.CellStateReady
+				existingCell.Spec.Containers = []intmodel.ContainerSpec{
+					{ID: "root", Image: "alpine:latest", Root: true},
+				}
+				existingCell.Status.Containers = []intmodel.ContainerStatus{
+					{ID: "root", State: intmodel.ContainerStateReady},
+				}
+				f.GetCellFn = func(_ intmodel.Cell) (intmodel.Cell, error) {
+					return existingCell, nil
+				}
+				f.ExistsCgroupFn = func(_ any) (bool, error) {
+					return true, nil
+				}
+				f.ExistsCellRootContainerFn = func(_ intmodel.Cell) (bool, error) {
+					return true, nil
+				}
+			},
+			wantErr:     true,
+			errContains: "cell \"root-only-cell\" has running containers and must first be stopped",
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Summary

- An `Exited` cell whose non-root workload cleanly exited under a `restartPolicy` that vetoes wind-down (`on-failure` + clean exit, or `never`) deliberately keeps its **root** container alive (#1003 — `restartPolicyPermitsCellReap` returns false, so `shouldWindDownCell` is vetoed and the root is left running by design). Such a cell shows `Exited` with `READY 1/2`.
- `kuke run`/`start`/`restart` on that cell calls `StartCell`, which routes `Failed`/`Error`/`Degraded` to `RecreateCell` (those handle a leftover-running root) but lets `Exited` fall through to the running-container guard at `internal/controller/start_cell.go`. That guard iterated **all** `Status.Containers` and tripped on the deliberately-alive root, returning `cell %q has running containers and must first be stopped` — wedging the cell (it won't wind down by design, and won't restart). The only workaround was `kuke stop` then `kuke run`.
- Fix narrows the guard to live **workloads**: on a cell with a non-root workload spec the **root** container is excluded from the running-container check (cross-referencing `Status.Containers` IDs against the root spec via the same `rootContainerID` / root-vs-non-root split `deriveCellStateFromNonRootContainerStatuses` already uses). This is the issue's suggested option 1 — lower blast radius than re-routing `Exited` through `RecreateCell`, and it matches the guard's documented intent.
- **Guardrail preserved for root-only cells.** The root-exclusion is gated on `hasNonRootContainerSpec`: kukeond-style / cgroup-only cells (no non-root spec) keep the root in the check, because there the root *is* the workload and a running root must still block a duplicate start. A new `hasNonRootContainerSpec` helper is added to the `controller` package (`get_cell.go`), mirroring the runner package's same-named helper — `runner`'s is unexported so it can't be reused across the package boundary, and duplicating the trivial 5-line check keeps the root/non-root split consistent without exporting internals.

## Implementation notes

- The suggested fix referenced `internal/controller/start_cell.go:129-143` and `:126-128`; those line numbers shifted slightly after #1318 added `Degraded` to the recovery switch. The fix lands at the same logical guard (now ~`:140-154`). The guard's doc-comment is updated: the prior "a leftover-running root … no longer trips this guard" claim was true only for the `Failed`/`Error`/`Degraded` recreate routes; it now states the `Exited`-with-pinned-root exclusion explicitly.

## Test plan

- [x] `make test` (full CI suite, `GOWORK=off`) — exit 0, no failures.
- [x] `GOWORK=off go vet ./internal/controller/...` — clean.
- [x] New table case `cell in Exited state with restart-policy-pinned live root allows start` (mirrors `start_cell_test.go`'s `Error`-live-root case but with cell state `Exited`, the running container marked root, and a non-root workload `Exited`): asserts the start is allowed and routes through a plain `StartCell` (not refused).
- [x] New guardrail case `root-only cell with running root still blocks start`: asserts a `Ready` root-only cell with a live root still trips the guard — pins that the root-exclusion does not leak into root-only cells.

Closes #1316