### PR TITLE
docs: add Google Analytics to mkdocs site config

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -136,6 +136,9 @@ nav:
   - FAQ: faq.md
 
 extra:
+  analytics:
+    provider: google
+    property: G-SFBQZ2FFFQ
   social:
     - icon: fontawesome/brands/github
       link: https://github.com/eminwux/kukeon


### PR DESCRIPTION
## Summary

Enable mkdocs-material's native Google Analytics provider for property `G-SFBQZ2FFFQ`.

```yaml
extra:
  analytics:
    provider: google
    property: G-SFBQZ2FFFQ
```

Material injects the `gtag.js` loader and `gtag('config', 'G-SFBQZ2FFFQ')` call into the page `<head>`, equivalent to pasting the raw gtag snippet but routed through the theme templates (correct `extrahead` placement, SPA page-view tracking, and compatibility with the optional consent/feedback widgets).

## Notes

- No cookie-consent banner is wired up — the tag loads unconditionally. If GDPR consent gating is needed, add an `extra.consent` block in a follow-up.
- Verify locally with `mkdocs serve` (page source should reference `googletagmanager.com/gtag/js?id=G-SFBQZ2FFFQ`); the Pages deploy picks it up on merge to `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)