### PR TITLE
feat: add user-authored restart backoff and max-retries container fields

### DIFF
--- a/docs/site/manifests/container.md
+++ b/docs/site/manifests/container.md
@@ -87,6 +87,8 @@ See [Concepts → Container](../concepts/container.md) for what a container is.
 | `git`             | `ContainerGit`             | no       | Declarative git identity + signing, expanded into `GIT_AUTHOR_*`/`GIT_COMMITTER_*`/`GIT_CONFIG_*` env before start (see [ContainerGit](#containergit))                                                                       |
 | `cniConfigPath`   | string                     | no       | Override the CNI config directory for this container                                                                                                                                                                         |
 | `restartPolicy`   | string                     | no       | Per-container reap policy at the cell wind-down / auto-delete gate. One of `always`, `on-failure`, `never`. Empty defaults to `never` (matches the Kubernetes default restartPolicy; see [Restart policy](#restart-policy)). |
+| `restartBackoffSeconds` | int                  | no       | Minimum seconds between reconciler-driven restarts of this container. Unset uses the built-in `30s` default; `0` disables the floor. Requires a restarting policy (`always`/`on-failure`). See [Restart on exit](#restart-on-exit).                                                       |
+| `restartMaxRetries`     | int                  | no       | `on-failure` retry cap before the container is left terminal. Unset uses the built-in `5` default; must be ≥ 1. Requires `restartPolicy: on-failure`. See [Restart on exit](#restart-on-exit).                                                                                            |
 | `tty`             | `ContainerTty`             | no       | Shell-UX config for the kuketty wrapper (prompt, init scripts, logging) — requires `attachable: true` (see [ContainerTty](#containertty))                                                                                    |
 
 !!! warning "Fields marked reserved"
@@ -119,6 +121,24 @@ The same `restartPolicy` value also drives whether the reconciler **relaunches**
 | `never`      | Never.                                                                                    |
 
 **Restart timing.** Restarts are evaluated on the reconcile loop, so a relaunch lands on the next reconcile tick after the exit is observed, not synchronously. Successive attempts on the same container are spaced by a minimum **30s backoff** — an exit inside the backoff window defers to a later tick. An `on-failure` container is capped at **5 restart attempts**; once the cap is exhausted the cell settles into the sticky `Error` state and self-healing stops until an operator intervenes. `always` is uncapped (it keeps the backoff but never exhausts).
+
+**Tuning the backoff and cap.** The `30s` backoff floor and `5`-attempt `on-failure` cap above are the built-in defaults. Two optional per-container fields override them:
+
+| Field                   | Type | Default | Behavior                                                                                                                                                                                |
+| ----------------------- | ---- | ------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `restartBackoffSeconds` | int  | `30`    | Minimum seconds between successive restarts of this container. `0` disables the floor (a restart fires on the next reconcile tick that observes the exit). Negative values are rejected. |
+| `restartMaxRetries`     | int  | `5`     | Maximum `on-failure` restart attempts before the container is left terminal and the cell settles into `Error`. Must be ≥ 1.                                                             |
+
+Both fields are optional; **omit them and existing behavior is unchanged** (the built-in `30s` / `5` defaults apply). They only take effect under a restarting policy, so applying them with a policy that does not restart is a validation error:
+
+- `restartBackoffSeconds` requires `restartPolicy: always` or `on-failure`.
+- `restartMaxRetries` requires `restartPolicy: on-failure` (the cap is on-failure-specific; `always` is uncapped by contract).
+
+```yaml
+restartPolicy: on-failure
+restartBackoffSeconds: 10 # retry sooner than the 30s default
+restartMaxRetries: 3 # give up after 3 failed relaunches instead of 5
+```
 
 **Policy → cell `STATE`.** While a workload is down with a relaunch owed (or in backoff), the cell holds at the non-sticky `Degraded` state rather than the sticky `Error` a bare crash would derive — so the restart loop stays re-derivable and the cell returns to `Ready` once the workload is back up. `Degraded` is the partial-health rung between `Ready` and `Error` (root/sandbox up, a non-root workload down or restarting); see the [`status.state` table in the cell manifest](cell.md#status). The settled cell state after a single non-root workload is killed with a non-zero (e.g. SIGKILL / exit 137) signal:
 

--- a/internal/apischeme/scheme.go
+++ b/internal/apischeme/scheme.go
@@ -394,6 +394,9 @@ func ConvertContainerDocToInternal(in ext.ContainerDoc) (intmodel.Container, err
 		if err := validateContainerVolumes(in.Spec); err != nil {
 			return intmodel.Container{}, err
 		}
+		if err := validateContainerRestart(in.Spec); err != nil {
+			return intmodel.Container{}, err
+		}
 		return intmodel.Container{
 			Metadata: intmodel.ContainerMetadata{
 				Name:   in.Metadata.Name,
@@ -431,6 +434,8 @@ func ConvertContainerDocToInternal(in ext.ContainerDoc) (intmodel.Container, err
 				Git:                    gitToInternal(in.Spec.Git),
 				CNIConfigPath:          in.Spec.CNIConfigPath,
 				RestartPolicy:          in.Spec.RestartPolicy,
+				RestartBackoffSeconds:  in.Spec.RestartBackoffSeconds,
+				RestartMaxRetries:      in.Spec.RestartMaxRetries,
 				Attachable:             in.Spec.Attachable,
 				Tty:                    convertContainerTtyToInternal(in.Spec.Tty),
 			},
@@ -497,6 +502,8 @@ func BuildContainerExternalFromInternal(in intmodel.Container, apiVersion ext.Ve
 				Git:                    gitToExternal(in.Spec.Git),
 				CNIConfigPath:          in.Spec.CNIConfigPath,
 				RestartPolicy:          in.Spec.RestartPolicy,
+				RestartBackoffSeconds:  in.Spec.RestartBackoffSeconds,
+				RestartMaxRetries:      in.Spec.RestartMaxRetries,
 				Attachable:             in.Spec.Attachable,
 				Tty:                    buildContainerTtyExternalFromInternal(in.Spec.Tty),
 			},
@@ -566,6 +573,8 @@ func convertContainerSpecToInternal(in ext.ContainerSpec) intmodel.ContainerSpec
 		Git:                    gitToInternal(in.Git),
 		CNIConfigPath:          in.CNIConfigPath,
 		RestartPolicy:          in.RestartPolicy,
+		RestartBackoffSeconds:  in.RestartBackoffSeconds,
+		RestartMaxRetries:      in.RestartMaxRetries,
 		Attachable:             in.Attachable,
 		Tty:                    convertContainerTtyToInternal(in.Tty),
 	}
@@ -607,6 +616,8 @@ func BuildContainerSpecExternalFromInternal(in intmodel.ContainerSpec) ext.Conta
 		Git:                    gitToExternal(in.Git),
 		CNIConfigPath:          in.CNIConfigPath,
 		RestartPolicy:          in.RestartPolicy,
+		RestartBackoffSeconds:  in.RestartBackoffSeconds,
+		RestartMaxRetries:      in.RestartMaxRetries,
 		Attachable:             in.Attachable,
 		Tty:                    buildContainerTtyExternalFromInternal(in.Tty),
 	}
@@ -702,6 +713,47 @@ func validateContainerTty(spec ext.ContainerSpec) error {
 	}
 	if err := validateContainerCreateStagePersistence(spec); err != nil {
 		return err
+	}
+	return nil
+}
+
+// validateContainerRestart enforces the bounds and policy-applicability of the
+// user-authored restart-tuning fields (#1235). The fields parameterize the
+// runner's hardcoded backoff floor and on-failure retry cap (#1233); they are
+// rejected at apply time rather than silently ignored when they can never take
+// effect, mirroring validateContainerTty's "config that can't take effect is an
+// error" contract.
+//
+//   - restartBackoffSeconds: must be >= 0, and only valid under a restarting
+//     policy (`always` or `on-failure`) — the floor never applies to a
+//     `never`/empty policy that does not restart on exit.
+//   - restartMaxRetries: must be >= 1, and only valid under `on-failure` — the
+//     cap is on-failure-specific (`always` is uncapped by contract, see
+//     refresh.go:restartDecisionFor).
+func validateContainerRestart(spec ext.ContainerSpec) error {
+	policy := spec.RestartPolicy
+	restarts := policy == intmodel.RestartPolicyAlways || policy == intmodel.RestartPolicyOnFailure
+	if spec.RestartBackoffSeconds != nil {
+		if *spec.RestartBackoffSeconds < 0 {
+			return fmt.Errorf("container %q: restartBackoffSeconds must be >= 0, got %d", spec.ID, *spec.RestartBackoffSeconds)
+		}
+		if !restarts {
+			return fmt.Errorf(
+				"container %q: restartBackoffSeconds requires restartPolicy %q or %q, got %q",
+				spec.ID, intmodel.RestartPolicyAlways, intmodel.RestartPolicyOnFailure, policy,
+			)
+		}
+	}
+	if spec.RestartMaxRetries != nil {
+		if *spec.RestartMaxRetries < 1 {
+			return fmt.Errorf("container %q: restartMaxRetries must be >= 1, got %d", spec.ID, *spec.RestartMaxRetries)
+		}
+		if policy != intmodel.RestartPolicyOnFailure {
+			return fmt.Errorf(
+				"container %q: restartMaxRetries requires restartPolicy %q, got %q",
+				spec.ID, intmodel.RestartPolicyOnFailure, policy,
+			)
+		}
 	}
 	return nil
 }
@@ -1545,6 +1597,9 @@ func ConvertCellDocToInternal(in ext.CellDoc) (intmodel.Cell, error) {
 				return intmodel.Cell{}, err
 			}
 			if err := validateContainerVolumes(c); err != nil {
+				return intmodel.Cell{}, err
+			}
+			if err := validateContainerRestart(c); err != nil {
 				return intmodel.Cell{}, err
 			}
 		}

--- a/internal/apischeme/scheme_test.go
+++ b/internal/apischeme/scheme_test.go
@@ -2733,3 +2733,172 @@ func TestContainerCreateStagePersistenceValidation(t *testing.T) {
 		}
 	})
 }
+
+// restartInt64Ptr is a local helper for the *int64 restart-tuning fields (#1235).
+func restartInt64Ptr(v int64) *int64 { return &v }
+
+// TestContainerRestartTuningRoundTripV1Beta1 pins the #1235 user-authored
+// restart-tuning fields: restartBackoffSeconds + restartMaxRetries set on a
+// container survive Normalize → controller → Build with no drops, in both the
+// standalone ContainerDoc path and the nested CellSpec.Containers path.
+func TestContainerRestartTuningRoundTripV1Beta1(t *testing.T) {
+	backoff := restartInt64Ptr(10)
+	maxRetries := restartInt64Ptr(3)
+
+	input := ext.ContainerDoc{
+		APIVersion: ext.APIVersionV1Beta1,
+		Kind:       ext.KindContainer,
+		Metadata:   ext.ContainerMetadata{Name: "c"},
+		Spec: ext.ContainerSpec{
+			ID:      "c",
+			RealmID: "r", SpaceID: "s", StackID: "st", CellID: "cl",
+			Image:                 "alpine:latest",
+			RestartPolicy:         "on-failure",
+			RestartBackoffSeconds: backoff,
+			RestartMaxRetries:     maxRetries,
+		},
+	}
+
+	internal, version, err := apischeme.NormalizeContainer(input)
+	if err != nil {
+		t.Fatalf("NormalizeContainer failed: %v", err)
+	}
+	if internal.Spec.RestartBackoffSeconds == nil || *internal.Spec.RestartBackoffSeconds != 10 {
+		t.Fatalf("internal RestartBackoffSeconds = %v, want 10", internal.Spec.RestartBackoffSeconds)
+	}
+	if internal.Spec.RestartMaxRetries == nil || *internal.Spec.RestartMaxRetries != 3 {
+		t.Fatalf("internal RestartMaxRetries = %v, want 3", internal.Spec.RestartMaxRetries)
+	}
+
+	output, err := apischeme.BuildContainerExternalFromInternal(internal, version)
+	if err != nil {
+		t.Fatalf("BuildContainerExternalFromInternal failed: %v", err)
+	}
+	if output.Spec.RestartBackoffSeconds == nil || *output.Spec.RestartBackoffSeconds != 10 {
+		t.Fatalf("output RestartBackoffSeconds = %v, want 10", output.Spec.RestartBackoffSeconds)
+	}
+	if output.Spec.RestartMaxRetries == nil || *output.Spec.RestartMaxRetries != 3 {
+		t.Fatalf("output RestartMaxRetries = %v, want 3", output.Spec.RestartMaxRetries)
+	}
+}
+
+// TestContainerRestartTuningOmittedRoundTrip pins AC: an unset (nil) field
+// preserves the hardcoded default — it stays nil through the round trip (the
+// runner's effective* helpers, not the conversion, apply the default) and is
+// omitted from marshalled YAML so existing specs are byte-unaffected.
+func TestContainerRestartTuningOmittedRoundTrip(t *testing.T) {
+	input := ext.ContainerDoc{
+		APIVersion: ext.APIVersionV1Beta1,
+		Kind:       ext.KindContainer,
+		Metadata:   ext.ContainerMetadata{Name: "c"},
+		Spec: ext.ContainerSpec{
+			ID:      "c",
+			RealmID: "r", SpaceID: "s", StackID: "st", CellID: "cl",
+			Image: "alpine:latest",
+		},
+	}
+
+	internal, version, err := apischeme.NormalizeContainer(input)
+	if err != nil {
+		t.Fatalf("NormalizeContainer failed: %v", err)
+	}
+	if internal.Spec.RestartBackoffSeconds != nil || internal.Spec.RestartMaxRetries != nil {
+		t.Fatalf("unset fields became non-nil internally: backoff=%v retries=%v",
+			internal.Spec.RestartBackoffSeconds, internal.Spec.RestartMaxRetries)
+	}
+
+	output, err := apischeme.BuildContainerExternalFromInternal(internal, version)
+	if err != nil {
+		t.Fatalf("BuildContainerExternalFromInternal failed: %v", err)
+	}
+	if output.Spec.RestartBackoffSeconds != nil || output.Spec.RestartMaxRetries != nil {
+		t.Fatalf("unset fields became non-nil externally: backoff=%v retries=%v",
+			output.Spec.RestartBackoffSeconds, output.Spec.RestartMaxRetries)
+	}
+
+	marshalled, err := yaml.Marshal(output.Spec)
+	if err != nil {
+		t.Fatalf("yaml.Marshal: %v", err)
+	}
+	if strings.Contains(string(marshalled), "restartBackoffSeconds") ||
+		strings.Contains(string(marshalled), "restartMaxRetries") {
+		t.Fatalf("omitempty failed; unset restart-tuning fields rendered in YAML:\n%s", marshalled)
+	}
+}
+
+// TestValidateContainerRestart pins the #1235 validation surface: bounds and
+// policy-applicability of the restart-tuning fields. Driven through
+// NormalizeContainer so it exercises the same entrypoint apply uses.
+func TestValidateContainerRestart(t *testing.T) {
+	cases := []struct {
+		name       string
+		policy     string
+		backoff    *int64
+		maxRetries *int64
+		wantErr    bool
+	}{
+		{"unset fields, never policy", "never", nil, nil, false},
+		{"unset fields, empty policy", "", nil, nil, false},
+		{"backoff with always", "always", restartInt64Ptr(5), nil, false},
+		{"backoff with on-failure", "on-failure", restartInt64Ptr(15), nil, false},
+		{"backoff zero with on-failure", "on-failure", restartInt64Ptr(0), nil, false},
+		{"maxRetries with on-failure", "on-failure", nil, restartInt64Ptr(3), false},
+		{"both with on-failure", "on-failure", restartInt64Ptr(10), restartInt64Ptr(2), false},
+		{"backoff with never rejected", "never", restartInt64Ptr(5), nil, true},
+		{"backoff with empty rejected", "", restartInt64Ptr(5), nil, true},
+		{"backoff negative rejected", "on-failure", restartInt64Ptr(-1), nil, true},
+		{"maxRetries with always rejected", "always", nil, restartInt64Ptr(3), true},
+		{"maxRetries with never rejected", "never", nil, restartInt64Ptr(3), true},
+		{"maxRetries zero rejected", "on-failure", nil, restartInt64Ptr(0), true},
+		{"maxRetries negative rejected", "on-failure", nil, restartInt64Ptr(-2), true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			input := ext.ContainerDoc{
+				APIVersion: ext.APIVersionV1Beta1,
+				Kind:       ext.KindContainer,
+				Metadata:   ext.ContainerMetadata{Name: "c"},
+				Spec: ext.ContainerSpec{
+					ID:      "c",
+					RealmID: "r", SpaceID: "s", StackID: "st", CellID: "cl",
+					Image:                 "alpine:latest",
+					RestartPolicy:         tc.policy,
+					RestartBackoffSeconds: tc.backoff,
+					RestartMaxRetries:     tc.maxRetries,
+				},
+			}
+			_, _, err := apischeme.NormalizeContainer(input)
+			if tc.wantErr && err == nil {
+				t.Fatalf("NormalizeContainer accepted %s; want validation error", tc.name)
+			}
+			if !tc.wantErr && err != nil {
+				t.Fatalf("NormalizeContainer rejected %s: %v", tc.name, err)
+			}
+		})
+	}
+}
+
+// TestValidateContainerRestartViaCellPath pins that the same validation fires on
+// the nested CellSpec.Containers path (ConvertCellDocToInternal), not just the
+// standalone ContainerDoc path.
+func TestValidateContainerRestartViaCellPath(t *testing.T) {
+	cell := ext.CellDoc{
+		APIVersion: ext.APIVersionV1Beta1,
+		Kind:       ext.KindCell,
+		Metadata:   ext.CellMetadata{Name: "web"},
+		Spec: ext.CellSpec{
+			Containers: []ext.ContainerSpec{
+				{
+					ID:      "c",
+					RealmID: "r", SpaceID: "s", StackID: "st", CellID: "cl",
+					Image:             "alpine:latest",
+					RestartPolicy:     "never",
+					RestartMaxRetries: restartInt64Ptr(3),
+				},
+			},
+		},
+	}
+	if _, _, err := apischeme.NormalizeCell(cell); err == nil {
+		t.Fatal("NormalizeCell accepted restartMaxRetries with never policy; want validation error")
+	}
+}

--- a/internal/controller/runner/refresh.go
+++ b/internal/controller/runner/refresh.go
@@ -1257,7 +1257,7 @@ const (
 // policy says must restart should fire now, wait for backoff, or give up
 // against the on-failure cap. Reads (does not mutate) the per-container restart
 // state under the lock.
-func (r *Exec) restartDecisionFor(cell intmodel.Cell, containerID, policy string) restartPassResult {
+func (r *Exec) restartDecisionFor(cell intmodel.Cell, containerID, policy string, backoff time.Duration, maxRetries int) restartPassResult {
 	r.restartStatesMu.Lock()
 	defer r.restartStatesMu.Unlock()
 
@@ -1266,16 +1266,41 @@ func (r *Exec) restartDecisionFor(cell intmodel.Cell, containerID, policy string
 		// First observation of this exit: fire immediately, no prior backoff.
 		return restartFired
 	}
-	if policy == intmodel.RestartPolicyOnFailure && st.attempts >= onFailureMaxRestarts {
+	if policy == intmodel.RestartPolicyOnFailure && st.attempts >= maxRetries {
 		// on-failure cap exhausted: stop retrying. Reported as restartNone so
 		// the caller falls through to the reap gate (the crashed workload
 		// settles as Error and is preserved for the operator).
 		return restartNone
 	}
-	if !st.lastAttempt.IsZero() && r.nowUTC().Sub(st.lastAttempt) < restartBackoff {
+	if !st.lastAttempt.IsZero() && r.nowUTC().Sub(st.lastAttempt) < backoff {
 		return restartDeferred
 	}
 	return restartFired
+}
+
+// effectiveRestartBackoff resolves the per-container backoff floor the restart
+// pass enforces: the user-authored Spec.RestartBackoffSeconds (#1235) when set,
+// else the hardcoded restartBackoff default (#1233). A nil pointer is unset and
+// falls back to the default — no behavior change for specs that never set the
+// field. An explicit 0 disables the floor so a restart fires on the next
+// reconcile tick that observes the exit. Validation (apischeme) already rejects
+// a negative value, so the conversion to time.Duration is safe here.
+func effectiveRestartBackoff(spec intmodel.ContainerSpec) time.Duration {
+	if spec.RestartBackoffSeconds != nil {
+		return time.Duration(*spec.RestartBackoffSeconds) * time.Second
+	}
+	return restartBackoff
+}
+
+// effectiveOnFailureMaxRestarts resolves the per-container on-failure retry cap:
+// the user-authored Spec.RestartMaxRetries (#1235) when set, else the hardcoded
+// onFailureMaxRestarts default (#1233). A nil pointer is unset and falls back to
+// the default. Validation (apischeme) already rejects a value below 1.
+func effectiveOnFailureMaxRestarts(spec intmodel.ContainerSpec) int {
+	if spec.RestartMaxRetries != nil {
+		return int(*spec.RestartMaxRetries)
+	}
+	return onFailureMaxRestarts
 }
 
 // maybeRestartExitedContainers is the reconciler's restart-on-exit pass (#1233).
@@ -1338,7 +1363,8 @@ func (r *Exec) maybeRestartExitedContainers(cell intmodel.Cell) (intmodel.Cell, 
 			continue
 		}
 
-		switch r.restartDecisionFor(cell, spec.ID, spec.RestartPolicy) {
+		switch r.restartDecisionFor(cell, spec.ID, spec.RestartPolicy,
+			effectiveRestartBackoff(spec), effectiveOnFailureMaxRestarts(spec)) {
 		case restartFired:
 			started, startErr := r.restartContainer(cell, spec.ID)
 			// Record the attempt regardless of outcome: a failed relaunch still

--- a/internal/controller/runner/restart_on_exit_test.go
+++ b/internal/controller/runner/restart_on_exit_test.go
@@ -323,28 +323,28 @@ func TestRestartDecisionFor(t *testing.T) {
 
 	t.Run("first_attempt_fires", func(t *testing.T) {
 		r := &Exec{nowFn: fixedClock(now)}
-		if got := r.restartDecisionFor(cell, "work", intmodel.RestartPolicyOnFailure); got != restartFired {
+		if got := r.restartDecisionFor(cell, "work", intmodel.RestartPolicyOnFailure, restartBackoff, onFailureMaxRestarts); got != restartFired {
 			t.Errorf("got %v, want restartFired on first attempt", got)
 		}
 	})
 	t.Run("within_backoff_defers", func(t *testing.T) {
 		r := &Exec{nowFn: fixedClock(now)}
 		r.restartStates = map[string]*containerRestartState{key(r): {attempts: 1, lastAttempt: now.Add(-time.Second)}}
-		if got := r.restartDecisionFor(cell, "work", intmodel.RestartPolicyOnFailure); got != restartDeferred {
+		if got := r.restartDecisionFor(cell, "work", intmodel.RestartPolicyOnFailure, restartBackoff, onFailureMaxRestarts); got != restartDeferred {
 			t.Errorf("got %v, want restartDeferred within backoff", got)
 		}
 	})
 	t.Run("past_backoff_fires", func(t *testing.T) {
 		r := &Exec{nowFn: fixedClock(now)}
 		r.restartStates = map[string]*containerRestartState{key(r): {attempts: 1, lastAttempt: now.Add(-restartBackoff)}}
-		if got := r.restartDecisionFor(cell, "work", intmodel.RestartPolicyOnFailure); got != restartFired {
+		if got := r.restartDecisionFor(cell, "work", intmodel.RestartPolicyOnFailure, restartBackoff, onFailureMaxRestarts); got != restartFired {
 			t.Errorf("got %v, want restartFired past backoff", got)
 		}
 	})
 	t.Run("cap_exhausted_gives_up", func(t *testing.T) {
 		r := &Exec{nowFn: fixedClock(now)}
 		r.restartStates = map[string]*containerRestartState{key(r): {attempts: onFailureMaxRestarts, lastAttempt: now.Add(-time.Hour)}}
-		if got := r.restartDecisionFor(cell, "work", intmodel.RestartPolicyOnFailure); got != restartNone {
+		if got := r.restartDecisionFor(cell, "work", intmodel.RestartPolicyOnFailure, restartBackoff, onFailureMaxRestarts); got != restartNone {
 			t.Errorf("got %v, want restartNone (cap exhausted)", got)
 		}
 	})
@@ -730,5 +730,98 @@ func TestPopulateCellContainerStatuses_PreservesRestartCounters(t *testing.T) {
 		if !got.RestartTime.Equal(restartTime) {
 			t.Errorf("pass %d: RestartTime = %v, want preserved %v", pass, got.RestartTime, restartTime)
 		}
+	}
+}
+
+// restartTuningInt64Ptr is a local helper for the *int64 restart-tuning fields.
+func restartTuningInt64Ptr(v int64) *int64 { return &v }
+
+// TestEffectiveRestartBackoff pins the #1235 fallback contract: an unset
+// (nil) Spec.RestartBackoffSeconds resolves to the hardcoded restartBackoff
+// default (no behavior change), a set value resolves to that many seconds, and
+// an explicit 0 disables the floor.
+func TestEffectiveRestartBackoff(t *testing.T) {
+	cases := []struct {
+		name string
+		spec intmodel.ContainerSpec
+		want time.Duration
+	}{
+		{"unset falls back to default", intmodel.ContainerSpec{}, restartBackoff},
+		{"set to 10s", intmodel.ContainerSpec{RestartBackoffSeconds: restartTuningInt64Ptr(10)}, 10 * time.Second},
+		{"explicit zero disables floor", intmodel.ContainerSpec{RestartBackoffSeconds: restartTuningInt64Ptr(0)}, 0},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := effectiveRestartBackoff(tc.spec); got != tc.want {
+				t.Errorf("effectiveRestartBackoff = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestEffectiveOnFailureMaxRestarts pins the #1235 fallback contract: an unset
+// (nil) Spec.RestartMaxRetries resolves to the hardcoded onFailureMaxRestarts
+// default, a set value resolves to itself.
+func TestEffectiveOnFailureMaxRestarts(t *testing.T) {
+	cases := []struct {
+		name string
+		spec intmodel.ContainerSpec
+		want int
+	}{
+		{"unset falls back to default", intmodel.ContainerSpec{}, onFailureMaxRestarts},
+		{"set to 3", intmodel.ContainerSpec{RestartMaxRetries: restartTuningInt64Ptr(3)}, 3},
+		{"set to 1", intmodel.ContainerSpec{RestartMaxRetries: restartTuningInt64Ptr(1)}, 1},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := effectiveOnFailureMaxRestarts(tc.spec); got != tc.want {
+				t.Errorf("effectiveOnFailureMaxRestarts = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestRestartDecisionFor_HonorsUserBackoff proves the user-authored backoff,
+// not the hardcoded restartBackoff constant, governs the defer window: a
+// lastAttempt that is past the default 30s floor but inside a user-set 60s floor
+// must defer.
+func TestRestartDecisionFor_HonorsUserBackoff(t *testing.T) {
+	now := time.Unix(1_700_000_000, 0).UTC()
+	cell := restartTestCell(intmodel.RestartPolicyOnFailure, intmodel.ContainerStateStopped, 1)
+	key := func(r *Exec) string { return r.restartStateKey(cell, "work") }
+
+	// lastAttempt 45s ago: past the default 30s, inside a user 60s window.
+	userBackoff := 60 * time.Second
+	r := &Exec{nowFn: fixedClock(now)}
+	r.restartStates = map[string]*containerRestartState{
+		key(r): {attempts: 1, lastAttempt: now.Add(-45 * time.Second)},
+	}
+	if got := r.restartDecisionFor(cell, "work", intmodel.RestartPolicyOnFailure, userBackoff, onFailureMaxRestarts); got != restartDeferred {
+		t.Errorf("got %v, want restartDeferred inside user 60s backoff", got)
+	}
+	// Same state under the default 30s backoff would fire — sanity that the
+	// difference is the backoff value, not the bookkeeping.
+	if got := r.restartDecisionFor(cell, "work", intmodel.RestartPolicyOnFailure, restartBackoff, onFailureMaxRestarts); got != restartFired {
+		t.Errorf("got %v, want restartFired under default 30s backoff", got)
+	}
+}
+
+// TestRestartDecisionFor_HonorsUserMaxRetries proves the user-authored cap, not
+// the hardcoded onFailureMaxRestarts, decides when the on-failure loop gives up:
+// 2 attempts exhausts a user cap of 2 while the default 5 would still fire.
+func TestRestartDecisionFor_HonorsUserMaxRetries(t *testing.T) {
+	now := time.Unix(1_700_000_000, 0).UTC()
+	cell := restartTestCell(intmodel.RestartPolicyOnFailure, intmodel.ContainerStateStopped, 1)
+	key := func(r *Exec) string { return r.restartStateKey(cell, "work") }
+
+	r := &Exec{nowFn: fixedClock(now)}
+	r.restartStates = map[string]*containerRestartState{
+		key(r): {attempts: 2, lastAttempt: now.Add(-time.Hour)},
+	}
+	if got := r.restartDecisionFor(cell, "work", intmodel.RestartPolicyOnFailure, restartBackoff, 2); got != restartNone {
+		t.Errorf("got %v, want restartNone (user cap of 2 exhausted)", got)
+	}
+	if got := r.restartDecisionFor(cell, "work", intmodel.RestartPolicyOnFailure, restartBackoff, onFailureMaxRestarts); got != restartFired {
+		t.Errorf("got %v, want restartFired (default cap of 5 not yet reached)", got)
 	}
 }

--- a/internal/modelhub/container.go
+++ b/internal/modelhub/container.go
@@ -100,8 +100,21 @@ type ContainerSpec struct {
 	// non-zero exit) — that relaunch fires first and the cell is restarted, not
 	// deleted, for that tick (cf. `docker run --rm`).
 	RestartPolicy string
-	Attachable    bool
-	Tty           *ContainerTty
+	// RestartBackoffSeconds is the user-authored minimum interval (seconds)
+	// between reconciler-driven restarts of this container, parameterizing the
+	// runner's hardcoded restartBackoff floor (#1235, mirrors the v1beta1 field).
+	// Nil falls back to that built-in default; an explicit 0 disables the floor.
+	// Consumed by the runner's restart-on-exit pass (refresh.go:restartDecisionFor
+	// via effectiveRestartBackoff).
+	RestartBackoffSeconds *int64
+	// RestartMaxRetries is the user-authored `on-failure` retry cap for this
+	// container, parameterizing the runner's hardcoded onFailureMaxRestarts
+	// (#1235, mirrors the v1beta1 field). Nil falls back to that built-in
+	// default. Only consulted under the `on-failure` policy
+	// (refresh.go:restartDecisionFor via effectiveOnFailureMaxRestarts).
+	RestartMaxRetries *int64
+	Attachable        bool
+	Tty               *ContainerTty
 	// CellCgroupPath is the absolute cgroup path of the parent cell (mirrors
 	// Cell.Status.CgroupPath). When set, BuildContainerSpec emits an OCI
 	// Linux.CgroupsPath rooted at <CellCgroupPath>/<containerd-id> so the

--- a/pkg/api/model/v1beta1/container.go
+++ b/pkg/api/model/v1beta1/container.go
@@ -124,6 +124,27 @@ type ContainerSpec struct {
 	Git           *ContainerGit `json:"git,omitempty"                    yaml:"git,omitempty"`
 	CNIConfigPath string        `json:"cniConfigPath,omitempty"          yaml:"cniConfigPath,omitempty"`
 	RestartPolicy string        `json:"restartPolicy"                    yaml:"restartPolicy"`
+	// RestartBackoffSeconds is the minimum wall-clock interval, in seconds,
+	// between successive reconciler-driven restarts of this non-root container
+	// (#1235 parameterizes the hardcoded floor #1233 introduced). Nil/unset
+	// falls back to the runner's built-in default (30s) — existing specs see no
+	// behavior change. An explicit 0 disables the floor so a restart fires on
+	// the next reconcile tick that observes the exit. Only meaningful under a
+	// restarting policy (`always` or `on-failure`); setting it with `never` /
+	// empty is a validation error since it can never take effect. Validation
+	// also rejects a negative value.
+	RestartBackoffSeconds *int64 `json:"restartBackoffSeconds,omitempty"  yaml:"restartBackoffSeconds,omitempty"`
+	// RestartMaxRetries caps how many times the reconciler relaunches this
+	// container under the `on-failure` policy before giving up and leaving it
+	// terminal for the operator (#1235 parameterizes the hardcoded cap #1233
+	// introduced). Nil/unset falls back to the runner's built-in default (5) —
+	// existing specs see no behavior change. The counter resets whenever the
+	// container is next observed running, so the cap bites a tight crash loop,
+	// not a workload that runs for a while between crashes. `always` is uncapped
+	// by contract, so this field is only meaningful under `on-failure`; setting
+	// it with any other policy is a validation error. Validation rejects a value
+	// below 1.
+	RestartMaxRetries *int64 `json:"restartMaxRetries,omitempty"      yaml:"restartMaxRetries,omitempty"`
 	// Attachable opts the container into kuketty-wrapper injection. When
 	// true, the daemon rewrites process.args to a single element
 	// [/.kukeon/bin/kuketty] — no CLI flags, every runtime input flows


### PR DESCRIPTION
## Summary

Phase 3 of the restart-on-exit epic (#1151), parameterizing the hardcoded backoff floor and `on-failure` retry cap that step 1 (#1233) shipped as the constants `restartBackoff` (30s) and `onFailureMaxRestarts` (5) in `internal/controller/runner/refresh.go`.

- New optional `v1beta1.ContainerSpec` fields `restartBackoffSeconds *int64` and `restartMaxRetries *int64`, mirrored on `intmodel.ContainerSpec`, with scheme conversion both ways across all four container-conversion sites in `internal/apischeme/scheme.go`.
- New `validateContainerRestart` (sibling to `validateContainerTty`), wired into both the standalone `ContainerDoc` path and the nested `CellSpec.Containers` path. Rejects out-of-bounds or inapplicable values at apply time rather than silently ignoring config that can't take effect (the established `validateContainerTty` contract):
  - `restartBackoffSeconds` must be `>= 0` and requires a restarting policy (`always` or `on-failure`).
  - `restartMaxRetries` must be `>= 1` and requires `on-failure` (the cap is on-failure-specific; `always` is uncapped by contract).
- Runner consumption: `restartDecisionFor` now takes the effective backoff/cap, resolved by `effectiveRestartBackoff` / `effectiveOnFailureMaxRestarts`, which fall back to the hardcoded constants when the field is `nil` (unset). An unset spec sees byte-identical behavior to before; an explicit `0` backoff disables the floor.
- Field reference docs in `docs/site/manifests/container.md` (table rows + a "Tuning the backoff and cap" subsection with a YAML example).

## Scope decisions (please push back)

- **Runner consumption wired in, beyond the AC's literal "conversion to intmodel".** The epic frames step 3 as *"parameterizes step 1's constants"* / *"exposes them as user-authored knobs"*, so the fields are consumed at cell create/reconcile time — inert fields wouldn't be knobs. The fallback (`nil → constant`) is exactly AC item 2's "no behavior change for existing specs" guarantee. Kept minimal: one helper pair + threading two args into `restartDecisionFor`.
- **Deliberately deferred (separable follow-ups), since the AC scopes to `ContainerSpec` and frames the step as *"additive API surface … file-and-forget until operator demand materializes"*:**
  - `DiffCell` drift-detection (`internal/controller/apply/diff.go`) and the `kuke run` reapply-reject diff (`cmd/kuke/run/run.go:divergedContainerFields`) — changing these fields via `kuke apply` on an existing cell is not yet detected as drift. Note both diffs are already curated subsets (they omit `Resources`, `Devices`, `Git`, etc.), so this is consistent with the existing pattern rather than a new gap. The knobs take effect at cell *create* time.
  - The `CellBlueprint` authoring layer (`BlueprintContainer` + `cellconfig` materialize) — `restartPolicy`'s peer there is unextended, so the fields are authored via a direct `CellDoc` (`kuke run -f` / `kuke apply`), not via a blueprint template.
  - Happy to fold any of these in if you'd prefer the full peer-of-`restartPolicy` treatment in one PR; recommend PM file follow-ups otherwise.

## Test plan

- [x] `make test` (full CI suite, `GOWORK=off`) — passes
- [x] `go vet` on the touched packages — clean
- [x] Conversion round-trip tests (set + omitted) and `validateContainerRestart` table (`internal/apischeme/scheme_test.go`), incl. the nested-cell validation path
- [x] Runner fallback/override tests: `effectiveRestartBackoff`, `effectiveOnFailureMaxRestarts`, and `restartDecisionFor` honoring user backoff/cap over the defaults (`internal/controller/runner/restart_on_exit_test.go`)

## Acceptance criteria

- [x] v1beta1 `ContainerSpec` gains restart-backoff and max-retries fields with schema, scheme conversion to `intmodel.ContainerSpec`, and validation
- [x] Unset fields preserve step 1's hardcoded defaults — no behavior change for existing specs
- [x] Field reference docs updated
- [x] Unit coverage for conversion and validation

Closes #1235