### PR TITLE
chore: add codex team harness

### DIFF
--- a/kuketeam.yaml
+++ b/kuketeam.yaml
@@ -3,7 +3,7 @@ kind: ProjectTeam
 metadata: { name: kukeon }
 spec:
   source: { repo: github.com/eminwux/agents, branch: main }
-  defaults: { harnesses: [claude, opencode] }
+  defaults: { harnesses: [claude, opencode, codex] }
   roles:
     - { ref: dev, needs: { image: [go, root] } }
     - { ref: pm }


### PR DESCRIPTION
## Summary

- enable the `codex` harness in the project team defaults

## Test plan

- configuration-only change; verified the branch diff is limited to `kuketeam.yaml`